### PR TITLE
fix(release) workflow ruleset compatible

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -3,19 +3,6 @@ name: Release CLI
 on:
   workflow_dispatch:
     inputs:
-      release_type:
-        description: Version strategy to publish
-        required: true
-        type: choice
-        default: current
-        options:
-          - current
-          - alpha
-          - custom
-      custom_version:
-        description: Exact version when release_type is custom (for example 0.2.0)
-        required: false
-        type: string
       dry_run:
         description: Validate the release without publishing, tagging, or pushing
         required: false
@@ -58,34 +45,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Configure git author
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Bump CLI version
+      - name: Resolve CLI version
         id: cli_version
-        env:
-          RELEASE_TYPE: ${{ inputs.release_type }}
-          CUSTOM_VERSION: ${{ inputs.custom_version }}
         run: |
-          if [ "${RELEASE_TYPE}" = "custom" ] && [ -z "${CUSTOM_VERSION}" ]; then
-            echo "custom_version is required when release_type=custom."
-            exit 1
-          fi
-
-          if [ "${RELEASE_TYPE}" = "current" ]; then
-            VERSION="$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('packages/cli/package.json', 'utf8')).version)")"
-            printf 'version=%s\n' "${VERSION}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          TARGET="prerelease --preid alpha"
-          if [ "${RELEASE_TYPE}" = "custom" ]; then
-            TARGET="${CUSTOM_VERSION}"
-          fi
-
-          npm --prefix packages/cli version ${TARGET} --no-git-tag-version >/dev/null
           VERSION="$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('packages/cli/package.json', 'utf8')).version)")"
           printf 'version=%s\n' "${VERSION}" >> "$GITHUB_OUTPUT"
 
@@ -95,6 +57,15 @@ jobs:
           VERSION='${{ steps.cli_version.outputs.version }}'
           if npm view "${PACKAGE}@${VERSION}" version >/dev/null 2>&1; then
             echo "${PACKAGE}@${VERSION} already exists on npm."
+            exit 1
+          fi
+
+      - name: Fail if release tag already exists
+        run: |
+          VERSION='${{ steps.cli_version.outputs.version }}'
+          TAG="cli-v${VERSION}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Release tag ${TAG} already exists."
             exit 1
           fi
 
@@ -165,22 +136,13 @@ jobs:
         working-directory: .publish/cli
         run: npm publish --access public --tag preview --provenance
 
-      - name: Commit release version
+      - name: Create and push release tag
         if: ${{ !inputs.dry_run }}
         run: |
           VERSION='${{ steps.cli_version.outputs.version }}'
-          git add packages/cli/package.json
-          if ! git diff --cached --quiet; then
-            git commit -m "chore(cli): release @prisma/cli v${VERSION}"
-          fi
-          git tag "cli-v${VERSION}"
-
-      - name: Push release commit and tag
-        if: ${{ !inputs.dry_run }}
-        run: |
-          VERSION='${{ steps.cli_version.outputs.version }}'
-          git push origin HEAD:main
-          git push origin "cli-v${VERSION}"
+          TAG="cli-v${VERSION}"
+          git tag "${TAG}"
+          git push origin "refs/tags/${TAG}"
 
       - name: Summarize release
         run: |

--- a/README.md
+++ b/README.md
@@ -139,8 +139,23 @@ inside an example only when you want to run manual end-to-end checks.
 
 ## Publishing
 
-Publishing is intentionally manual and gated through GitHub Actions.
+Publishing is intentionally manual and gated through GitHub Actions. The
+workflow publishes the version that is already merged in
+`packages/cli/package.json`; it does not bump versions or push commits to
+`main`.
 
 The prerelease line uses `3.0.0-alpha.N`. The release workflow is configured to
 publish to the `preview` dist-tag. Do not publish from a local checkout unless
 the release owner explicitly asks you to do so.
+
+For a preview release:
+
+1. Open a PR that bumps `packages/cli/package.json` to the next
+   `3.0.0-alpha.N` version.
+2. Merge the PR to `main`.
+3. Run the `Release CLI` GitHub Actions workflow with `dry_run: true`.
+4. Run the same workflow with `dry_run: false`.
+
+If a release workflow fails after the npm publish step, check npm before
+rerunning. The package version may already be published even if tag creation
+failed.

--- a/docs/architecture/adrs/0001-preview-package-and-publishing.md
+++ b/docs/architecture/adrs/0001-preview-package-and-publishing.md
@@ -18,8 +18,13 @@ dist-tag. The package exposes a `prisma-cli` binary so it can coexist with the
 existing `prisma` executable.
 
 Release preparation is staged through the repository scripts and the manual
-GitHub Actions release workflow. The publish workflow is prepared for npm
-trusted publishing with provenance and publishes with:
+GitHub Actions release workflow. Version bumps are merged through pull requests
+before publishing. The publish workflow reads the already-merged version from
+`packages/cli/package.json`, publishes it, and creates the matching release tag.
+It must not push release commits directly to `main`.
+
+The publish workflow is prepared for npm trusted publishing with provenance and
+publishes with:
 
 ```bash
 npm publish --access public --tag preview --provenance
@@ -35,3 +40,5 @@ Local development should build and stage the package, but should not publish it.
 - The npm package should contain only the staged package files: built `dist`,
   package README, license, and package manifest.
 - Publishing remains manual and gated until the release owner runs the workflow.
+- Preview version changes must be reviewed and merged before publishing so
+  repository rules that require pull requests are respected.


### PR DESCRIPTION
This PR makes the CLI release workflow compatible with branch rulesets by removing direct version commits to `main`.

## Change summary

- Publish the already-merged CLI package version
- Create and push only the release tag
- Document the updated preview release process
