### PR TITLE
feat(cli): add github repo connection foundation

### DIFF
--- a/docs/product/command-principles.md
+++ b/docs/product/command-principles.md
@@ -36,8 +36,9 @@ The long-term command surface grows through workflow groups such as:
 - `database`
 - `migrate`
 - `app`
+- `git`
 
-The preview implements only `auth`, `project`, `branch`, and `app`.
+The preview implements only `auth`, `project`, `git`, `branch`, and `app`.
 
 ## Stable Nouns
 

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -14,6 +14,9 @@ The preview package includes these command groups:
 - `branch`
 - `app`
 
+The GitHub repository connection slice extends the `project` group. It does not
+add a top-level `git` or `github` group.
+
 Out of scope for the current preview:
 
 - `init`
@@ -224,6 +227,68 @@ Examples:
 prisma-cli project show
 prisma-cli project show --json
 prisma-cli project show --project proj_123 --json
+```
+
+## `prisma-cli project connect-repo [git-url]`
+
+Purpose:
+
+- connect the resolved Prisma project to a GitHub repository
+
+Behavior:
+
+- requires auth
+- resolves project context without creating projects
+- supports `--project <id-or-name>` for explicit project selection
+- if `[git-url]` is provided, parses it as a GitHub repository URL
+- if `[git-url]` is omitted, reads the local Git `origin` remote URL
+- accepts common GitHub URL forms such as:
+  - `https://github.com/prisma/prisma-cli`
+  - `https://github.com/prisma/prisma-cli.git`
+  - `git@github.com:prisma/prisma-cli.git`
+- rejects unsupported providers with `REPO_PROVIDER_UNSUPPORTED`
+- stores the repository connection server-side through the Management API
+- does not write repository data to `prisma.config.ts`
+- does not create branches synchronously
+- enables platform webhook automation to map GitHub branch activity to Prisma Branch state
+
+Current backend contract:
+
+- the Management API link call requires GitHub's numeric repository id as `providerRepositoryId`
+- the CLI first tries to resolve that id from `gh repo view` or GitHub's public repository API
+- private repositories may require `gh auth login` or an explicit `--provider-repository-id <id>`
+
+Examples:
+
+```bash
+prisma-cli project connect-repo
+prisma-cli project connect-repo git@github.com:prisma/prisma-cli.git
+prisma-cli project connect-repo --project proj_123
+prisma-cli project connect-repo https://github.com/prisma/prisma-cli --provider-repository-id 123456
+```
+
+## `prisma-cli project disconnect-repo`
+
+Purpose:
+
+- disconnect the GitHub repository from the resolved Prisma project
+
+Behavior:
+
+- requires auth
+- resolves project context without creating projects
+- supports `--project <id-or-name>` for explicit project selection
+- removes the active server-side repository connection
+- stops future GitHub branch automation for that project
+- does not delete the resolved Prisma project
+- does not delete existing Branches synchronously; server-side retention rules own that behavior
+
+Examples:
+
+```bash
+prisma-cli project disconnect-repo
+prisma-cli project disconnect-repo --project proj_123
+prisma-cli project disconnect-repo --json
 ```
 
 ## `prisma-cli branch list`

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -256,9 +256,11 @@ Current backend contract:
 
 - the CLI lists GitHub App installations for the authenticated workspace through the Management API
 - if no installation exists, the CLI creates a GitHub App install intent and returns the install URL
-- in interactive mode, the CLI attempts to open the install URL in the browser
+- in interactive mode, the CLI attempts to open the install URL in the browser and waits for the installation to become available
+- in non-interactive mode, JSON mode, or CI, the CLI exits with `REPO_INSTALLATION_REQUIRED` and includes the install URL
 - the CLI lists repositories visible to the installation and finds the matching `owner/repo`
 - if the repository is not visible to any installation, the command fails with `REPO_NOT_ACCESSIBLE`
+- if the project is already connected to the same repository, the command returns the existing connection without creating a duplicate
 - the CLI links the project to the repository with `POST /v1/source-repositories`
 - the link call sends `projectId`, `provider: "github"`, `providerRepositoryId`, and `installationId`
 

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -11,11 +11,12 @@ The preview package includes these command groups:
 
 - `auth`
 - `project` (includes `project env` subgroup)
+- `git`
 - `branch`
 - `app`
 
-The GitHub repository connection slice extends the `project` group. It does not
-add a top-level `git` or `github` group.
+The Git repository connection slice uses the `git` group. It does not add a
+provider-specific `github` group.
 
 Out of scope for the current preview:
 
@@ -229,7 +230,7 @@ prisma-cli project show --json
 prisma-cli project show --project proj_123 --json
 ```
 
-## `prisma-cli project connect-repo [git-url]`
+## `prisma-cli git connect [git-url]`
 
 Purpose:
 
@@ -267,13 +268,13 @@ Current backend contract:
 Examples:
 
 ```bash
-prisma-cli project connect-repo
-prisma-cli project connect-repo git@github.com:prisma/prisma-cli.git
-prisma-cli project connect-repo --project proj_123
-prisma-cli project connect-repo https://github.com/prisma/prisma-cli --project proj_123
+prisma-cli git connect
+prisma-cli git connect git@github.com:prisma/prisma-cli.git
+prisma-cli git connect --project proj_123
+prisma-cli git connect https://github.com/prisma/prisma-cli --project proj_123
 ```
 
-## `prisma-cli project disconnect-repo`
+## `prisma-cli git disconnect`
 
 Purpose:
 
@@ -292,9 +293,9 @@ Behavior:
 Examples:
 
 ```bash
-prisma-cli project disconnect-repo
-prisma-cli project disconnect-repo --project proj_123
-prisma-cli project disconnect-repo --json
+prisma-cli git disconnect
+prisma-cli git disconnect --project proj_123
+prisma-cli git disconnect --json
 ```
 
 ## `prisma-cli branch list`

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -258,7 +258,7 @@ Current backend contract:
 - the CLI lists GitHub App installations for the authenticated workspace through the Management API
 - if no installation exists, the CLI creates a GitHub App install intent and returns the install URL
 - in interactive mode, the CLI attempts to open the install URL in the browser and waits for the installation to become available
-- in non-interactive mode, JSON mode, or CI, the CLI exits with `REPO_INSTALLATION_REQUIRED` and includes the install URL
+- in non-interactive or `--json` mode, the CLI exits with `REPO_INSTALLATION_REQUIRED` and includes the install URL
 - the CLI lists repositories visible to the installation and finds the matching `owner/repo`
 - if the repository is not visible to any installation, the command fails with `REPO_NOT_ACCESSIBLE`
 - if the project is already connected to the same repository, the command returns the existing connection without creating a duplicate

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -260,8 +260,10 @@ Current backend contract:
 - in interactive mode, the CLI attempts to open the install URL in the browser and waits for the installation to become available
 - in non-interactive or `--json` mode, the CLI exits with `REPO_INSTALLATION_REQUIRED` and includes the install URL
 - the CLI lists repositories visible to the installation and finds the matching `owner/repo`
-- if the repository is not visible to any installation, the command fails with `REPO_NOT_ACCESSIBLE`
+- if the repository is not visible to any installation, the CLI creates a GitHub App install intent and exposes the install URL
+- if the repository still is not visible after the installation or repository-access step, the command fails with `REPO_NOT_ACCESSIBLE`
 - if the project is already connected to the same repository, the command returns the existing connection without creating a duplicate
+- if the project is already connected to a different repository, the command fails with `REPO_ALREADY_CONNECTED`
 - the CLI links the project to the repository with `POST /v1/source-repositories`
 - the link call sends `projectId`, `provider: "github"`, `providerRepositoryId`, and `installationId`
 

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -16,7 +16,7 @@ The preview package includes these command groups:
 - `app`
 
 The Git repository connection slice uses the `git` group. It does not add a
-provider-specific `github` group.
+provider-specific `GitHub` group.
 
 Out of scope for the current preview:
 

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -251,7 +251,7 @@ Behavior:
 - stores the repository connection server-side through the Management API
 - does not write repository data to `prisma.config.ts`
 - does not create branches synchronously
-- enables platform webhook automation to map GitHub branch activity to Prisma Branch state
+- when the connection is active, enables platform webhook automation to map GitHub branch activity to Prisma Branch state
 
 Current backend contract:
 

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -254,9 +254,13 @@ Behavior:
 
 Current backend contract:
 
-- the Management API link call requires GitHub's numeric repository id as `providerRepositoryId`
-- the CLI first tries to resolve that id from `gh repo view` or GitHub's public repository API
-- private repositories may require `gh auth login` or an explicit `--provider-repository-id <id>`
+- the CLI lists GitHub App installations for the authenticated workspace through the Management API
+- if no installation exists, the CLI creates a GitHub App install intent and returns the install URL
+- in interactive mode, the CLI attempts to open the install URL in the browser
+- the CLI lists repositories visible to the installation and finds the matching `owner/repo`
+- if the repository is not visible to any installation, the command fails with `REPO_NOT_ACCESSIBLE`
+- the CLI links the project to the repository with `POST /v1/source-repositories`
+- the link call sends `projectId`, `provider: "github"`, `providerRepositoryId`, and `installationId`
 
 Examples:
 
@@ -264,7 +268,7 @@ Examples:
 prisma-cli project connect-repo
 prisma-cli project connect-repo git@github.com:prisma/prisma-cli.git
 prisma-cli project connect-repo --project proj_123
-prisma-cli project connect-repo https://github.com/prisma/prisma-cli --provider-repository-id 123456
+prisma-cli project connect-repo https://github.com/prisma/prisma-cli --project proj_123
 ```
 
 ## `prisma-cli project disconnect-repo`

--- a/docs/product/error-conventions.md
+++ b/docs/product/error-conventions.md
@@ -161,7 +161,8 @@ These codes are the minimum stable set for the MVP:
 - `REMOVE_FAILED`
 - `FEATURE_UNAVAILABLE`
 - `REPO_PROVIDER_UNSUPPORTED`
-- `REPO_ID_REQUIRED`
+- `REPO_INSTALLATION_REQUIRED`
+- `REPO_NOT_ACCESSIBLE`
 - `REPO_NOT_CONNECTED`
 - `REPO_CONNECTION_FAILED`
 - `BUILD_FAILED`
@@ -186,7 +187,8 @@ Recommended meanings:
 - `REMOVE_FAILED`: app removal could not complete remotely
 - `FEATURE_UNAVAILABLE`: the command exists in the CLI model, but the current preview cannot support it yet
 - `REPO_PROVIDER_UNSUPPORTED`: repository connection received a non-GitHub repository URL
-- `REPO_ID_REQUIRED`: the CLI could not resolve the GitHub numeric repository id required by the current API
+- `REPO_INSTALLATION_REQUIRED`: repository connection needs a GitHub App installation before the project can be linked
+- `REPO_NOT_ACCESSIBLE`: the connected GitHub App installations do not expose the requested repository
 - `REPO_NOT_CONNECTED`: a command expected a project repository connection, but none exists
 - `REPO_CONNECTION_FAILED`: the Management API repository connection operation failed
 - `BUILD_FAILED`: build failed before a healthy deployment existed

--- a/docs/product/error-conventions.md
+++ b/docs/product/error-conventions.md
@@ -164,6 +164,7 @@ These codes are the minimum stable set for the MVP:
 - `REPO_INSTALLATION_REQUIRED`
 - `REPO_NOT_ACCESSIBLE`
 - `REPO_NOT_CONNECTED`
+- `REPO_ALREADY_CONNECTED`
 - `REPO_CONNECTION_FAILED`
 - `BUILD_FAILED`
 - `RUN_FAILED`
@@ -190,6 +191,7 @@ Recommended meanings:
 - `REPO_INSTALLATION_REQUIRED`: repository connection needs a GitHub App installation before the project can be linked
 - `REPO_NOT_ACCESSIBLE`: the connected GitHub App installations do not expose the requested repository
 - `REPO_NOT_CONNECTED`: a command expected a project repository connection, but none exists
+- `REPO_ALREADY_CONNECTED`: a project already has a different GitHub repository connected
 - `REPO_CONNECTION_FAILED`: the Management API repository connection operation failed
 - `BUILD_FAILED`: build failed before a healthy deployment existed
 - `RUN_FAILED`: local framework run command could not be started or exited unsuccessfully

--- a/docs/product/error-conventions.md
+++ b/docs/product/error-conventions.md
@@ -160,6 +160,10 @@ These codes are the minimum stable set for the MVP:
 - `CONFIRMATION_REQUIRED`
 - `REMOVE_FAILED`
 - `FEATURE_UNAVAILABLE`
+- `REPO_PROVIDER_UNSUPPORTED`
+- `REPO_ID_REQUIRED`
+- `REPO_NOT_CONNECTED`
+- `REPO_CONNECTION_FAILED`
 - `BUILD_FAILED`
 - `RUN_FAILED`
 - `DEPLOY_FAILED`
@@ -181,6 +185,10 @@ Recommended meanings:
 - `CONFIRMATION_REQUIRED`: command cannot continue without confirmation in the current mode
 - `REMOVE_FAILED`: app removal could not complete remotely
 - `FEATURE_UNAVAILABLE`: the command exists in the CLI model, but the current preview cannot support it yet
+- `REPO_PROVIDER_UNSUPPORTED`: repository connection received a non-GitHub repository URL
+- `REPO_ID_REQUIRED`: the CLI could not resolve the GitHub numeric repository id required by the current API
+- `REPO_NOT_CONNECTED`: a command expected a project repository connection, but none exists
+- `REPO_CONNECTION_FAILED`: the Management API repository connection operation failed
 - `BUILD_FAILED`: build failed before a healthy deployment existed
 - `RUN_FAILED`: local framework run command could not be started or exited unsuccessfully
 - `DEPLOY_FAILED`: deployment or post-build health failed

--- a/docs/product/output-conventions.md
+++ b/docs/product/output-conventions.md
@@ -67,8 +67,8 @@ Current MVP commands map to patterns like this:
 | `auth whoami` | `show` |
 | `project list` | `list` |
 | `project show` | `show` |
-| `project connect-repo` | `mutate` |
-| `project disconnect-repo` | `mutate` |
+| `git connect` | `mutate` |
+| `git disconnect` | `mutate` |
 | `branch list` | `list` |
 | `branch show` | `show` |
 | `branch use` | `mutate` |

--- a/docs/product/output-conventions.md
+++ b/docs/product/output-conventions.md
@@ -67,6 +67,8 @@ Current MVP commands map to patterns like this:
 | `auth whoami` | `show` |
 | `project list` | `list` |
 | `project show` | `show` |
+| `project connect-repo` | `mutate` |
+| `project disconnect-repo` | `mutate` |
 | `branch list` | `list` |
 | `branch show` | `show` |
 | `branch use` | `mutate` |

--- a/packages/cli/src/adapters/git.ts
+++ b/packages/cli/src/adapters/git.ts
@@ -1,0 +1,130 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export interface GitHubRepositoryReference {
+  provider: "github";
+  owner: string;
+  name: string;
+  fullName: string;
+  url: string;
+}
+
+export async function readGitOriginRemote(cwd: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", ["config", "--get", "remote.origin.url"], {
+      cwd,
+      timeout: 5_000,
+    });
+    const remote = stdout.trim();
+    return remote.length > 0 ? remote : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseGitHubRepositoryUrl(value: string): GitHubRepositoryReference | null {
+  const input = value.trim();
+  const shorthand = input.match(/^git@github\.com:([^/\s]+)\/([^/\s]+?)(?:\.git)?$/);
+
+  if (shorthand) {
+    return toGitHubRepositoryReference(shorthand[1], shorthand[2]);
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(input);
+  } catch {
+    return null;
+  }
+
+  if (parsed.hostname !== "github.com") {
+    return null;
+  }
+
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:" && parsed.protocol !== "ssh:") {
+    return null;
+  }
+
+  const parts = parsed.pathname.split("/").filter(Boolean);
+  if (parts.length !== 2) {
+    return null;
+  }
+
+  const [owner, rawName] = parts;
+  const name = rawName.endsWith(".git") ? rawName.slice(0, -4) : rawName;
+
+  return toGitHubRepositoryReference(owner, name);
+}
+
+export async function resolveGitHubRepositoryId(
+  repository: GitHubRepositoryReference,
+): Promise<number | null> {
+  const fromGh = await resolveGitHubRepositoryIdWithGh(repository);
+  if (fromGh !== null) {
+    return fromGh;
+  }
+
+  return resolveGitHubRepositoryIdWithPublicApi(repository);
+}
+
+async function resolveGitHubRepositoryIdWithGh(
+  repository: GitHubRepositoryReference,
+): Promise<number | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      "gh",
+      ["repo", "view", repository.fullName, "--json", "databaseId"],
+      { timeout: 5_000 },
+    );
+    const parsed = JSON.parse(stdout) as { databaseId?: unknown };
+    return typeof parsed.databaseId === "number" && Number.isInteger(parsed.databaseId)
+      ? parsed.databaseId
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveGitHubRepositoryIdWithPublicApi(
+  repository: GitHubRepositoryReference,
+): Promise<number | null> {
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${encodeURIComponent(repository.owner)}/${encodeURIComponent(repository.name)}`,
+      {
+        headers: {
+          "user-agent": "prisma-cli",
+          accept: "application/vnd.github+json",
+        },
+        signal: AbortSignal.timeout(5_000),
+      },
+    );
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const parsed = await response.json() as { id?: unknown };
+    return typeof parsed.id === "number" && Number.isInteger(parsed.id)
+      ? parsed.id
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function toGitHubRepositoryReference(owner: string | undefined, name: string | undefined): GitHubRepositoryReference | null {
+  if (!owner || !name || owner.includes("/") || name.includes("/")) {
+    return null;
+  }
+
+  return {
+    provider: "github",
+    owner,
+    name,
+    fullName: `${owner}/${name}`,
+    url: `https://github.com/${owner}/${name}`,
+  };
+}

--- a/packages/cli/src/adapters/git.ts
+++ b/packages/cli/src/adapters/git.ts
@@ -58,63 +58,6 @@ export function parseGitHubRepositoryUrl(value: string): GitHubRepositoryReferen
   return toGitHubRepositoryReference(owner, name);
 }
 
-export async function resolveGitHubRepositoryId(
-  repository: GitHubRepositoryReference,
-): Promise<number | null> {
-  const fromGh = await resolveGitHubRepositoryIdWithGh(repository);
-  if (fromGh !== null) {
-    return fromGh;
-  }
-
-  return resolveGitHubRepositoryIdWithPublicApi(repository);
-}
-
-async function resolveGitHubRepositoryIdWithGh(
-  repository: GitHubRepositoryReference,
-): Promise<number | null> {
-  try {
-    const { stdout } = await execFileAsync(
-      "gh",
-      ["repo", "view", repository.fullName, "--json", "databaseId"],
-      { timeout: 5_000 },
-    );
-    const parsed = JSON.parse(stdout) as { databaseId?: unknown };
-    return typeof parsed.databaseId === "number" && Number.isInteger(parsed.databaseId)
-      ? parsed.databaseId
-      : null;
-  } catch {
-    return null;
-  }
-}
-
-async function resolveGitHubRepositoryIdWithPublicApi(
-  repository: GitHubRepositoryReference,
-): Promise<number | null> {
-  try {
-    const response = await fetch(
-      `https://api.github.com/repos/${encodeURIComponent(repository.owner)}/${encodeURIComponent(repository.name)}`,
-      {
-        headers: {
-          "user-agent": "prisma-cli",
-          accept: "application/vnd.github+json",
-        },
-        signal: AbortSignal.timeout(5_000),
-      },
-    );
-
-    if (!response.ok) {
-      return null;
-    }
-
-    const parsed = await response.json() as { id?: unknown };
-    return typeof parsed.id === "number" && Number.isInteger(parsed.id)
-      ? parsed.id
-      : null;
-  } catch {
-    return null;
-  }
-}
-
 function toGitHubRepositoryReference(owner: string | undefined, name: string | undefined): GitHubRepositoryReference | null {
   if (!owner || !name || owner.includes("/") || name.includes("/")) {
     return null;

--- a/packages/cli/src/adapters/local-state.ts
+++ b/packages/cli/src/adapters/local-state.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import type { AuthProviderId } from "../types/auth";
+import type { GitRepositoryConnection } from "../types/project";
 
 export interface LocalState {
   auth: {
@@ -12,6 +13,7 @@ export interface LocalState {
   project: {
     rememberedByWorkspace: Record<string, RememberedProjectState>;
     lastResolved: RememberedProjectState | null;
+    repositoryConnectionsByProject: Record<string, GitRepositoryConnection>;
   };
   branch: {
     active: string;
@@ -38,6 +40,7 @@ const DEFAULT_STATE: LocalState = {
   project: {
     rememberedByWorkspace: {},
     lastResolved: null,
+    repositoryConnectionsByProject: {},
   },
   branch: {
     active: "preview",
@@ -70,6 +73,7 @@ export class LocalStateStore {
         project: {
           rememberedByWorkspace: parsed.project?.rememberedByWorkspace ?? {},
           lastResolved: parsed.project?.lastResolved ?? null,
+          repositoryConnectionsByProject: parsed.project?.repositoryConnectionsByProject ?? {},
         },
         branch: {
           active: parsed.branch?.active ?? DEFAULT_STATE.branch.active,
@@ -128,6 +132,28 @@ export class LocalStateStore {
     const state = await this.read();
     state.project.rememberedByWorkspace[project.workspaceId] = project;
     state.project.lastResolved = project;
+    await this.write(state);
+    return state;
+  }
+
+  async readRepositoryConnection(projectId: string): Promise<GitRepositoryConnection | null> {
+    const state = await this.read();
+    return state.project.repositoryConnectionsByProject[projectId] ?? null;
+  }
+
+  async setRepositoryConnection(
+    projectId: string,
+    connection: GitRepositoryConnection,
+  ): Promise<LocalState> {
+    const state = await this.read();
+    state.project.repositoryConnectionsByProject[projectId] = connection;
+    await this.write(state);
+    return state;
+  }
+
+  async clearRepositoryConnection(projectId: string): Promise<LocalState> {
+    const state = await this.read();
+    delete state.project.repositoryConnectionsByProject[projectId];
     await this.write(state);
     return state;
   }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,7 +5,7 @@ import { Command, CommanderError } from "commander";
 import { createAppCommand } from "./commands/app";
 import { createAuthCommand } from "./commands/auth";
 import { createBranchCommand } from "./commands/branch";
-
+import { createGitCommand } from "./commands/git";
 import { createProjectCommand } from "./commands/project";
 import { attachCommandDescriptor } from "./shell/command-meta";
 import { addCompactGlobalFlags } from "./shell/global-flags";
@@ -54,8 +54,9 @@ export function createProgram(runtime: CliRuntime): Command {
     .showSuggestionAfterError();
 
   program.addCommand(createAuthCommand(runtime));
-  program.addCommand(createBranchCommand(runtime));
   program.addCommand(createProjectCommand(runtime));
+  program.addCommand(createGitCommand(runtime));
+  program.addCommand(createBranchCommand(runtime));
   program.addCommand(createAppCommand(runtime));
 
   return program;

--- a/packages/cli/src/commands/git/index.ts
+++ b/packages/cli/src/commands/git/index.ts
@@ -1,0 +1,67 @@
+import { Command } from "commander";
+
+import { runGitConnect, runGitDisconnect } from "../../controllers/project";
+import { renderGitConnect, renderGitDisconnect } from "../../presenters/project";
+import { runCommand } from "../../shell/command-runner";
+import { attachCommandDescriptor } from "../../shell/command-meta";
+import { addCompactGlobalFlags, addGlobalFlags } from "../../shell/global-flags";
+import { configureRuntimeCommand, type CliRuntime } from "../../shell/runtime";
+import type { ProjectRepositoryConnectionResult } from "../../types/project";
+
+export function createGitCommand(runtime: CliRuntime): Command {
+  const git = attachCommandDescriptor(configureRuntimeCommand(new Command("git"), runtime), "git");
+
+  addCompactGlobalFlags(git);
+
+  git.addCommand(createGitConnectCommand(runtime));
+  git.addCommand(createGitDisconnectCommand(runtime));
+
+  return git;
+}
+
+function createGitConnectCommand(runtime: CliRuntime): Command {
+  const command = attachCommandDescriptor(configureRuntimeCommand(new Command("connect"), runtime), "git.connect");
+
+  command.argument("[git-url]", "GitHub repository URL");
+  command.option("--project <id-or-name>", "Project id or name");
+  addGlobalFlags(command);
+
+  command.action(async (gitUrl: string | undefined, options) => {
+    await runCommand<ProjectRepositoryConnectionResult>(
+      runtime,
+      "git.connect",
+      options as Record<string, unknown>,
+      (context) => runGitConnect(context, gitUrl, {
+        project: typeof options.project === "string" ? options.project : undefined,
+      }),
+      {
+        renderHuman: (context, descriptor, result) => renderGitConnect(context, descriptor, result),
+      },
+    );
+  });
+
+  return command;
+}
+
+function createGitDisconnectCommand(runtime: CliRuntime): Command {
+  const command = attachCommandDescriptor(configureRuntimeCommand(new Command("disconnect"), runtime), "git.disconnect");
+
+  command.option("--project <id-or-name>", "Project id or name");
+  addGlobalFlags(command);
+
+  command.action(async (options) => {
+    await runCommand<ProjectRepositoryConnectionResult>(
+      runtime,
+      "git.disconnect",
+      options as Record<string, unknown>,
+      (context) => runGitDisconnect(context, {
+        project: typeof options.project === "string" ? options.project : undefined,
+      }),
+      {
+        renderHuman: (context, descriptor, result) => renderGitDisconnect(context, descriptor, result),
+      },
+    );
+  });
+
+  return command;
+}

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -89,7 +89,6 @@ function createProjectConnectRepoCommand(runtime: CliRuntime): Command {
 
   command.argument("[git-url]", "GitHub repository URL");
   command.option("--project <id-or-name>", "Project id or name");
-  command.option("--provider-repository-id <id>", "GitHub numeric repository id");
   addGlobalFlags(command);
 
   command.action(async (gitUrl: string | undefined, options) => {
@@ -99,9 +98,6 @@ function createProjectConnectRepoCommand(runtime: CliRuntime): Command {
       options as Record<string, unknown>,
       (context) => runProjectConnectRepo(context, gitUrl, {
         project: typeof options.project === "string" ? options.project : undefined,
-        providerRepositoryId: typeof options.providerRepositoryId === "string"
-          ? options.providerRepositoryId
-          : undefined,
       }),
       {
         renderHuman: (context, descriptor, result) => renderProjectConnectRepo(context, descriptor, result),

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -1,14 +1,7 @@
 import { Command } from "commander";
 
+import { runProjectList, runProjectShow } from "../../controllers/project";
 import {
-  runProjectConnectRepo,
-  runProjectDisconnectRepo,
-  runProjectList,
-  runProjectShow,
-} from "../../controllers/project";
-import {
-  renderProjectConnectRepo,
-  renderProjectDisconnectRepo,
   renderProjectList,
   renderProjectShow,
   serializeProjectList,
@@ -18,11 +11,7 @@ import { attachCommandDescriptor } from "../../shell/command-meta";
 import { addCompactGlobalFlags, addGlobalFlags } from "../../shell/global-flags";
 import { runCommand } from "../../shell/command-runner";
 import { configureRuntimeCommand, type CliRuntime } from "../../shell/runtime";
-import type {
-  ProjectListResult,
-  ProjectRepositoryConnectionResult,
-  ProjectShowResult,
-} from "../../types/project";
+import type { ProjectListResult, ProjectShowResult } from "../../types/project";
 import { createEnvCommand } from "../env";
 
 export function createProjectCommand(runtime: CliRuntime): Command {
@@ -32,8 +21,6 @@ export function createProjectCommand(runtime: CliRuntime): Command {
 
   project.addCommand(createProjectListCommand(runtime));
   project.addCommand(createProjectShowCommand(runtime));
-  project.addCommand(createProjectConnectRepoCommand(runtime));
-  project.addCommand(createProjectDisconnectRepoCommand(runtime));
   project.addCommand(createEnvCommand(runtime));
 
   return project;
@@ -77,53 +64,6 @@ function createProjectShowCommand(runtime: CliRuntime): Command {
       {
         renderHuman: (context, descriptor, result) => renderProjectShow(context, descriptor, result),
         renderJson: (result) => serializeProjectShow(result),
-      },
-    );
-  });
-
-  return command;
-}
-
-function createProjectConnectRepoCommand(runtime: CliRuntime): Command {
-  const command = attachCommandDescriptor(configureRuntimeCommand(new Command("connect-repo"), runtime), "project.connect-repo");
-
-  command.argument("[git-url]", "GitHub repository URL");
-  command.option("--project <id-or-name>", "Project id or name");
-  addGlobalFlags(command);
-
-  command.action(async (gitUrl: string | undefined, options) => {
-    await runCommand<ProjectRepositoryConnectionResult>(
-      runtime,
-      "project.connect-repo",
-      options as Record<string, unknown>,
-      (context) => runProjectConnectRepo(context, gitUrl, {
-        project: typeof options.project === "string" ? options.project : undefined,
-      }),
-      {
-        renderHuman: (context, descriptor, result) => renderProjectConnectRepo(context, descriptor, result),
-      },
-    );
-  });
-
-  return command;
-}
-
-function createProjectDisconnectRepoCommand(runtime: CliRuntime): Command {
-  const command = attachCommandDescriptor(configureRuntimeCommand(new Command("disconnect-repo"), runtime), "project.disconnect-repo");
-
-  command.option("--project <id-or-name>", "Project id or name");
-  addGlobalFlags(command);
-
-  command.action(async (options) => {
-    await runCommand<ProjectRepositoryConnectionResult>(
-      runtime,
-      "project.disconnect-repo",
-      options as Record<string, unknown>,
-      (context) => runProjectDisconnectRepo(context, {
-        project: typeof options.project === "string" ? options.project : undefined,
-      }),
-      {
-        renderHuman: (context, descriptor, result) => renderProjectDisconnectRepo(context, descriptor, result),
       },
     );
   });

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -1,7 +1,14 @@
 import { Command } from "commander";
 
-import { runProjectList, runProjectShow } from "../../controllers/project";
 import {
+  runProjectConnectRepo,
+  runProjectDisconnectRepo,
+  runProjectList,
+  runProjectShow,
+} from "../../controllers/project";
+import {
+  renderProjectConnectRepo,
+  renderProjectDisconnectRepo,
   renderProjectList,
   renderProjectShow,
   serializeProjectList,
@@ -11,7 +18,11 @@ import { attachCommandDescriptor } from "../../shell/command-meta";
 import { addCompactGlobalFlags, addGlobalFlags } from "../../shell/global-flags";
 import { runCommand } from "../../shell/command-runner";
 import { configureRuntimeCommand, type CliRuntime } from "../../shell/runtime";
-import type { ProjectListResult, ProjectShowResult } from "../../types/project";
+import type {
+  ProjectListResult,
+  ProjectRepositoryConnectionResult,
+  ProjectShowResult,
+} from "../../types/project";
 import { createEnvCommand } from "../env";
 
 export function createProjectCommand(runtime: CliRuntime): Command {
@@ -21,6 +32,8 @@ export function createProjectCommand(runtime: CliRuntime): Command {
 
   project.addCommand(createProjectListCommand(runtime));
   project.addCommand(createProjectShowCommand(runtime));
+  project.addCommand(createProjectConnectRepoCommand(runtime));
+  project.addCommand(createProjectDisconnectRepoCommand(runtime));
   project.addCommand(createEnvCommand(runtime));
 
   return project;
@@ -64,6 +77,57 @@ function createProjectShowCommand(runtime: CliRuntime): Command {
       {
         renderHuman: (context, descriptor, result) => renderProjectShow(context, descriptor, result),
         renderJson: (result) => serializeProjectShow(result),
+      },
+    );
+  });
+
+  return command;
+}
+
+function createProjectConnectRepoCommand(runtime: CliRuntime): Command {
+  const command = attachCommandDescriptor(configureRuntimeCommand(new Command("connect-repo"), runtime), "project.connect-repo");
+
+  command.argument("[git-url]", "GitHub repository URL");
+  command.option("--project <id-or-name>", "Project id or name");
+  command.option("--provider-repository-id <id>", "GitHub numeric repository id");
+  addGlobalFlags(command);
+
+  command.action(async (gitUrl: string | undefined, options) => {
+    await runCommand<ProjectRepositoryConnectionResult>(
+      runtime,
+      "project.connect-repo",
+      options as Record<string, unknown>,
+      (context) => runProjectConnectRepo(context, gitUrl, {
+        project: typeof options.project === "string" ? options.project : undefined,
+        providerRepositoryId: typeof options.providerRepositoryId === "string"
+          ? options.providerRepositoryId
+          : undefined,
+      }),
+      {
+        renderHuman: (context, descriptor, result) => renderProjectConnectRepo(context, descriptor, result),
+      },
+    );
+  });
+
+  return command;
+}
+
+function createProjectDisconnectRepoCommand(runtime: CliRuntime): Command {
+  const command = attachCommandDescriptor(configureRuntimeCommand(new Command("disconnect-repo"), runtime), "project.disconnect-repo");
+
+  command.option("--project <id-or-name>", "Project id or name");
+  addGlobalFlags(command);
+
+  command.action(async (options) => {
+    await runCommand<ProjectRepositoryConnectionResult>(
+      runtime,
+      "project.disconnect-repo",
+      options as Record<string, unknown>,
+      (context) => runProjectDisconnectRepo(context, {
+        project: typeof options.project === "string" ? options.project : undefined,
+      }),
+      {
+        renderHuman: (context, descriptor, result) => renderProjectDisconnectRepo(context, descriptor, result),
       },
     );
   });

--- a/packages/cli/src/controllers/project.ts
+++ b/packages/cli/src/controllers/project.ts
@@ -1,19 +1,39 @@
 import type { ManagementApiClient } from "@prisma/management-api-sdk";
 
-import { authRequiredError, workspaceRequiredError } from "../shell/errors";
-import type { CommandSuccess } from "../shell/output";
-import type { CommandContext } from "../shell/runtime";
-import type { AuthWorkspace } from "../types/auth";
-import type { ProjectListResult, ProjectShowResult } from "../types/project";
+import {
+  parseGitHubRepositoryUrl,
+  readGitOriginRemote,
+  resolveGitHubRepositoryId,
+  type GitHubRepositoryReference,
+} from "../adapters/git";
 import { requireComputeAuth } from "../lib/auth/guard";
 import {
   resolveProjectTarget,
   sortProjects,
   type ProjectCandidate,
 } from "../lib/project/resolution";
-import { createProjectUseCases } from "../use-cases/project";
+import { authRequiredError, CliError, usageError, workspaceRequiredError } from "../shell/errors";
+import type { CommandSuccess } from "../shell/output";
+import type { CommandContext } from "../shell/runtime";
+import type { AuthWorkspace } from "../types/auth";
+import type {
+  GitRepositoryConnection,
+  ProjectListResult,
+  ProjectRepositoryConnectionResult,
+  ProjectShowResult,
+} from "../types/project";
 import { createCliUseCaseGateways } from "../use-cases/create-cli-gateways";
+import { createProjectUseCases } from "../use-cases/project";
 import { requireAuthenticatedAuthState } from "./auth";
+
+export interface ProjectConnectRepoOptions {
+  providerRepositoryId?: string;
+  project?: string;
+}
+
+export interface ProjectDisconnectRepoOptions {
+  project?: string;
+}
 
 function isRealMode(context: CommandContext): boolean {
   return !context.runtime.fixturePath && !context.runtime.env.PRISMA_CLI_MOCK_FIXTURE_PATH;
@@ -71,6 +91,133 @@ export async function runProjectShow(
   return {
     command: "project.show",
     result,
+    warnings: [],
+    nextSteps: [],
+  };
+}
+
+export async function runProjectConnectRepo(
+  context: CommandContext,
+  gitUrl: string | undefined,
+  options: ProjectConnectRepoOptions = {},
+): Promise<CommandSuccess<ProjectRepositoryConnectionResult>> {
+  const authState = await requireAuthenticatedAuthState(context);
+  const workspace = authState.workspace;
+  if (!workspace) {
+    throw workspaceRequiredError();
+  }
+
+  if (isRealMode(context)) {
+    const client = await requireComputeAuth(context.runtime.env);
+    if (!client) {
+      throw authRequiredError();
+    }
+
+    const target = await resolveProjectShowInRealMode(context, workspace, options.project);
+    const repository = await resolveRepositoryForConnect(context, gitUrl);
+    const providerRepositoryId = await resolveProviderRepositoryId(repository, options.providerRepositoryId);
+    const api = client as unknown as SourceRepositoryApiClient;
+    const { data, error, response } = await api.POST("/v1/source-repositories", {
+      body: {
+        projectId: target.project.id,
+        provider: "github",
+        providerRepositoryId,
+      },
+    });
+
+    if (error || !data) {
+      throw repoConnectionApiError("Failed to connect GitHub repository", response, error);
+    }
+
+    return {
+      command: "project.connect-repo",
+      result: {
+        ...target,
+        repositoryConnection: toRepositoryConnection(data.data),
+      },
+      warnings: [],
+      nextSteps: [],
+    };
+  }
+
+  const target = await resolveProjectShowInFixtureMode(context, workspace, options.project);
+  const repository = await resolveRepositoryForConnect(context, gitUrl);
+  const connection = createPendingRepositoryConnection(repository);
+  await context.stateStore.setRepositoryConnection(target.project.id, connection);
+
+  return {
+    command: "project.connect-repo",
+    result: {
+      ...target,
+      repositoryConnection: connection,
+    },
+    warnings: [],
+    nextSteps: [],
+  };
+}
+
+export async function runProjectDisconnectRepo(
+  context: CommandContext,
+  options: ProjectDisconnectRepoOptions = {},
+): Promise<CommandSuccess<ProjectRepositoryConnectionResult>> {
+  const authState = await requireAuthenticatedAuthState(context);
+  const workspace = authState.workspace;
+  if (!workspace) {
+    throw workspaceRequiredError();
+  }
+
+  if (isRealMode(context)) {
+    const client = await requireComputeAuth(context.runtime.env);
+    if (!client) {
+      throw authRequiredError();
+    }
+
+    const target = await resolveProjectShowInRealMode(context, workspace, options.project);
+    const api = client as unknown as SourceRepositoryApiClient;
+    const existing = await readFirstSourceRepository(api, target.project.id);
+
+    if (!existing) {
+      throw repoNotConnectedError();
+    }
+
+    const { error, response } = await api.DELETE("/v1/source-repositories/{id}", {
+      params: {
+        path: {
+          id: existing.id,
+        },
+      },
+    });
+
+    if (error) {
+      throw repoConnectionApiError("Failed to disconnect GitHub repository", response, error);
+    }
+
+    return {
+      command: "project.disconnect-repo",
+      result: {
+        ...target,
+        repositoryConnection: toRepositoryConnection(existing),
+      },
+      warnings: [],
+      nextSteps: [],
+    };
+  }
+
+  const target = await resolveProjectShowInFixtureMode(context, workspace, options.project);
+  const existingConnection = await context.stateStore.readRepositoryConnection(target.project.id);
+
+  if (!existingConnection) {
+    throw repoNotConnectedError();
+  }
+
+  await context.stateStore.clearRepositoryConnection(target.project.id);
+
+  return {
+    command: "project.disconnect-repo",
+    result: {
+      ...target,
+      repositoryConnection: existingConnection,
+    },
     warnings: [],
     nextSteps: [],
   };
@@ -141,6 +288,280 @@ export function listFixtureWorkspaceProjects(
       workspace,
     })),
   );
+}
+
+interface SourceRepositoryResponse {
+  id: string;
+  repoId: number;
+  provider: "github";
+  repoFullName: string;
+  defaultBranch: string;
+  isPrivate: boolean;
+  status: "active" | "archived";
+  installationId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface SourceRepositoryApiError {
+  error?: {
+    code?: string;
+    message?: string;
+    hint?: string;
+  };
+}
+
+interface SourceRepositoryApiResult<T> {
+  data?: T;
+  error?: SourceRepositoryApiError;
+  response?: Response;
+}
+
+interface SourceRepositoryApiClient {
+  POST(
+    path: "/v1/source-repositories",
+    options: {
+      body: {
+        projectId: string;
+        provider: "github";
+        providerRepositoryId: number;
+      };
+    },
+  ): Promise<SourceRepositoryApiResult<{ data: SourceRepositoryResponse }>>;
+  GET(
+    path: "/v1/source-repositories",
+    options: {
+      params: {
+        query: {
+          projectId: string;
+          cursor?: string;
+          limit?: number;
+        };
+      };
+    },
+  ): Promise<SourceRepositoryApiResult<{
+    data: SourceRepositoryResponse[];
+    pagination: {
+      nextCursor: string | null;
+      hasMore: boolean;
+    };
+  }>>;
+  DELETE(
+    path: "/v1/source-repositories/{id}",
+    options: {
+      params: {
+        path: {
+          id: string;
+        };
+      };
+    },
+  ): Promise<SourceRepositoryApiResult<unknown>>;
+}
+
+async function resolveRepositoryForConnect(
+  context: CommandContext,
+  gitUrl: string | undefined,
+): Promise<GitHubRepositoryReference> {
+  const remoteUrl = gitUrl ?? await readGitOriginRemote(context.runtime.cwd);
+
+  if (!remoteUrl) {
+    throw usageError(
+      "Repository connection requires a GitHub repository URL",
+      "No git-url was provided and the local repo does not have an origin remote.",
+      "Pass a GitHub repository URL, or add a GitHub origin remote and rerun prisma-cli project connect-repo.",
+      ["prisma-cli project connect-repo git@github.com:prisma/prisma-cli.git"],
+      "project",
+    );
+  }
+
+  const repository = parseGitHubRepositoryUrl(remoteUrl);
+  if (!repository) {
+    throw unsupportedRepositoryProviderError();
+  }
+
+  return repository;
+}
+
+async function resolveProviderRepositoryId(
+  repository: GitHubRepositoryReference,
+  explicitId: string | undefined,
+): Promise<number> {
+  if (explicitId !== undefined) {
+    const parsed = Number(explicitId);
+    if (Number.isInteger(parsed) && parsed > 0) {
+      return parsed;
+    }
+
+    throw usageError(
+      "GitHub repository id must be a positive integer",
+      `Received "${explicitId}" for --provider-repository-id.`,
+      "Pass the numeric GitHub repository id, for example --provider-repository-id 123456.",
+      [`prisma-cli project connect-repo ${repository.url} --provider-repository-id 123456`],
+      "project",
+    );
+  }
+
+  const resolved = await resolveGitHubRepositoryId(repository);
+  if (resolved !== null) {
+    return resolved;
+  }
+
+  throw new CliError({
+    code: "REPO_ID_REQUIRED",
+    domain: "project",
+    summary: "GitHub repository id required",
+    why: "The platform API links repositories by GitHub's numeric repository id, and the CLI could not resolve it automatically.",
+    fix: "Pass --provider-repository-id, authenticate the GitHub CLI with gh auth login, or connect the repository in Console.",
+    exitCode: 2,
+    nextSteps: [
+      `gh repo view ${repository.fullName} --json databaseId`,
+      `prisma-cli project connect-repo ${repository.url} --provider-repository-id <id>`,
+    ],
+  });
+}
+
+async function readFirstSourceRepository(
+  api: SourceRepositoryApiClient,
+  projectId: string,
+): Promise<SourceRepositoryResponse | null> {
+  const { data, error, response } = await api.GET("/v1/source-repositories", {
+    params: {
+      query: {
+        projectId,
+        limit: 1,
+      },
+    },
+  });
+
+  if (error || !data) {
+    throw repoConnectionApiError("Failed to inspect GitHub repository connection", response, error);
+  }
+
+  return data.data[0] ?? null;
+}
+
+function createPendingRepositoryConnection(
+  repository: GitHubRepositoryReference,
+): GitRepositoryConnection {
+  return {
+    id: null,
+    provider: "github",
+    repoId: null,
+    repository,
+    defaultBranch: null,
+    isPrivate: null,
+    status: "pending",
+    installation: {
+      id: null,
+      status: "pending",
+    },
+    automation: {
+      branches: false,
+      pullRequests: false,
+      comments: false,
+    },
+    connectedAt: new Date().toISOString(),
+    updatedAt: null,
+  };
+}
+
+function toRepositoryConnection(record: SourceRepositoryResponse): GitRepositoryConnection {
+  const [owner = "", name = ""] = record.repoFullName.split("/");
+
+  return {
+    id: record.id,
+    provider: "github",
+    repoId: record.repoId,
+    repository: {
+      owner,
+      name,
+      fullName: record.repoFullName,
+      url: `https://github.com/${record.repoFullName}`,
+    },
+    defaultBranch: record.defaultBranch,
+    isPrivate: record.isPrivate,
+    status: record.status,
+    installation: {
+      id: record.installationId,
+      status: "connected",
+    },
+    automation: {
+      branches: record.status === "active",
+      pullRequests: false,
+      comments: false,
+    },
+    connectedAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  };
+}
+
+function unsupportedRepositoryProviderError(): CliError {
+  return new CliError({
+    code: "REPO_PROVIDER_UNSUPPORTED",
+    domain: "project",
+    summary: "Repository provider is not supported",
+    why: "Repository connection supports GitHub repository URLs only.",
+    fix: "Pass a GitHub repository URL such as git@github.com:prisma/prisma-cli.git.",
+    exitCode: 2,
+    nextSteps: ["prisma-cli project connect-repo git@github.com:owner/repo.git"],
+  });
+}
+
+function repoNotConnectedError(): CliError {
+  return new CliError({
+    code: "REPO_NOT_CONNECTED",
+    domain: "project",
+    summary: "No GitHub repository connected",
+    why: "The resolved project does not have an active GitHub repository connection.",
+    fix: "Run prisma-cli project connect-repo before disconnecting.",
+    exitCode: 1,
+    nextSteps: ["prisma-cli project connect-repo"],
+  });
+}
+
+function repoConnectionApiError(
+  summary: string,
+  response: Response | undefined,
+  error: SourceRepositoryApiError | undefined,
+): CliError {
+  const status = response?.status ?? 0;
+  const apiCode = error?.error?.code;
+  const apiMessage = error?.error?.message;
+  const apiHint = error?.error?.hint;
+
+  if (status === 401 || status === 403) {
+    return authRequiredError(["prisma-cli auth login"]);
+  }
+
+  return new CliError({
+    code: "REPO_CONNECTION_FAILED",
+    domain: "project",
+    summary,
+    why: apiMessage ?? `The Management API returned status ${status || "unknown"}.`,
+    fix: apiHint ?? repoConnectionFixForStatus(status),
+    meta: {
+      status,
+      ...(apiCode ? { apiCode } : {}),
+    },
+    exitCode: 1,
+    nextSteps: ["prisma-cli project show"],
+  });
+}
+
+function repoConnectionFixForStatus(status: number): string {
+  if (status === 404) {
+    return "Install the GitHub App for this workspace, then rerun prisma-cli project connect-repo.";
+  }
+
+  if (status === 409) {
+    return "This project or repository is already linked. Disconnect the old link first, then try again.";
+  }
+
+  if (status === 422) {
+    return "Make sure the GitHub App installation has access to this repository.";
+  }
+
+  return "Re-run with --trace for the underlying API response details.";
 }
 
 function toProjectSummary(project: ProjectCandidate) {

--- a/packages/cli/src/controllers/project.ts
+++ b/packages/cli/src/controllers/project.ts
@@ -653,6 +653,7 @@ async function listScmInstallations(
 ): Promise<ScmInstallationResponse[]> {
   const installations: ScmInstallationResponse[] = [];
   let cursor: string | undefined;
+  const seenCursors = new Set<string>();
 
   do {
     const { data, error, response } = await api.GET("/v1/scm-installations", {
@@ -670,7 +671,12 @@ async function listScmInstallations(
     }
 
     installations.push(...data.data);
-    cursor = data.pagination.hasMore && data.pagination.nextCursor ? data.pagination.nextCursor : undefined;
+    cursor = readNextPaginationCursor(
+      data.pagination,
+      seenCursors,
+      "Failed to inspect GitHub App installations",
+      response,
+    );
   } while (cursor);
 
   return installations;
@@ -683,6 +689,7 @@ async function findRepositoryInInstallation(
 ): Promise<ScmRepositoryResponse | null> {
   const expectedFullName = repository.fullName.toLowerCase();
   let cursor: string | undefined;
+  const seenCursors = new Set<string>();
 
   do {
     const { data, error, response } = await api.GET("/v1/scm-installations/{installationId}/repositories", {
@@ -706,10 +713,38 @@ async function findRepositoryInInstallation(
       return matchedRepository;
     }
 
-    cursor = data.pagination.hasMore && data.pagination.nextCursor ? data.pagination.nextCursor : undefined;
+    cursor = readNextPaginationCursor(
+      data.pagination,
+      seenCursors,
+      "Failed to inspect GitHub repositories",
+      response,
+    );
   } while (cursor);
 
   return null;
+}
+
+function readNextPaginationCursor(
+  pagination: { hasMore: boolean; nextCursor: string | null },
+  seenCursors: Set<string>,
+  summary: string,
+  response: Response | undefined,
+): string | undefined {
+  const nextCursor = pagination.hasMore && pagination.nextCursor ? pagination.nextCursor : undefined;
+  if (!nextCursor) {
+    return undefined;
+  }
+
+  if (seenCursors.has(nextCursor)) {
+    throw repoConnectionApiError(summary, response, {
+      error: {
+        message: "Pagination cursor did not advance.",
+      },
+    });
+  }
+
+  seenCursors.add(nextCursor);
+  return nextCursor;
 }
 
 async function findRepositoryInInstallationIfAvailable(

--- a/packages/cli/src/controllers/project.ts
+++ b/packages/cli/src/controllers/project.ts
@@ -524,34 +524,30 @@ async function resolveInstalledRepository(
     return lookup.match;
   }
 
-  if (!hasUsableGitHubInstallation(installations) || lookup.inspectableInstallationCount === 0) {
-    const installUrl = await createGitHubInstallIntent(api, workspaceId);
-    const canWait = canPrompt(context);
-    const opened = await openInstallUrlIfInteractive(context, installUrl);
+  const installUrl = await createGitHubInstallIntent(api, workspaceId);
+  const canWait = canPrompt(context);
+  const opened = await openInstallUrlIfInteractive(context, installUrl);
 
-    if (!canWait) {
-      throw repoInstallationRequiredError(repository, installUrl, opened);
-    }
-
-    writeInstallWaitStatus(context, opened, installUrl);
-
-    const result = await waitForInstalledRepository(context, api, workspaceId, repository);
-    if (result.match) {
-      return result.match;
-    }
-
-    if (result.inspectableInstallationCount > 0) {
-      throw repoNotAccessibleError(repository);
+  if (!canWait) {
+    if (lookup.inspectableInstallationCount > 0) {
+      throw repoNotAccessibleError(repository, installUrl, opened);
     }
 
     throw repoInstallationRequiredError(repository, installUrl, opened);
   }
 
-  throw repoNotAccessibleError(repository);
-}
+  writeInstallWaitStatus(context, opened, installUrl);
 
-function hasUsableGitHubInstallation(installations: ScmInstallationResponse[]): boolean {
-  return installations.some((installation) => installation.provider === "github" && !installation.suspended);
+  const result = await waitForInstalledRepository(context, api, workspaceId, repository);
+  if (result.match) {
+    return result.match;
+  }
+
+  if (result.inspectableInstallationCount > 0) {
+    throw repoNotAccessibleError(repository, installUrl, opened);
+  }
+
+  throw repoInstallationRequiredError(repository, installUrl, opened);
 }
 
 async function findRepositoryInInstallations(
@@ -649,8 +645,8 @@ function writeInstallWaitStatus(
       context.ui,
       "info",
       opened
-        ? "Waiting for GitHub App installation approval..."
-        : "Waiting for GitHub App installation approval. Open the install URL in your browser.",
+        ? "Waiting for GitHub App installation or repository access approval..."
+        : "Waiting for GitHub App installation or repository access approval. Open the install URL in your browser.",
     ),
   ];
 
@@ -948,18 +944,27 @@ function repoInstallationRequiredError(
   });
 }
 
-function repoNotAccessibleError(repository: GitHubRepositoryReference): CliError {
+function repoNotAccessibleError(
+  repository: GitHubRepositoryReference,
+  installUrl: string,
+  opened: boolean,
+): CliError {
   return new CliError({
     code: "REPO_NOT_ACCESSIBLE",
     domain: "project",
     summary: "GitHub repository is not accessible",
     why: `The GitHub App installations connected to this workspace do not expose ${repository.fullName}.`,
-    fix: "Update the GitHub App installation so it has access to this repository, then rerun prisma-cli git connect.",
+    fix: "Open the GitHub App installation URL, grant access to this repository, then rerun prisma-cli git connect.",
     meta: {
       repository: repository.fullName,
+      installUrl,
+      opened,
     },
     exitCode: 1,
-    nextSteps: [`prisma-cli git connect ${repository.url}`],
+    nextSteps: [
+      installUrl,
+      `prisma-cli git connect ${repository.url}`,
+    ],
   });
 }
 

--- a/packages/cli/src/controllers/project.ts
+++ b/packages/cli/src/controllers/project.ts
@@ -27,11 +27,11 @@ import { createCliUseCaseGateways } from "../use-cases/create-cli-gateways";
 import { createProjectUseCases } from "../use-cases/project";
 import { requireAuthenticatedAuthState } from "./auth";
 
-export interface ProjectConnectRepoOptions {
+export interface GitConnectOptions {
   project?: string;
 }
 
-export interface ProjectDisconnectRepoOptions {
+export interface GitDisconnectOptions {
   project?: string;
 }
 
@@ -99,10 +99,10 @@ export async function runProjectShow(
   };
 }
 
-export async function runProjectConnectRepo(
+export async function runGitConnect(
   context: CommandContext,
   gitUrl: string | undefined,
-  options: ProjectConnectRepoOptions = {},
+  options: GitConnectOptions = {},
 ): Promise<CommandSuccess<ProjectRepositoryConnectionResult>> {
   const authState = await requireAuthenticatedAuthState(context);
   const workspace = authState.workspace;
@@ -125,7 +125,7 @@ export async function runProjectConnectRepo(
       const existingConnection = toRepositoryConnection(existing);
       if (repositoryFullNamesMatch(existingConnection.repository.fullName, repository.fullName)) {
         return {
-          command: "project.connect-repo",
+          command: "git.connect",
           result: {
             ...target,
             repositoryConnection: existingConnection,
@@ -153,7 +153,7 @@ export async function runProjectConnectRepo(
     }
 
     return {
-      command: "project.connect-repo",
+      command: "git.connect",
       result: {
         ...target,
         repositoryConnection: toRepositoryConnection(data.data),
@@ -169,7 +169,7 @@ export async function runProjectConnectRepo(
   await context.stateStore.setRepositoryConnection(target.project.id, connection);
 
   return {
-    command: "project.connect-repo",
+    command: "git.connect",
     result: {
       ...target,
       repositoryConnection: connection,
@@ -179,9 +179,9 @@ export async function runProjectConnectRepo(
   };
 }
 
-export async function runProjectDisconnectRepo(
+export async function runGitDisconnect(
   context: CommandContext,
-  options: ProjectDisconnectRepoOptions = {},
+  options: GitDisconnectOptions = {},
 ): Promise<CommandSuccess<ProjectRepositoryConnectionResult>> {
   const authState = await requireAuthenticatedAuthState(context);
   const workspace = authState.workspace;
@@ -216,7 +216,7 @@ export async function runProjectDisconnectRepo(
     }
 
     return {
-      command: "project.disconnect-repo",
+      command: "git.disconnect",
       result: {
         ...target,
         repositoryConnection: toRepositoryConnection(existing),
@@ -236,7 +236,7 @@ export async function runProjectDisconnectRepo(
   await context.stateStore.clearRepositoryConnection(target.project.id);
 
   return {
-    command: "project.disconnect-repo",
+    command: "git.disconnect",
     result: {
       ...target,
       repositoryConnection: existingConnection,
@@ -480,8 +480,8 @@ async function resolveRepositoryForConnect(
     throw usageError(
       "Repository connection requires a GitHub repository URL",
       "No git-url was provided and the local repo does not have an origin remote.",
-      "Pass a GitHub repository URL, or add a GitHub origin remote and rerun prisma-cli project connect-repo.",
-      ["prisma-cli project connect-repo git@github.com:prisma/prisma-cli.git"],
+      "Pass a GitHub repository URL, or add a GitHub origin remote and rerun prisma-cli git connect.",
+      ["prisma-cli git connect git@github.com:prisma/prisma-cli.git"],
       "project",
     );
   }
@@ -853,7 +853,7 @@ function unsupportedRepositoryProviderError(): CliError {
     why: "Repository connection supports GitHub repository URLs only.",
     fix: "Pass a GitHub repository URL such as git@github.com:prisma/prisma-cli.git.",
     exitCode: 2,
-    nextSteps: ["prisma-cli project connect-repo git@github.com:owner/repo.git"],
+    nextSteps: ["prisma-cli git connect git@github.com:owner/repo.git"],
   });
 }
 
@@ -863,9 +863,9 @@ function repoNotConnectedError(): CliError {
     domain: "project",
     summary: "No GitHub repository connected",
     why: "The resolved project does not have an active GitHub repository connection.",
-    fix: "Run prisma-cli project connect-repo before disconnecting.",
+    fix: "Run prisma-cli git connect before disconnecting.",
     exitCode: 1,
-    nextSteps: ["prisma-cli project connect-repo"],
+    nextSteps: ["prisma-cli git connect"],
   });
 }
 
@@ -880,8 +880,8 @@ function repoInstallationRequiredError(
     summary: "GitHub App installation required",
     why: `The selected workspace does not have a GitHub App installation that can be used to link ${repository.fullName}.`,
     fix: opened
-      ? "Finish installing the GitHub App in the browser, then rerun prisma-cli project connect-repo."
-      : "Open the GitHub App installation URL, approve access, then rerun prisma-cli project connect-repo.",
+      ? "Finish installing the GitHub App in the browser, then rerun prisma-cli git connect."
+      : "Open the GitHub App installation URL, approve access, then rerun prisma-cli git connect.",
     meta: {
       repository: repository.fullName,
       installUrl,
@@ -890,7 +890,7 @@ function repoInstallationRequiredError(
     exitCode: 1,
     nextSteps: [
       installUrl,
-      `prisma-cli project connect-repo ${repository.url}`,
+      `prisma-cli git connect ${repository.url}`,
     ],
   });
 }
@@ -901,12 +901,12 @@ function repoNotAccessibleError(repository: GitHubRepositoryReference): CliError
     domain: "project",
     summary: "GitHub repository is not accessible",
     why: `The GitHub App installations connected to this workspace do not expose ${repository.fullName}.`,
-    fix: "Update the GitHub App installation so it has access to this repository, then rerun prisma-cli project connect-repo.",
+    fix: "Update the GitHub App installation so it has access to this repository, then rerun prisma-cli git connect.",
     meta: {
       repository: repository.fullName,
     },
     exitCode: 1,
-    nextSteps: [`prisma-cli project connect-repo ${repository.url}`],
+    nextSteps: [`prisma-cli git connect ${repository.url}`],
   });
 }
 
@@ -921,7 +921,7 @@ function repoAlreadyConnectedError(repositoryFullName: string): CliError {
       repository: repositoryFullName,
     },
     exitCode: 1,
-    nextSteps: ["prisma-cli project disconnect-repo"],
+    nextSteps: ["prisma-cli git disconnect"],
   });
 }
 
@@ -960,7 +960,7 @@ function repoConnectionApiError(
 
 function repoConnectionFixForStatus(status: number): string {
   if (status === 404) {
-    return "Install the GitHub App for this workspace, then rerun prisma-cli project connect-repo.";
+    return "Install the GitHub App for this workspace, then rerun prisma-cli git connect.";
   }
 
   if (status === 409) {

--- a/packages/cli/src/controllers/project.ts
+++ b/packages/cli/src/controllers/project.ts
@@ -15,6 +15,7 @@ import {
 import { authRequiredError, CliError, usageError, workspaceRequiredError } from "../shell/errors";
 import type { CommandSuccess } from "../shell/output";
 import { canPrompt, type CommandContext } from "../shell/runtime";
+import { renderSummaryLine } from "../shell/ui";
 import type { AuthWorkspace } from "../types/auth";
 import type {
   GitRepositoryConnection,
@@ -33,6 +34,9 @@ export interface ProjectConnectRepoOptions {
 export interface ProjectDisconnectRepoOptions {
   project?: string;
 }
+
+const GITHUB_INSTALL_POLL_INTERVAL_MS = 2_000;
+const GITHUB_INSTALL_POLL_TIMEOUT_MS = 120_000;
 
 function isRealMode(context: CommandContext): boolean {
   return !context.runtime.fixturePath && !context.runtime.env.PRISMA_CLI_MOCK_FIXTURE_PATH;
@@ -115,6 +119,25 @@ export async function runProjectConnectRepo(
     const target = await resolveProjectShowInRealMode(context, workspace, options.project);
     const repository = await resolveRepositoryForConnect(context, gitUrl);
     const api = client as unknown as SourceRepositoryApiClient;
+    const existing = await readFirstSourceRepository(api, target.project.id);
+
+    if (existing) {
+      const existingConnection = toRepositoryConnection(existing);
+      if (repositoryFullNamesMatch(existingConnection.repository.fullName, repository.fullName)) {
+        return {
+          command: "project.connect-repo",
+          result: {
+            ...target,
+            repositoryConnection: existingConnection,
+          },
+          warnings: [],
+          nextSteps: [],
+        };
+      }
+
+      throw repoAlreadyConnectedError(existingConnection.repository.fullName);
+    }
+
     const resolvedRepository = await resolveInstalledRepository(context, api, workspace.id, repository);
     const { data, error, response } = await api.POST("/v1/source-repositories", {
       body: {
@@ -332,6 +355,11 @@ interface InstalledRepositoryMatch {
   repository: ScmRepositoryResponse;
 }
 
+interface InstallationRepositoryLookup {
+  match: InstalledRepositoryMatch | null;
+  inspectableInstallationCount: number;
+}
+
 interface SourceRepositoryApiError {
   error?: {
     code?: string;
@@ -473,27 +501,150 @@ async function resolveInstalledRepository(
   repository: GitHubRepositoryReference,
 ): Promise<InstalledRepositoryMatch> {
   const installations = await listScmInstallations(api, workspaceId);
-  if (installations.length === 0) {
+  const lookup = await findRepositoryInInstallations(api, installations, repository);
+  if (lookup.match) {
+    return lookup.match;
+  }
+
+  if (!hasUsableGitHubInstallation(installations) || lookup.inspectableInstallationCount === 0) {
     const installUrl = await createGitHubInstallIntent(api, workspaceId);
+    const canWait = canPrompt(context);
     const opened = await openInstallUrlIfInteractive(context, installUrl);
+
+    if (!canWait) {
+      throw repoInstallationRequiredError(repository, installUrl, opened);
+    }
+
+    writeInstallWaitStatus(context, opened, installUrl);
+
+    const result = await waitForInstalledRepository(context, api, workspaceId, repository);
+    if (result.match) {
+      return result.match;
+    }
+
+    if (result.inspectableInstallationCount > 0) {
+      throw repoNotAccessibleError(repository);
+    }
+
     throw repoInstallationRequiredError(repository, installUrl, opened);
   }
+
+  throw repoNotAccessibleError(repository);
+}
+
+function hasUsableGitHubInstallation(installations: ScmInstallationResponse[]): boolean {
+  return installations.some((installation) => installation.provider === "github" && !installation.suspended);
+}
+
+async function findRepositoryInInstallations(
+  api: SourceRepositoryApiClient,
+  installations: ScmInstallationResponse[],
+  repository: GitHubRepositoryReference,
+): Promise<InstallationRepositoryLookup> {
+  let inspectableInstallationCount = 0;
 
   for (const installation of installations) {
     if (installation.provider !== "github" || installation.suspended) {
       continue;
     }
 
-    const matchedRepository = await findRepositoryInInstallation(api, installation.id, repository);
+    const matchedRepository = await findRepositoryInInstallationIfAvailable(api, installation.id, repository);
+    if (matchedRepository === "unavailable") {
+      continue;
+    }
+
+    inspectableInstallationCount += 1;
     if (matchedRepository) {
       return {
-        installation,
-        repository: matchedRepository,
+        match: {
+          installation,
+          repository: matchedRepository,
+        },
+        inspectableInstallationCount,
       };
     }
   }
 
-  throw repoNotAccessibleError(repository);
+  return {
+    match: null,
+    inspectableInstallationCount,
+  };
+}
+
+async function waitForInstalledRepository(
+  context: CommandContext,
+  api: SourceRepositoryApiClient,
+  workspaceId: string,
+  repository: GitHubRepositoryReference,
+): Promise<{ match: InstalledRepositoryMatch | null; inspectableInstallationCount: number }> {
+  const timeoutMs = readPositiveIntegerEnv(
+    context.runtime.env.PRISMA_CLI_GITHUB_INSTALL_TIMEOUT_MS,
+    GITHUB_INSTALL_POLL_TIMEOUT_MS,
+  );
+  const intervalMs = readPositiveIntegerEnv(
+    context.runtime.env.PRISMA_CLI_GITHUB_INSTALL_POLL_INTERVAL_MS,
+    GITHUB_INSTALL_POLL_INTERVAL_MS,
+  );
+  const deadline = Date.now() + timeoutMs;
+  let inspectableInstallationCount = 0;
+
+  while (Date.now() <= deadline) {
+    const installations = await listScmInstallations(api, workspaceId);
+
+    const lookup = await findRepositoryInInstallations(api, installations, repository);
+    inspectableInstallationCount = lookup.inspectableInstallationCount;
+    if (lookup.match) {
+      return { match: lookup.match, inspectableInstallationCount };
+    }
+
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      break;
+    }
+
+    await sleep(Math.min(intervalMs, remainingMs));
+  }
+
+  return { match: null, inspectableInstallationCount };
+}
+
+function readPositiveIntegerEnv(value: string | undefined, fallback: number): number {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function writeInstallWaitStatus(
+  context: CommandContext,
+  opened: boolean,
+  installUrl: string,
+): void {
+  if (context.flags.quiet) {
+    return;
+  }
+
+  const lines = [
+    renderSummaryLine(
+      context.ui,
+      "info",
+      opened
+        ? "Waiting for GitHub App installation approval..."
+        : "Waiting for GitHub App installation approval. Open the install URL in your browser.",
+    ),
+  ];
+
+  if (!opened) {
+    lines.push(installUrl);
+  }
+
+  context.output.stderr.write(`${lines.join("\n")}\n`);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function listScmInstallations(
@@ -559,6 +710,30 @@ async function findRepositoryInInstallation(
   } while (cursor);
 
   return null;
+}
+
+async function findRepositoryInInstallationIfAvailable(
+  api: SourceRepositoryApiClient,
+  installationId: string,
+  repository: GitHubRepositoryReference,
+): Promise<ScmRepositoryResponse | null | "unavailable"> {
+  try {
+    return await findRepositoryInInstallation(api, installationId, repository);
+  } catch (error) {
+    if (isUnavailableScmInstallationError(error)) {
+      return "unavailable";
+    }
+
+    throw error;
+  }
+}
+
+function isUnavailableScmInstallationError(error: unknown): boolean {
+  if (!(error instanceof CliError) || error.code !== "REPO_CONNECTION_FAILED") {
+    return false;
+  }
+
+  return error.meta.status === 404 || error.meta.status === 422;
 }
 
 async function createGitHubInstallIntent(
@@ -733,6 +908,25 @@ function repoNotAccessibleError(repository: GitHubRepositoryReference): CliError
     exitCode: 1,
     nextSteps: [`prisma-cli project connect-repo ${repository.url}`],
   });
+}
+
+function repoAlreadyConnectedError(repositoryFullName: string): CliError {
+  return new CliError({
+    code: "REPO_ALREADY_CONNECTED",
+    domain: "project",
+    summary: "Project already has a GitHub repository connected",
+    why: `The resolved project is already connected to ${repositoryFullName}.`,
+    fix: "Disconnect the existing repository before connecting a different one.",
+    meta: {
+      repository: repositoryFullName,
+    },
+    exitCode: 1,
+    nextSteps: ["prisma-cli project disconnect-repo"],
+  });
+}
+
+function repositoryFullNamesMatch(left: string, right: string): boolean {
+  return left.toLowerCase() === right.toLowerCase();
 }
 
 function repoConnectionApiError(

--- a/packages/cli/src/controllers/project.ts
+++ b/packages/cli/src/controllers/project.ts
@@ -1,9 +1,9 @@
 import type { ManagementApiClient } from "@prisma/management-api-sdk";
+import open from "open";
 
 import {
   parseGitHubRepositoryUrl,
   readGitOriginRemote,
-  resolveGitHubRepositoryId,
   type GitHubRepositoryReference,
 } from "../adapters/git";
 import { requireComputeAuth } from "../lib/auth/guard";
@@ -14,7 +14,7 @@ import {
 } from "../lib/project/resolution";
 import { authRequiredError, CliError, usageError, workspaceRequiredError } from "../shell/errors";
 import type { CommandSuccess } from "../shell/output";
-import type { CommandContext } from "../shell/runtime";
+import { canPrompt, type CommandContext } from "../shell/runtime";
 import type { AuthWorkspace } from "../types/auth";
 import type {
   GitRepositoryConnection,
@@ -27,7 +27,6 @@ import { createProjectUseCases } from "../use-cases/project";
 import { requireAuthenticatedAuthState } from "./auth";
 
 export interface ProjectConnectRepoOptions {
-  providerRepositoryId?: string;
   project?: string;
 }
 
@@ -115,13 +114,14 @@ export async function runProjectConnectRepo(
 
     const target = await resolveProjectShowInRealMode(context, workspace, options.project);
     const repository = await resolveRepositoryForConnect(context, gitUrl);
-    const providerRepositoryId = await resolveProviderRepositoryId(repository, options.providerRepositoryId);
     const api = client as unknown as SourceRepositoryApiClient;
+    const resolvedRepository = await resolveInstalledRepository(context, api, workspace.id, repository);
     const { data, error, response } = await api.POST("/v1/source-repositories", {
       body: {
         projectId: target.project.id,
         provider: "github",
-        providerRepositoryId,
+        providerRepositoryId: resolvedRepository.repository.id,
+        installationId: resolvedRepository.installation.id,
       },
     });
 
@@ -292,6 +292,8 @@ export function listFixtureWorkspaceProjects(
 
 interface SourceRepositoryResponse {
   id: string;
+  type?: "source-repository";
+  url?: string;
   repoId: number;
   provider: "github";
   repoFullName: string;
@@ -301,6 +303,33 @@ interface SourceRepositoryResponse {
   installationId: string;
   createdAt: string;
   updatedAt: string;
+}
+
+interface ScmInstallationResponse {
+  id: string;
+  type: "scm-installation";
+  url: string;
+  provider: "github";
+  installationId: number;
+  accountId: number;
+  accountLogin: string;
+  accountType: "user" | "organization";
+  suspended: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ScmRepositoryResponse {
+  id: number;
+  type: "scm-repository";
+  fullName: string;
+  defaultBranch: string;
+  isPrivate: boolean;
+}
+
+interface InstalledRepositoryMatch {
+  installation: ScmInstallationResponse;
+  repository: ScmRepositoryResponse;
 }
 
 interface SourceRepositoryApiError {
@@ -325,6 +354,7 @@ interface SourceRepositoryApiClient {
         projectId: string;
         provider: "github";
         providerRepositoryId: number;
+        installationId?: string;
       };
     },
   ): Promise<SourceRepositoryApiResult<{ data: SourceRepositoryResponse }>>;
@@ -344,6 +374,60 @@ interface SourceRepositoryApiClient {
     pagination: {
       nextCursor: string | null;
       hasMore: boolean;
+    };
+  }>>;
+  GET(
+    path: "/v1/scm-installations",
+    options: {
+      params: {
+        query: {
+          workspaceId: string;
+          cursor?: string;
+          limit?: number;
+        };
+      };
+    },
+  ): Promise<SourceRepositoryApiResult<{
+    data: ScmInstallationResponse[];
+    pagination: {
+      nextCursor: string | null;
+      hasMore: boolean;
+    };
+  }>>;
+  GET(
+    path: "/v1/scm-installations/{installationId}/repositories",
+    options: {
+      params: {
+        path: {
+          installationId: string;
+        };
+        query: {
+          cursor?: string;
+          limit?: number;
+        };
+      };
+    },
+  ): Promise<SourceRepositoryApiResult<{
+    data: ScmRepositoryResponse[];
+    pagination: {
+      nextCursor: string | null;
+      hasMore: boolean;
+    };
+  }>>;
+  POST(
+    path: "/v1/scm-installations/install-intents",
+    options: {
+      body: {
+        provider: "github";
+        workspaceId: string;
+      };
+    },
+  ): Promise<SourceRepositoryApiResult<{
+    data: {
+      type: "install-intent";
+      provider: "github";
+      workspaceId: string;
+      installUrl: string;
     };
   }>>;
   DELETE(
@@ -382,42 +466,133 @@ async function resolveRepositoryForConnect(
   return repository;
 }
 
-async function resolveProviderRepositoryId(
+async function resolveInstalledRepository(
+  context: CommandContext,
+  api: SourceRepositoryApiClient,
+  workspaceId: string,
   repository: GitHubRepositoryReference,
-  explicitId: string | undefined,
-): Promise<number> {
-  if (explicitId !== undefined) {
-    const parsed = Number(explicitId);
-    if (Number.isInteger(parsed) && parsed > 0) {
-      return parsed;
+): Promise<InstalledRepositoryMatch> {
+  const installations = await listScmInstallations(api, workspaceId);
+  if (installations.length === 0) {
+    const installUrl = await createGitHubInstallIntent(api, workspaceId);
+    const opened = await openInstallUrlIfInteractive(context, installUrl);
+    throw repoInstallationRequiredError(repository, installUrl, opened);
+  }
+
+  for (const installation of installations) {
+    if (installation.provider !== "github" || installation.suspended) {
+      continue;
     }
 
-    throw usageError(
-      "GitHub repository id must be a positive integer",
-      `Received "${explicitId}" for --provider-repository-id.`,
-      "Pass the numeric GitHub repository id, for example --provider-repository-id 123456.",
-      [`prisma-cli project connect-repo ${repository.url} --provider-repository-id 123456`],
-      "project",
-    );
+    const matchedRepository = await findRepositoryInInstallation(api, installation.id, repository);
+    if (matchedRepository) {
+      return {
+        installation,
+        repository: matchedRepository,
+      };
+    }
   }
 
-  const resolved = await resolveGitHubRepositoryId(repository);
-  if (resolved !== null) {
-    return resolved;
-  }
+  throw repoNotAccessibleError(repository);
+}
 
-  throw new CliError({
-    code: "REPO_ID_REQUIRED",
-    domain: "project",
-    summary: "GitHub repository id required",
-    why: "The platform API links repositories by GitHub's numeric repository id, and the CLI could not resolve it automatically.",
-    fix: "Pass --provider-repository-id, authenticate the GitHub CLI with gh auth login, or connect the repository in Console.",
-    exitCode: 2,
-    nextSteps: [
-      `gh repo view ${repository.fullName} --json databaseId`,
-      `prisma-cli project connect-repo ${repository.url} --provider-repository-id <id>`,
-    ],
+async function listScmInstallations(
+  api: SourceRepositoryApiClient,
+  workspaceId: string,
+): Promise<ScmInstallationResponse[]> {
+  const installations: ScmInstallationResponse[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const { data, error, response } = await api.GET("/v1/scm-installations", {
+      params: {
+        query: {
+          workspaceId,
+          limit: 100,
+          ...(cursor ? { cursor } : {}),
+        },
+      },
+    });
+
+    if (error || !data) {
+      throw repoConnectionApiError("Failed to inspect GitHub App installations", response, error);
+    }
+
+    installations.push(...data.data);
+    cursor = data.pagination.hasMore && data.pagination.nextCursor ? data.pagination.nextCursor : undefined;
+  } while (cursor);
+
+  return installations;
+}
+
+async function findRepositoryInInstallation(
+  api: SourceRepositoryApiClient,
+  installationId: string,
+  repository: GitHubRepositoryReference,
+): Promise<ScmRepositoryResponse | null> {
+  const expectedFullName = repository.fullName.toLowerCase();
+  let cursor: string | undefined;
+
+  do {
+    const { data, error, response } = await api.GET("/v1/scm-installations/{installationId}/repositories", {
+      params: {
+        path: {
+          installationId,
+        },
+        query: {
+          limit: 100,
+          ...(cursor ? { cursor } : {}),
+        },
+      },
+    });
+
+    if (error || !data) {
+      throw repoConnectionApiError("Failed to inspect GitHub repositories", response, error);
+    }
+
+    const matchedRepository = data.data.find((candidate) => candidate.fullName.toLowerCase() === expectedFullName);
+    if (matchedRepository) {
+      return matchedRepository;
+    }
+
+    cursor = data.pagination.hasMore && data.pagination.nextCursor ? data.pagination.nextCursor : undefined;
+  } while (cursor);
+
+  return null;
+}
+
+async function createGitHubInstallIntent(
+  api: SourceRepositoryApiClient,
+  workspaceId: string,
+): Promise<string> {
+  const { data, error, response } = await api.POST("/v1/scm-installations/install-intents", {
+    body: {
+      provider: "github",
+      workspaceId,
+    },
   });
+
+  if (error || !data) {
+    throw repoConnectionApiError("Failed to create GitHub App installation link", response, error);
+  }
+
+  return data.data.installUrl;
+}
+
+async function openInstallUrlIfInteractive(
+  context: CommandContext,
+  installUrl: string,
+): Promise<boolean> {
+  if (!canPrompt(context)) {
+    return false;
+  }
+
+  try {
+    await open(installUrl);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function readFirstSourceRepository(
@@ -516,6 +691,47 @@ function repoNotConnectedError(): CliError {
     fix: "Run prisma-cli project connect-repo before disconnecting.",
     exitCode: 1,
     nextSteps: ["prisma-cli project connect-repo"],
+  });
+}
+
+function repoInstallationRequiredError(
+  repository: GitHubRepositoryReference,
+  installUrl: string,
+  opened: boolean,
+): CliError {
+  return new CliError({
+    code: "REPO_INSTALLATION_REQUIRED",
+    domain: "project",
+    summary: "GitHub App installation required",
+    why: `The selected workspace does not have a GitHub App installation that can be used to link ${repository.fullName}.`,
+    fix: opened
+      ? "Finish installing the GitHub App in the browser, then rerun prisma-cli project connect-repo."
+      : "Open the GitHub App installation URL, approve access, then rerun prisma-cli project connect-repo.",
+    meta: {
+      repository: repository.fullName,
+      installUrl,
+      opened,
+    },
+    exitCode: 1,
+    nextSteps: [
+      installUrl,
+      `prisma-cli project connect-repo ${repository.url}`,
+    ],
+  });
+}
+
+function repoNotAccessibleError(repository: GitHubRepositoryReference): CliError {
+  return new CliError({
+    code: "REPO_NOT_ACCESSIBLE",
+    domain: "project",
+    summary: "GitHub repository is not accessible",
+    why: `The GitHub App installations connected to this workspace do not expose ${repository.fullName}.`,
+    fix: "Update the GitHub App installation so it has access to this repository, then rerun prisma-cli project connect-repo.",
+    meta: {
+      repository: repository.fullName,
+    },
+    exitCode: 1,
+    nextSteps: [`prisma-cli project connect-repo ${repository.url}`],
   });
 }
 

--- a/packages/cli/src/controllers/project.ts
+++ b/packages/cli/src/controllers/project.ts
@@ -165,6 +165,24 @@ export async function runGitConnect(
 
   const target = await resolveProjectShowInFixtureMode(context, workspace, options.project);
   const repository = await resolveRepositoryForConnect(context, gitUrl);
+  const existingConnection = await context.stateStore.readRepositoryConnection(target.project.id);
+
+  if (existingConnection) {
+    if (repositoryFullNamesMatch(existingConnection.repository.fullName, repository.fullName)) {
+      return {
+        command: "git.connect",
+        result: {
+          ...target,
+          repositoryConnection: existingConnection,
+        },
+        warnings: [],
+        nextSteps: [],
+      };
+    }
+
+    throw repoAlreadyConnectedError(existingConnection.repository.fullName);
+  }
+
   const connection = createPendingRepositoryConnection(repository);
   await context.stateStore.setRepositoryConnection(target.project.id, connection);
 

--- a/packages/cli/src/presenters/project.ts
+++ b/packages/cli/src/presenters/project.ts
@@ -1,6 +1,7 @@
 import type { CommandDescriptor } from "../shell/command-meta";
 import type { CommandContext } from "../shell/runtime";
 import type {
+  GitRepositoryConnection,
   ProjectListResult,
   ProjectRepositoryConnectionResult,
   ProjectShowResult,
@@ -87,11 +88,7 @@ export function renderGitConnect(
       ],
       operationDescription: "Applying repository connection",
       operationCount: 1,
-      details: [
-        connection.status === "active"
-          ? "GitHub branch automation is active for this project."
-          : "GitHub branch automation is pending GitHub App installation.",
-      ],
+      details: [formatGitConnectionDetail(connection.status)],
     },
     context.ui,
   );
@@ -133,5 +130,18 @@ function formatProjectSource(source: ProjectShowResult["resolution"]["projectSou
       return "created";
     case "prompt":
       return "prompt";
+  }
+}
+
+function formatGitConnectionDetail(status: GitRepositoryConnection["status"]): string {
+  switch (status) {
+    case "active":
+      return "GitHub branch automation is active for this project.";
+    case "pending":
+      return "GitHub branch automation is pending GitHub App installation.";
+    case "archived":
+      return "GitHub branch automation has been archived for this project.";
+    default:
+      return "GitHub repository is connected, but branch automation is not active.";
   }
 }

--- a/packages/cli/src/presenters/project.ts
+++ b/packages/cli/src/presenters/project.ts
@@ -1,7 +1,11 @@
 import type { CommandDescriptor } from "../shell/command-meta";
 import type { CommandContext } from "../shell/runtime";
-import type { ProjectListResult, ProjectShowResult } from "../types/project";
-import { renderList, renderShow, serializeList } from "../output/patterns";
+import type {
+  ProjectListResult,
+  ProjectRepositoryConnectionResult,
+  ProjectShowResult,
+} from "../types/project";
+import { renderList, renderMutate, renderShow, serializeList } from "../output/patterns";
 
 export function renderProjectList(
   context: CommandContext,
@@ -63,6 +67,56 @@ export function renderProjectShow(
 
 export function serializeProjectShow(result: ProjectShowResult) {
   return result;
+}
+
+export function renderProjectConnectRepo(
+  context: CommandContext,
+  descriptor: CommandDescriptor,
+  result: ProjectRepositoryConnectionResult,
+): string[] {
+  const connection = result.repositoryConnection;
+  return renderMutate(
+    {
+      title: "Connecting the resolved project to a GitHub repository.",
+      descriptor,
+      context: [
+        { key: "project", value: result.project.name },
+        { key: "workspace", value: result.workspace.name },
+        { key: "repository", value: connection.repository.fullName },
+        { key: "status", value: connection.status },
+      ],
+      operationDescription: "Applying repository connection",
+      operationCount: 1,
+      details: [
+        connection.status === "active"
+          ? "GitHub branch automation is active for this project."
+          : "GitHub branch automation is pending GitHub App installation.",
+      ],
+    },
+    context.ui,
+  );
+}
+
+export function renderProjectDisconnectRepo(
+  context: CommandContext,
+  descriptor: CommandDescriptor,
+  result: ProjectRepositoryConnectionResult,
+): string[] {
+  return renderMutate(
+    {
+      title: "Disconnecting the GitHub repository from the resolved project.",
+      descriptor,
+      context: [
+        { key: "project", value: result.project.name },
+        { key: "workspace", value: result.workspace.name },
+        { key: "repository", value: result.repositoryConnection.repository.fullName },
+      ],
+      operationDescription: "Applying repository disconnection",
+      operationCount: 1,
+      details: ["GitHub branch automation is no longer active for this project."],
+    },
+    context.ui,
+  );
 }
 
 function formatProjectSource(source: ProjectShowResult["resolution"]["projectSource"]): string {

--- a/packages/cli/src/presenters/project.ts
+++ b/packages/cli/src/presenters/project.ts
@@ -69,7 +69,7 @@ export function serializeProjectShow(result: ProjectShowResult) {
   return result;
 }
 
-export function renderProjectConnectRepo(
+export function renderGitConnect(
   context: CommandContext,
   descriptor: CommandDescriptor,
   result: ProjectRepositoryConnectionResult,
@@ -77,7 +77,7 @@ export function renderProjectConnectRepo(
   const connection = result.repositoryConnection;
   return renderMutate(
     {
-      title: "Connecting the resolved project to a GitHub repository.",
+      title: "Connecting Git to the resolved project.",
       descriptor,
       context: [
         { key: "project", value: result.project.name },
@@ -97,14 +97,14 @@ export function renderProjectConnectRepo(
   );
 }
 
-export function renderProjectDisconnectRepo(
+export function renderGitDisconnect(
   context: CommandContext,
   descriptor: CommandDescriptor,
   result: ProjectRepositoryConnectionResult,
 ): string[] {
   return renderMutate(
     {
-      title: "Disconnecting the GitHub repository from the resolved project.",
+      title: "Disconnecting Git from the resolved project.",
       descriptor,
       context: [
         { key: "project", value: result.project.name },

--- a/packages/cli/src/shell/command-meta.ts
+++ b/packages/cli/src/shell/command-meta.ts
@@ -78,6 +78,22 @@ const DESCRIPTORS: CommandDescriptor[] = [
     examples: ["prisma-cli project show", "prisma-cli project show --project proj_123 --json"],
   },
   {
+    id: "project.connect-repo",
+    path: ["prisma", "project", "connect-repo"],
+    description: "Connect the resolved project to a GitHub repository",
+    examples: [
+      "prisma-cli project connect-repo",
+      "prisma-cli project connect-repo git@github.com:prisma/prisma-cli.git",
+      "prisma-cli project connect-repo --project proj_123",
+    ],
+  },
+  {
+    id: "project.disconnect-repo",
+    path: ["prisma", "project", "disconnect-repo"],
+    description: "Disconnect the GitHub repository from the resolved project",
+    examples: ["prisma-cli project disconnect-repo", "prisma-cli project disconnect-repo --project proj_123"],
+  },
+  {
     id: "branch.list",
     path: ["prisma", "branch", "list"],
     description: "List active Platform branches for the resolved project",

--- a/packages/cli/src/shell/command-meta.ts
+++ b/packages/cli/src/shell/command-meta.ts
@@ -66,6 +66,12 @@ const DESCRIPTORS: CommandDescriptor[] = [
     examples: ["prisma-cli branch list", "prisma-cli branch show"],
   },
   {
+    id: "git",
+    path: ["prisma", "git"],
+    description: "Manage Git repository connections for a project",
+    examples: ["prisma-cli git connect", "prisma-cli git disconnect"],
+  },
+  {
     id: "project.list",
     path: ["prisma", "project", "list"],
     description: "List all projects in your workspace",
@@ -78,20 +84,20 @@ const DESCRIPTORS: CommandDescriptor[] = [
     examples: ["prisma-cli project show", "prisma-cli project show --project proj_123 --json"],
   },
   {
-    id: "project.connect-repo",
-    path: ["prisma", "project", "connect-repo"],
+    id: "git.connect",
+    path: ["prisma", "git", "connect"],
     description: "Connect the resolved project to a GitHub repository",
     examples: [
-      "prisma-cli project connect-repo",
-      "prisma-cli project connect-repo git@github.com:prisma/prisma-cli.git",
-      "prisma-cli project connect-repo --project proj_123",
+      "prisma-cli git connect",
+      "prisma-cli git connect git@github.com:prisma/prisma-cli.git",
+      "prisma-cli git connect --project proj_123",
     ],
   },
   {
-    id: "project.disconnect-repo",
-    path: ["prisma", "project", "disconnect-repo"],
+    id: "git.disconnect",
+    path: ["prisma", "git", "disconnect"],
     description: "Disconnect the GitHub repository from the resolved project",
-    examples: ["prisma-cli project disconnect-repo", "prisma-cli project disconnect-repo --project proj_123"],
+    examples: ["prisma-cli git disconnect", "prisma-cli git disconnect --project proj_123"],
   },
   {
     id: "branch.list",

--- a/packages/cli/src/types/project.ts
+++ b/packages/cli/src/types/project.ts
@@ -27,3 +27,33 @@ export interface ProjectShowResult {
   project: ProjectSummary;
   resolution: ProjectResolution;
 }
+
+export interface GitRepositoryConnection {
+  id: string | null;
+  provider: "github";
+  repoId: number | null;
+  repository: {
+    owner: string;
+    name: string;
+    fullName: string;
+    url: string;
+  };
+  defaultBranch: string | null;
+  isPrivate: boolean | null;
+  status: "pending" | "active" | "archived";
+  installation: {
+    id: string | null;
+    status: "pending" | "connected";
+  };
+  automation: {
+    branches: boolean;
+    pullRequests: boolean;
+    comments: boolean;
+  };
+  connectedAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface ProjectRepositoryConnectionResult extends ProjectShowResult {
+  repositoryConnection: GitRepositoryConnection | null;
+}

--- a/packages/cli/tests/git-adapter.test.ts
+++ b/packages/cli/tests/git-adapter.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { parseGitHubRepositoryUrl } from "../src/adapters/git";
+
+describe("git adapter", () => {
+  it("parses supported GitHub repository URLs", () => {
+    expect(parseGitHubRepositoryUrl("https://github.com/prisma/prisma-cli")).toEqual({
+      provider: "github",
+      owner: "prisma",
+      name: "prisma-cli",
+      fullName: "prisma/prisma-cli",
+      url: "https://github.com/prisma/prisma-cli",
+    });
+    expect(parseGitHubRepositoryUrl("https://github.com/prisma/prisma-cli.git")).toEqual({
+      provider: "github",
+      owner: "prisma",
+      name: "prisma-cli",
+      fullName: "prisma/prisma-cli",
+      url: "https://github.com/prisma/prisma-cli",
+    });
+    expect(parseGitHubRepositoryUrl("git@github.com:prisma/prisma-cli.git")).toEqual({
+      provider: "github",
+      owner: "prisma",
+      name: "prisma-cli",
+      fullName: "prisma/prisma-cli",
+      url: "https://github.com/prisma/prisma-cli",
+    });
+    expect(parseGitHubRepositoryUrl("ssh://git@github.com/prisma/prisma-cli.git")).toEqual({
+      provider: "github",
+      owner: "prisma",
+      name: "prisma-cli",
+      fullName: "prisma/prisma-cli",
+      url: "https://github.com/prisma/prisma-cli",
+    });
+  });
+
+  it("rejects unsupported providers and non-repository GitHub URLs", () => {
+    expect(parseGitHubRepositoryUrl("https://gitlab.com/prisma/prisma-cli")).toBeNull();
+    expect(parseGitHubRepositoryUrl("https://github.com/prisma/prisma-cli/issues")).toBeNull();
+    expect(parseGitHubRepositoryUrl("not a url")).toBeNull();
+  });
+});

--- a/packages/cli/tests/project-real-mode.test.ts
+++ b/packages/cli/tests/project-real-mode.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 afterEach(() => {
   vi.doUnmock("../src/lib/auth/auth-ops");
   vi.doUnmock("../src/lib/auth/guard");
+  vi.doUnmock("open");
   vi.resetModules();
   vi.restoreAllMocks();
 });
@@ -46,6 +47,35 @@ function mockClient(extra: Partial<{
     }),
     POST: extra.POST ?? vi.fn(),
     DELETE: extra.DELETE ?? vi.fn(),
+  };
+}
+
+function sourceRepositoryRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "srcrepo_123",
+    repoId: 123456,
+    provider: "github",
+    repoFullName: "prisma/prisma-cli",
+    defaultBranch: "main",
+    isPrivate: true,
+    status: "active",
+    projectId: "proj_123",
+    installationId: "scminstall_123",
+    createdAt: "2026-05-18T00:00:00.000Z",
+    updatedAt: "2026-05-18T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function sourceRepositoryList(records: unknown[] = []) {
+  return {
+    data: {
+      data: records,
+      pagination: {
+        nextCursor: null,
+        hasMore: false,
+      },
+    },
   };
 }
 
@@ -136,6 +166,10 @@ describe("real project mode", () => {
     const get = vi.fn().mockImplementation((pathName: string, request?: { params?: { query?: Record<string, unknown> } }) => {
       if (pathName === "/v1/projects") {
         return mockClient().GET(pathName);
+      }
+
+      if (pathName === "/v1/source-repositories") {
+        return sourceRepositoryList();
       }
 
       if (pathName === "/v1/scm-installations") {
@@ -292,10 +326,66 @@ describe("real project mode", () => {
     });
   });
 
+  it("returns the existing connection when the project is already connected to the same GitHub repository", async () => {
+    const get = vi.fn().mockImplementation((pathName: string) => {
+      if (pathName === "/v1/projects") {
+        return mockClient().GET(pathName);
+      }
+
+      if (pathName === "/v1/source-repositories") {
+        return sourceRepositoryList([
+          sourceRepositoryRecord({
+            repoFullName: "Prisma/Prisma-CLI",
+          }),
+        ]);
+      }
+
+      throw new Error(`Unexpected path ${pathName}`);
+    });
+    const post = vi.fn();
+
+    vi.doMock("../src/lib/auth/auth-ops", () => ({
+      readAuthState: mockAuthState(),
+      performLogin: vi.fn(),
+      performLogout: vi.fn(),
+    }));
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth: vi.fn().mockResolvedValue(mockClient({ GET: get, POST: post })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runProjectConnectRepo } = await import("../src/controllers/project");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    const result = await runProjectConnectRepo(context, "https://github.com/prisma/prisma-cli", { project: "proj_123" });
+
+    expect(post).not.toHaveBeenCalled();
+    expect(result.result.repositoryConnection).toMatchObject({
+      id: "srcrepo_123",
+      repository: {
+        fullName: "Prisma/Prisma-CLI",
+      },
+      status: "active",
+    });
+  });
+
   it("creates an install intent when the workspace has no GitHub App installation", async () => {
     const get = vi.fn().mockImplementation((pathName: string) => {
       if (pathName === "/v1/projects") {
         return mockClient().GET(pathName);
+      }
+
+      if (pathName === "/v1/source-repositories") {
+        return sourceRepositoryList();
       }
 
       if (pathName === "/v1/scm-installations") {
@@ -367,10 +457,275 @@ describe("real project mode", () => {
       });
   });
 
+  it("creates an install intent when the stored GitHub App installation is unavailable", async () => {
+    const get = vi.fn().mockImplementation((pathName: string) => {
+      if (pathName === "/v1/projects") {
+        return mockClient().GET(pathName);
+      }
+
+      if (pathName === "/v1/source-repositories") {
+        return sourceRepositoryList();
+      }
+
+      if (pathName === "/v1/scm-installations") {
+        return {
+          data: {
+            data: [
+              {
+                id: "scminstall_123",
+                type: "scm-installation",
+                url: "https://api.prisma.test/v1/scm-installations/scminstall_123",
+                provider: "github",
+                installationId: 98765,
+                accountId: 111,
+                accountLogin: "prisma",
+                accountType: "organization",
+                suspended: false,
+                createdAt: "2026-05-18T00:00:00.000Z",
+                updatedAt: "2026-05-18T00:00:00.000Z",
+              },
+            ],
+            pagination: {
+              nextCursor: null,
+              hasMore: false,
+            },
+          },
+        };
+      }
+
+      if (pathName === "/v1/scm-installations/{installationId}/repositories") {
+        return {
+          error: {
+            error: {
+              code: "validation-error",
+              message: "Failed to list repositories via the SCM provider",
+              hint: "Check the request body against the API docs at GET /v1/doc.",
+            },
+          },
+          response: new Response(null, { status: 422 }),
+        };
+      }
+
+      throw new Error(`Unexpected path ${pathName}`);
+    });
+    const post = vi.fn().mockImplementation((pathName: string, request?: { body?: unknown }) => {
+      if (pathName === "/v1/scm-installations/install-intents") {
+        expect(request?.body).toEqual({
+          provider: "github",
+          workspaceId: "ws_123",
+        });
+        return {
+          data: {
+            data: {
+              type: "install-intent",
+              provider: "github",
+              workspaceId: "wksp_123",
+              installUrl: "https://github.com/apps/prisma/installations/new?state=abc",
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected path ${pathName}`);
+    });
+
+    vi.doMock("../src/lib/auth/auth-ops", () => ({
+      readAuthState: mockAuthState(),
+      performLogin: vi.fn(),
+      performLogout: vi.fn(),
+    }));
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth: vi.fn().mockResolvedValue(mockClient({ GET: get, POST: post })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runProjectConnectRepo } = await import("../src/controllers/project");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await expect(runProjectConnectRepo(context, "https://github.com/prisma/prisma-cli", { project: "proj_123" }))
+      .rejects
+      .toMatchObject({
+        code: "REPO_INSTALLATION_REQUIRED",
+        meta: {
+          installUrl: "https://github.com/apps/prisma/installations/new?state=abc",
+          opened: false,
+          repository: "prisma/prisma-cli",
+        },
+      });
+    expect(post).toHaveBeenCalledOnce();
+  });
+
+  it("waits for GitHub App installation in interactive mode and connects after approval", async () => {
+    const openBrowser = vi.fn().mockResolvedValue(undefined);
+    vi.doMock("open", () => ({ default: openBrowser }));
+
+    let installationListCalls = 0;
+    const get = vi.fn().mockImplementation((pathName: string) => {
+      if (pathName === "/v1/projects") {
+        return mockClient().GET(pathName);
+      }
+
+      if (pathName === "/v1/source-repositories") {
+        return sourceRepositoryList();
+      }
+
+      if (pathName === "/v1/scm-installations") {
+        installationListCalls += 1;
+        return {
+          data: {
+            data: installationListCalls === 1
+              ? []
+              : [
+                  {
+                    id: "scminstall_123",
+                    type: "scm-installation",
+                    url: "https://api.prisma.test/v1/scm-installations/scminstall_123",
+                    provider: "github",
+                    installationId: 98765,
+                    accountId: 111,
+                    accountLogin: "prisma",
+                    accountType: "organization",
+                    suspended: false,
+                    createdAt: "2026-05-18T00:00:00.000Z",
+                    updatedAt: "2026-05-18T00:00:00.000Z",
+                  },
+                ],
+            pagination: {
+              nextCursor: null,
+              hasMore: false,
+            },
+          },
+        };
+      }
+
+      if (pathName === "/v1/scm-installations/{installationId}/repositories") {
+        return {
+          data: {
+            data: [
+              {
+                id: 123456,
+                type: "scm-repository",
+                fullName: "prisma/prisma-cli",
+                defaultBranch: "main",
+                isPrivate: true,
+              },
+            ],
+            pagination: {
+              nextCursor: null,
+              hasMore: false,
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected path ${pathName}`);
+    });
+    const post = vi.fn().mockImplementation((pathName: string, request?: { body?: unknown }) => {
+      if (pathName === "/v1/scm-installations/install-intents") {
+        expect(request?.body).toEqual({
+          provider: "github",
+          workspaceId: "ws_123",
+        });
+        return {
+          data: {
+            data: {
+              type: "install-intent",
+              provider: "github",
+              workspaceId: "wksp_123",
+              installUrl: "https://github.com/apps/prisma/installations/new?state=abc",
+            },
+          },
+        };
+      }
+
+      if (pathName === "/v1/source-repositories") {
+        expect(request?.body).toEqual({
+          projectId: "proj_123",
+          provider: "github",
+          providerRepositoryId: 123456,
+          installationId: "scminstall_123",
+        });
+        return {
+          data: {
+            data: {
+              id: "srcrepo_123",
+              repoId: 123456,
+              provider: "github",
+              repoFullName: "prisma/prisma-cli",
+              defaultBranch: "main",
+              isPrivate: true,
+              status: "active",
+              projectId: "proj_123",
+              installationId: "scminstall_123",
+              createdAt: "2026-05-18T00:00:00.000Z",
+              updatedAt: "2026-05-18T00:00:00.000Z",
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected path ${pathName}`);
+    });
+
+    vi.doMock("../src/lib/auth/auth-ops", () => ({
+      readAuthState: mockAuthState(),
+      performLogin: vi.fn(),
+      performLogout: vi.fn(),
+    }));
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth: vi.fn().mockResolvedValue(mockClient({ GET: get, POST: post })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runProjectConnectRepo } = await import("../src/controllers/project");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const { context, stderr } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      isTTY: true,
+      flags: { interactive: true },
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+        PRISMA_CLI_GITHUB_INSTALL_POLL_INTERVAL_MS: "1",
+        PRISMA_CLI_GITHUB_INSTALL_TIMEOUT_MS: "50",
+      },
+    });
+
+    const result = await runProjectConnectRepo(context, "https://github.com/prisma/prisma-cli", { project: "proj_123" });
+
+    expect(openBrowser).toHaveBeenCalledWith("https://github.com/apps/prisma/installations/new?state=abc");
+    expect(installationListCalls).toBe(2);
+    expect(post).toHaveBeenCalledWith("/v1/source-repositories", {
+      body: {
+        projectId: "proj_123",
+        provider: "github",
+        providerRepositoryId: 123456,
+        installationId: "scminstall_123",
+      },
+    });
+    expect(stderr.buffer).toContain("Waiting for GitHub App installation approval");
+    expect(result.result.repositoryConnection?.repository.fullName).toBe("prisma/prisma-cli");
+  });
+
   it("returns REPO_NOT_ACCESSIBLE when the GitHub App cannot see the repository", async () => {
     const get = vi.fn().mockImplementation((pathName: string) => {
       if (pathName === "/v1/projects") {
         return mockClient().GET(pathName);
+      }
+
+      if (pathName === "/v1/source-repositories") {
+        return sourceRepositoryList();
       }
 
       if (pathName === "/v1/scm-installations") {

--- a/packages/cli/tests/project-real-mode.test.ts
+++ b/packages/cli/tests/project-real-mode.test.ts
@@ -132,13 +132,91 @@ describe("real project mode", () => {
     });
   });
 
-  it("connects a GitHub repository through the source repositories API", async () => {
+  it("connects a GitHub repository through an installed GitHub App", async () => {
+    const get = vi.fn().mockImplementation((pathName: string, request?: { params?: { query?: Record<string, unknown> } }) => {
+      if (pathName === "/v1/projects") {
+        return mockClient().GET(pathName);
+      }
+
+      if (pathName === "/v1/scm-installations") {
+        expect(request?.params?.query).toEqual({
+          workspaceId: "ws_123",
+          limit: 100,
+        });
+        return {
+          data: {
+            data: [
+              {
+                id: "scminstall_123",
+                type: "scm-installation",
+                url: "https://api.prisma.test/v1/scm-installations/scminstall_123",
+                provider: "github",
+                installationId: 98765,
+                accountId: 111,
+                accountLogin: "prisma",
+                accountType: "organization",
+                suspended: false,
+                createdAt: "2026-05-18T00:00:00.000Z",
+                updatedAt: "2026-05-18T00:00:00.000Z",
+              },
+            ],
+            pagination: {
+              nextCursor: null,
+              hasMore: false,
+            },
+          },
+        };
+      }
+
+      if (pathName === "/v1/scm-installations/{installationId}/repositories") {
+        if (request?.params?.query?.cursor === "2") {
+          return {
+            data: {
+              data: [
+                {
+                  id: 123456,
+                  type: "scm-repository",
+                  fullName: "prisma/prisma-cli",
+                  defaultBranch: "main",
+                  isPrivate: true,
+                },
+              ],
+              pagination: {
+                nextCursor: null,
+                hasMore: false,
+              },
+            },
+          };
+        }
+
+        return {
+          data: {
+            data: [
+              {
+                id: 999,
+                type: "scm-repository",
+                fullName: "prisma/other",
+                defaultBranch: "main",
+                isPrivate: false,
+              },
+            ],
+            pagination: {
+              nextCursor: "2",
+              hasMore: true,
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected path ${pathName}`);
+    });
     const post = vi.fn().mockImplementation((pathName: string, request?: { body?: unknown }) => {
       if (pathName === "/v1/source-repositories") {
         expect(request?.body).toEqual({
           projectId: "proj_123",
           provider: "github",
           providerRepositoryId: 123456,
+          installationId: "scminstall_123",
         });
         return {
           data: {
@@ -168,7 +246,7 @@ describe("real project mode", () => {
       performLogout: vi.fn(),
     }));
     vi.doMock("../src/lib/auth/guard", () => ({
-      requireComputeAuth: vi.fn().mockResolvedValue(mockClient({ POST: post })),
+      requireComputeAuth: vi.fn().mockResolvedValue(mockClient({ GET: get, POST: post })),
     }));
 
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
@@ -184,13 +262,20 @@ describe("real project mode", () => {
       },
     });
 
-    const result = await runProjectConnectRepo(
-      context,
-      "https://github.com/prisma/prisma-cli",
-      { project: "proj_123", providerRepositoryId: "123456" },
-    );
+    const result = await runProjectConnectRepo(context, "https://github.com/prisma/prisma-cli", { project: "proj_123" });
 
     expect(post).toHaveBeenCalledOnce();
+    expect(get).toHaveBeenCalledWith("/v1/scm-installations/{installationId}/repositories", {
+      params: {
+        path: {
+          installationId: "scminstall_123",
+        },
+        query: {
+          limit: 100,
+          cursor: "2",
+        },
+      },
+    });
     expect(result.result.repositoryConnection).toMatchObject({
       id: "srcrepo_123",
       repoId: 123456,
@@ -205,6 +290,170 @@ describe("real project mode", () => {
         status: "connected",
       },
     });
+  });
+
+  it("creates an install intent when the workspace has no GitHub App installation", async () => {
+    const get = vi.fn().mockImplementation((pathName: string) => {
+      if (pathName === "/v1/projects") {
+        return mockClient().GET(pathName);
+      }
+
+      if (pathName === "/v1/scm-installations") {
+        return {
+          data: {
+            data: [],
+            pagination: {
+              nextCursor: null,
+              hasMore: false,
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected path ${pathName}`);
+    });
+    const post = vi.fn().mockImplementation((pathName: string, request?: { body?: unknown }) => {
+      if (pathName === "/v1/scm-installations/install-intents") {
+        expect(request?.body).toEqual({
+          provider: "github",
+          workspaceId: "ws_123",
+        });
+        return {
+          data: {
+            data: {
+              type: "install-intent",
+              provider: "github",
+              workspaceId: "wksp_123",
+              installUrl: "https://github.com/apps/prisma/installations/new?state=abc",
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected path ${pathName}`);
+    });
+
+    vi.doMock("../src/lib/auth/auth-ops", () => ({
+      readAuthState: mockAuthState(),
+      performLogin: vi.fn(),
+      performLogout: vi.fn(),
+    }));
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth: vi.fn().mockResolvedValue(mockClient({ GET: get, POST: post })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runProjectConnectRepo } = await import("../src/controllers/project");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await expect(runProjectConnectRepo(context, "https://github.com/prisma/prisma-cli", { project: "proj_123" }))
+      .rejects
+      .toMatchObject({
+        code: "REPO_INSTALLATION_REQUIRED",
+        meta: {
+          installUrl: "https://github.com/apps/prisma/installations/new?state=abc",
+          opened: false,
+          repository: "prisma/prisma-cli",
+        },
+      });
+  });
+
+  it("returns REPO_NOT_ACCESSIBLE when the GitHub App cannot see the repository", async () => {
+    const get = vi.fn().mockImplementation((pathName: string) => {
+      if (pathName === "/v1/projects") {
+        return mockClient().GET(pathName);
+      }
+
+      if (pathName === "/v1/scm-installations") {
+        return {
+          data: {
+            data: [
+              {
+                id: "scminstall_123",
+                type: "scm-installation",
+                url: "https://api.prisma.test/v1/scm-installations/scminstall_123",
+                provider: "github",
+                installationId: 98765,
+                accountId: 111,
+                accountLogin: "prisma",
+                accountType: "organization",
+                suspended: false,
+                createdAt: "2026-05-18T00:00:00.000Z",
+                updatedAt: "2026-05-18T00:00:00.000Z",
+              },
+            ],
+            pagination: {
+              nextCursor: null,
+              hasMore: false,
+            },
+          },
+        };
+      }
+
+      if (pathName === "/v1/scm-installations/{installationId}/repositories") {
+        return {
+          data: {
+            data: [
+              {
+                id: 999,
+                type: "scm-repository",
+                fullName: "prisma/other",
+                defaultBranch: "main",
+                isPrivate: false,
+              },
+            ],
+            pagination: {
+              nextCursor: null,
+              hasMore: false,
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected path ${pathName}`);
+    });
+    const post = vi.fn();
+
+    vi.doMock("../src/lib/auth/auth-ops", () => ({
+      readAuthState: mockAuthState(),
+      performLogin: vi.fn(),
+      performLogout: vi.fn(),
+    }));
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth: vi.fn().mockResolvedValue(mockClient({ GET: get, POST: post })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runProjectConnectRepo } = await import("../src/controllers/project");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await expect(runProjectConnectRepo(context, "https://github.com/prisma/prisma-cli", { project: "proj_123" }))
+      .rejects
+      .toMatchObject({
+        code: "REPO_NOT_ACCESSIBLE",
+        meta: {
+          repository: "prisma/prisma-cli",
+        },
+      });
+    expect(post).not.toHaveBeenCalled();
   });
 
   it("disconnects a GitHub repository through the source repositories API", async () => {
@@ -274,6 +523,6 @@ describe("real project mode", () => {
         },
       },
     });
-    expect(result.result.repositoryConnection.repository.fullName).toBe("prisma/prisma-cli");
+    expect(result.result.repositoryConnection?.repository.fullName).toBe("prisma/prisma-cli");
   });
 });

--- a/packages/cli/tests/project-real-mode.test.ts
+++ b/packages/cli/tests/project-real-mode.test.ts
@@ -742,7 +742,7 @@ describe("real project mode", () => {
         installationId: "scminstall_123",
       },
     });
-    expect(stderr.buffer).toContain("Waiting for GitHub App installation approval");
+    expect(stderr.buffer).toContain("Waiting for GitHub App installation or repository access approval");
     expect(result.result.repositoryConnection?.repository.fullName).toBe("prisma/prisma-cli");
   });
 
@@ -804,7 +804,26 @@ describe("real project mode", () => {
 
       throw new Error(`Unexpected path ${pathName}`);
     });
-    const post = vi.fn();
+    const post = vi.fn().mockImplementation((pathName: string, request?: { body?: unknown }) => {
+      if (pathName === "/v1/scm-installations/install-intents") {
+        expect(request?.body).toEqual({
+          provider: "github",
+          workspaceId: "ws_123",
+        });
+        return {
+          data: {
+            data: {
+              type: "install-intent",
+              provider: "github",
+              workspaceId: "wksp_123",
+              installUrl: "https://github.com/apps/prisma/installations/new?state=abc",
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected path ${pathName}`);
+    });
 
     vi.doMock("../src/lib/auth/auth-ops", () => ({
       readAuthState: mockAuthState(),
@@ -833,10 +852,12 @@ describe("real project mode", () => {
       .toMatchObject({
         code: "REPO_NOT_ACCESSIBLE",
         meta: {
+          installUrl: "https://github.com/apps/prisma/installations/new?state=abc",
+          opened: false,
           repository: "prisma/prisma-cli",
         },
       });
-    expect(post).not.toHaveBeenCalled();
+    expect(post).toHaveBeenCalledOnce();
   });
 
   it("guards repeated GitHub App installation pagination cursors", async () => {

--- a/packages/cli/tests/project-real-mode.test.ts
+++ b/packages/cli/tests/project-real-mode.test.ts
@@ -284,7 +284,7 @@ describe("real project mode", () => {
     }));
 
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
-    const { runProjectConnectRepo } = await import("../src/controllers/project");
+    const { runGitConnect } = await import("../src/controllers/project");
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
@@ -296,7 +296,7 @@ describe("real project mode", () => {
       },
     });
 
-    const result = await runProjectConnectRepo(context, "https://github.com/prisma/prisma-cli", { project: "proj_123" });
+    const result = await runGitConnect(context, "https://github.com/prisma/prisma-cli", { project: "proj_123" });
 
     expect(post).toHaveBeenCalledOnce();
     expect(get).toHaveBeenCalledWith("/v1/scm-installations/{installationId}/repositories", {
@@ -354,7 +354,7 @@ describe("real project mode", () => {
     }));
 
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
-    const { runProjectConnectRepo } = await import("../src/controllers/project");
+    const { runGitConnect } = await import("../src/controllers/project");
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
@@ -366,7 +366,7 @@ describe("real project mode", () => {
       },
     });
 
-    const result = await runProjectConnectRepo(context, "https://github.com/prisma/prisma-cli", { project: "proj_123" });
+    const result = await runGitConnect(context, "https://github.com/prisma/prisma-cli", { project: "proj_123" });
 
     expect(post).not.toHaveBeenCalled();
     expect(result.result.repositoryConnection).toMatchObject({
@@ -433,7 +433,7 @@ describe("real project mode", () => {
     }));
 
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
-    const { runProjectConnectRepo } = await import("../src/controllers/project");
+    const { runGitConnect } = await import("../src/controllers/project");
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
@@ -445,7 +445,7 @@ describe("real project mode", () => {
       },
     });
 
-    await expect(runProjectConnectRepo(context, "https://github.com/prisma/prisma-cli", { project: "proj_123" }))
+    await expect(runGitConnect(context, "https://github.com/prisma/prisma-cli", { project: "proj_123" }))
       .rejects
       .toMatchObject({
         code: "REPO_INSTALLATION_REQUIRED",
@@ -539,7 +539,7 @@ describe("real project mode", () => {
     }));
 
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
-    const { runProjectConnectRepo } = await import("../src/controllers/project");
+    const { runGitConnect } = await import("../src/controllers/project");
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
@@ -551,7 +551,7 @@ describe("real project mode", () => {
       },
     });
 
-    await expect(runProjectConnectRepo(context, "https://github.com/prisma/prisma-cli", { project: "proj_123" }))
+    await expect(runGitConnect(context, "https://github.com/prisma/prisma-cli", { project: "proj_123" }))
       .rejects
       .toMatchObject({
         code: "REPO_INSTALLATION_REQUIRED",
@@ -686,7 +686,7 @@ describe("real project mode", () => {
     }));
 
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
-    const { runProjectConnectRepo } = await import("../src/controllers/project");
+    const { runGitConnect } = await import("../src/controllers/project");
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");
     const { context, stderr } = await createTestCommandContext({
@@ -702,7 +702,7 @@ describe("real project mode", () => {
       },
     });
 
-    const result = await runProjectConnectRepo(context, "https://github.com/prisma/prisma-cli", { project: "proj_123" });
+    const result = await runGitConnect(context, "https://github.com/prisma/prisma-cli", { project: "proj_123" });
 
     expect(openBrowser).toHaveBeenCalledWith("https://github.com/apps/prisma/installations/new?state=abc");
     expect(installationListCalls).toBe(2);
@@ -788,7 +788,7 @@ describe("real project mode", () => {
     }));
 
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
-    const { runProjectConnectRepo } = await import("../src/controllers/project");
+    const { runGitConnect } = await import("../src/controllers/project");
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
@@ -800,7 +800,7 @@ describe("real project mode", () => {
       },
     });
 
-    await expect(runProjectConnectRepo(context, "https://github.com/prisma/prisma-cli", { project: "proj_123" }))
+    await expect(runGitConnect(context, "https://github.com/prisma/prisma-cli", { project: "proj_123" }))
       .rejects
       .toMatchObject({
         code: "REPO_NOT_ACCESSIBLE",
@@ -857,7 +857,7 @@ describe("real project mode", () => {
     }));
 
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
-    const { runProjectDisconnectRepo } = await import("../src/controllers/project");
+    const { runGitDisconnect } = await import("../src/controllers/project");
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
@@ -869,7 +869,7 @@ describe("real project mode", () => {
       },
     });
 
-    const result = await runProjectDisconnectRepo(context, { project: "proj_123" });
+    const result = await runGitDisconnect(context, { project: "proj_123" });
 
     expect(del).toHaveBeenCalledWith("/v1/source-repositories/{id}", {
       params: {

--- a/packages/cli/tests/project-real-mode.test.ts
+++ b/packages/cli/tests/project-real-mode.test.ts
@@ -79,6 +79,34 @@ function sourceRepositoryList(records: unknown[] = []) {
   };
 }
 
+function scmInstallationRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "scminstall_123",
+    type: "scm-installation",
+    url: "https://api.prisma.test/v1/scm-installations/scminstall_123",
+    provider: "github",
+    installationId: 98765,
+    accountId: 111,
+    accountLogin: "prisma",
+    accountType: "organization",
+    suspended: false,
+    createdAt: "2026-05-18T00:00:00.000Z",
+    updatedAt: "2026-05-18T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function scmRepositoryRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 999,
+    type: "scm-repository",
+    fullName: "prisma/other",
+    defaultBranch: "main",
+    isPrivate: false,
+    ...overrides,
+  };
+}
+
 describe("real project mode", () => {
   it("uses the real API path for project list and sorts by name then id", async () => {
     const readAuthState = mockAuthState();
@@ -807,6 +835,132 @@ describe("real project mode", () => {
         meta: {
           repository: "prisma/prisma-cli",
         },
+      });
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("guards repeated GitHub App installation pagination cursors", async () => {
+    const get = vi.fn().mockImplementation((pathName: string) => {
+      if (pathName === "/v1/projects") {
+        return mockClient().GET(pathName);
+      }
+
+      if (pathName === "/v1/source-repositories") {
+        return sourceRepositoryList();
+      }
+
+      if (pathName === "/v1/scm-installations") {
+        return {
+          data: {
+            data: [],
+            pagination: {
+              nextCursor: "repeat",
+              hasMore: true,
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected path ${pathName}`);
+    });
+    const post = vi.fn();
+
+    vi.doMock("../src/lib/auth/auth-ops", () => ({
+      readAuthState: mockAuthState(),
+      performLogin: vi.fn(),
+      performLogout: vi.fn(),
+    }));
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth: vi.fn().mockResolvedValue(mockClient({ GET: get, POST: post })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runGitConnect } = await import("../src/controllers/project");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await expect(runGitConnect(context, "https://github.com/prisma/prisma-cli", { project: "proj_123" }))
+      .rejects
+      .toMatchObject({
+        code: "REPO_CONNECTION_FAILED",
+        why: "Pagination cursor did not advance.",
+      });
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("guards repeated GitHub repository pagination cursors", async () => {
+    const get = vi.fn().mockImplementation((pathName: string) => {
+      if (pathName === "/v1/projects") {
+        return mockClient().GET(pathName);
+      }
+
+      if (pathName === "/v1/source-repositories") {
+        return sourceRepositoryList();
+      }
+
+      if (pathName === "/v1/scm-installations") {
+        return {
+          data: {
+            data: [scmInstallationRecord()],
+            pagination: {
+              nextCursor: null,
+              hasMore: false,
+            },
+          },
+        };
+      }
+
+      if (pathName === "/v1/scm-installations/{installationId}/repositories") {
+        return {
+          data: {
+            data: [scmRepositoryRecord()],
+            pagination: {
+              nextCursor: "repeat",
+              hasMore: true,
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected path ${pathName}`);
+    });
+    const post = vi.fn();
+
+    vi.doMock("../src/lib/auth/auth-ops", () => ({
+      readAuthState: mockAuthState(),
+      performLogin: vi.fn(),
+      performLogout: vi.fn(),
+    }));
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth: vi.fn().mockResolvedValue(mockClient({ GET: get, POST: post })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runGitConnect } = await import("../src/controllers/project");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await expect(runGitConnect(context, "https://github.com/prisma/prisma-cli", { project: "proj_123" }))
+      .rejects
+      .toMatchObject({
+        code: "REPO_CONNECTION_FAILED",
+        why: "Pagination cursor did not advance.",
       });
     expect(post).not.toHaveBeenCalled();
   });

--- a/packages/cli/tests/project-real-mode.test.ts
+++ b/packages/cli/tests/project-real-mode.test.ts
@@ -23,9 +23,13 @@ function mockAuthState() {
   });
 }
 
-function mockClient() {
+function mockClient(extra: Partial<{
+  GET: ReturnType<typeof vi.fn>;
+  POST: ReturnType<typeof vi.fn>;
+  DELETE: ReturnType<typeof vi.fn>;
+}> = {}) {
   return {
-    GET: vi.fn().mockImplementation((pathName: string) => {
+    GET: extra.GET ?? vi.fn().mockImplementation((pathName: string) => {
       if (pathName === "/v1/projects") {
         return {
           data: {
@@ -40,6 +44,8 @@ function mockClient() {
 
       throw new Error(`Unexpected path ${pathName}`);
     }),
+    POST: extra.POST ?? vi.fn(),
+    DELETE: extra.DELETE ?? vi.fn(),
   };
 }
 
@@ -124,5 +130,150 @@ describe("real project mode", () => {
         },
       },
     });
+  });
+
+  it("connects a GitHub repository through the source repositories API", async () => {
+    const post = vi.fn().mockImplementation((pathName: string, request?: { body?: unknown }) => {
+      if (pathName === "/v1/source-repositories") {
+        expect(request?.body).toEqual({
+          projectId: "proj_123",
+          provider: "github",
+          providerRepositoryId: 123456,
+        });
+        return {
+          data: {
+            data: {
+              id: "srcrepo_123",
+              repoId: 123456,
+              provider: "github",
+              repoFullName: "prisma/prisma-cli",
+              defaultBranch: "main",
+              isPrivate: true,
+              status: "active",
+              projectId: "proj_123",
+              installationId: "scminstall_123",
+              createdAt: "2026-05-18T00:00:00.000Z",
+              updatedAt: "2026-05-18T00:00:00.000Z",
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected path ${pathName}`);
+    });
+
+    vi.doMock("../src/lib/auth/auth-ops", () => ({
+      readAuthState: mockAuthState(),
+      performLogin: vi.fn(),
+      performLogout: vi.fn(),
+    }));
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth: vi.fn().mockResolvedValue(mockClient({ POST: post })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runProjectConnectRepo } = await import("../src/controllers/project");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    const result = await runProjectConnectRepo(
+      context,
+      "https://github.com/prisma/prisma-cli",
+      { project: "proj_123", providerRepositoryId: "123456" },
+    );
+
+    expect(post).toHaveBeenCalledOnce();
+    expect(result.result.repositoryConnection).toMatchObject({
+      id: "srcrepo_123",
+      repoId: 123456,
+      repository: {
+        fullName: "prisma/prisma-cli",
+      },
+      defaultBranch: "main",
+      isPrivate: true,
+      status: "active",
+      installation: {
+        id: "scminstall_123",
+        status: "connected",
+      },
+    });
+  });
+
+  it("disconnects a GitHub repository through the source repositories API", async () => {
+    const del = vi.fn().mockResolvedValue({});
+    const get = vi.fn().mockImplementation((pathName: string) => {
+      if (pathName === "/v1/projects") {
+        return mockClient().GET(pathName);
+      }
+
+      if (pathName === "/v1/source-repositories") {
+        return {
+          data: {
+            data: [
+              {
+                id: "srcrepo_123",
+                repoId: 123456,
+                provider: "github",
+                repoFullName: "prisma/prisma-cli",
+                defaultBranch: "main",
+                isPrivate: false,
+                status: "active",
+                projectId: "proj_123",
+                installationId: "scminstall_123",
+                createdAt: "2026-05-18T00:00:00.000Z",
+                updatedAt: "2026-05-18T00:00:00.000Z",
+              },
+            ],
+            pagination: {
+              nextCursor: null,
+              hasMore: false,
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected path ${pathName}`);
+    });
+
+    vi.doMock("../src/lib/auth/auth-ops", () => ({
+      readAuthState: mockAuthState(),
+      performLogin: vi.fn(),
+      performLogout: vi.fn(),
+    }));
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth: vi.fn().mockResolvedValue(mockClient({ GET: get, DELETE: del })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runProjectDisconnectRepo } = await import("../src/controllers/project");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    const result = await runProjectDisconnectRepo(context, { project: "proj_123" });
+
+    expect(del).toHaveBeenCalledWith("/v1/source-repositories/{id}", {
+      params: {
+        path: {
+          id: "srcrepo_123",
+        },
+      },
+    });
+    expect(result.result.repositoryConnection.repository.fullName).toBe("prisma/prisma-cli");
   });
 });

--- a/packages/cli/tests/project.test.ts
+++ b/packages/cli/tests/project.test.ts
@@ -290,6 +290,70 @@ describe("project commands", () => {
     expect(state.project.repositoryConnectionsByProject.proj_123.repository.fullName).toBe("prisma/prisma-cli");
   });
 
+  it("keeps fixture repository connection idempotent for the same repo", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    await login(cwd, stateDir);
+
+    await executeCli({
+      argv: ["git", "connect", "https://github.com/prisma/prisma-cli", "--project", "proj_123"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+
+    const result = await executeCli({
+      argv: ["git", "connect", "git@github.com:Prisma/Prisma-CLI.git", "--project", "proj_123", "--json"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: true,
+      command: "git.connect",
+      result: {
+        repositoryConnection: {
+          repository: {
+            fullName: "prisma/prisma-cli",
+          },
+        },
+      },
+    });
+  });
+
+  it("blocks fixture repository replacement without disconnecting first", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    await login(cwd, stateDir);
+
+    await executeCli({
+      argv: ["git", "connect", "https://github.com/prisma/prisma-cli", "--project", "proj_123"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+
+    const result = await executeCli({
+      argv: ["git", "connect", "https://github.com/prisma/other", "--project", "proj_123", "--json"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+    const state = JSON.parse(await readFile(path.join(stateDir, "state.json"), "utf8"));
+
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: false,
+      command: "git.connect",
+      error: {
+        code: "REPO_ALREADY_CONNECTED",
+      },
+    });
+    expect(state.project.repositoryConnectionsByProject.proj_123.repository.fullName).toBe("prisma/prisma-cli");
+  });
+
   it("disconnects a GitHub repository from an explicit project in fixture mode", async () => {
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");

--- a/packages/cli/tests/project.test.ts
+++ b/packages/cli/tests/project.test.ts
@@ -301,6 +301,8 @@ describe("project commands", () => {
       stateDir,
       fixturePath,
     });
+    const initialState = JSON.parse(await readFile(path.join(stateDir, "state.json"), "utf8"));
+    const initialConnection = initialState.project.repositoryConnectionsByProject.proj_123;
 
     const result = await executeCli({
       argv: ["git", "connect", "git@github.com:Prisma/Prisma-CLI.git", "--project", "proj_123", "--json"],
@@ -308,19 +310,16 @@ describe("project commands", () => {
       stateDir,
       fixturePath,
     });
+    const payload = JSON.parse(result.stdout);
+    const nextState = JSON.parse(await readFile(path.join(stateDir, "state.json"), "utf8"));
 
     expect(result.exitCode).toBe(0);
-    expect(JSON.parse(result.stdout)).toMatchObject({
+    expect(payload).toMatchObject({
       ok: true,
       command: "git.connect",
-      result: {
-        repositoryConnection: {
-          repository: {
-            fullName: "prisma/prisma-cli",
-          },
-        },
-      },
     });
+    expect(payload.result.repositoryConnection).toEqual(initialConnection);
+    expect(nextState.project.repositoryConnectionsByProject.proj_123).toEqual(initialConnection);
   });
 
   it("blocks fixture repository replacement without disconnecting first", async () => {
@@ -334,6 +333,8 @@ describe("project commands", () => {
       stateDir,
       fixturePath,
     });
+    const initialState = JSON.parse(await readFile(path.join(stateDir, "state.json"), "utf8"));
+    const initialConnection = initialState.project.repositoryConnectionsByProject.proj_123;
 
     const result = await executeCli({
       argv: ["git", "connect", "https://github.com/prisma/other", "--project", "proj_123", "--json"],
@@ -351,7 +352,7 @@ describe("project commands", () => {
         code: "REPO_ALREADY_CONNECTED",
       },
     });
-    expect(state.project.repositoryConnectionsByProject.proj_123.repository.fullName).toBe("prisma/prisma-cli");
+    expect(state.project.repositoryConnectionsByProject.proj_123).toEqual(initialConnection);
   });
 
   it("disconnects a GitHub repository from an explicit project in fixture mode", async () => {

--- a/packages/cli/tests/project.test.ts
+++ b/packages/cli/tests/project.test.ts
@@ -257,7 +257,7 @@ describe("project commands", () => {
     await login(cwd, stateDir);
 
     const result = await executeCli({
-      argv: ["project", "connect-repo", "git@github.com:prisma/prisma-cli.git", "--project", "proj_123", "--json"],
+      argv: ["git", "connect", "git@github.com:prisma/prisma-cli.git", "--project", "proj_123", "--json"],
       cwd,
       stateDir,
       fixturePath,
@@ -269,7 +269,7 @@ describe("project commands", () => {
     expect(result.stderr).toBe("");
     expect(payload).toMatchObject({
       ok: true,
-      command: "project.connect-repo",
+      command: "git.connect",
       result: {
         project: {
           id: "proj_123",
@@ -295,14 +295,14 @@ describe("project commands", () => {
     const stateDir = path.join(cwd, ".state");
     await login(cwd, stateDir);
     await executeCli({
-      argv: ["project", "connect-repo", "https://github.com/prisma/prisma-cli", "--project", "proj_123"],
+      argv: ["git", "connect", "https://github.com/prisma/prisma-cli", "--project", "proj_123"],
       cwd,
       stateDir,
       fixturePath,
     });
 
     const result = await executeCli({
-      argv: ["project", "disconnect-repo", "--project", "proj_123", "--json"],
+      argv: ["git", "disconnect", "--project", "proj_123", "--json"],
       cwd,
       stateDir,
       fixturePath,
@@ -312,7 +312,7 @@ describe("project commands", () => {
     expect(result.exitCode).toBe(0);
     expect(JSON.parse(result.stdout)).toMatchObject({
       ok: true,
-      command: "project.disconnect-repo",
+      command: "git.disconnect",
       result: {
         repositoryConnection: {
           repository: {
@@ -332,7 +332,7 @@ describe("project commands", () => {
     await login(cwd, stateDir);
 
     const result = await executeCli({
-      argv: ["project", "connect-repo", "https://gitlab.com/prisma/prisma-cli", "--project", "proj_123", "--json"],
+      argv: ["git", "connect", "https://gitlab.com/prisma/prisma-cli", "--project", "proj_123", "--json"],
       cwd,
       stateDir,
       fixturePath,
@@ -348,7 +348,7 @@ describe("project commands", () => {
     await login(cwd, stateDir);
 
     const result = await executeCli({
-      argv: ["project", "connect-repo", "https://github.com/prisma/prisma-cli", "--json"],
+      argv: ["git", "connect", "https://github.com/prisma/prisma-cli", "--json"],
       cwd,
       stateDir,
       fixturePath,
@@ -358,7 +358,7 @@ describe("project commands", () => {
     expect(JSON.parse(result.stdout).error.code).toBe("PROJECT_UNRESOLVED");
   });
 
-  it("shows Public Beta project help without project link", async () => {
+  it("shows Public Beta project and git help without project link", async () => {
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");
 
@@ -374,22 +374,30 @@ describe("project commands", () => {
       stateDir,
       fixturePath,
     });
+    const gitHelp = await executeCli({
+      argv: ["git", "--help"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
     const connectRepoHelp = await executeCli({
-      argv: ["project", "connect-repo", "--help"],
+      argv: ["git", "connect", "--help"],
       cwd,
       stateDir,
       fixturePath,
     });
     const disconnectRepoHelp = await executeCli({
-      argv: ["project", "disconnect-repo", "--help"],
+      argv: ["git", "disconnect", "--help"],
       cwd,
       stateDir,
       fixturePath,
     });
-    const stderr = stripAnsi(`${projectHelp.stderr}\n${showHelp.stderr}\n${connectRepoHelp.stderr}\n${disconnectRepoHelp.stderr}`);
+    const stderr = stripAnsi(`${projectHelp.stderr}\n${showHelp.stderr}\n${gitHelp.stderr}\n${connectRepoHelp.stderr}\n${disconnectRepoHelp.stderr}`);
 
     expect(projectHelp.exitCode).toBe(0);
+    expect(gitHelp.exitCode).toBe(0);
     expect(stderr).toContain("project → Manage and inspect your Prisma projects");
+    expect(stderr).toContain("git → Manage Git repository connections for a project");
     expect(stderr).toContain("Show which project is active for this directory");
     expect(stderr).toContain("Connect the resolved project to a GitHub repository");
     expect(stderr).toContain("Disconnect the GitHub repository from the resolved project");

--- a/packages/cli/tests/project.test.ts
+++ b/packages/cli/tests/project.test.ts
@@ -44,6 +44,7 @@ async function writeStaleProjectState(stateDir: string) {
             name: "Missing Project",
             workspaceId: "ws_123",
           },
+          repositoryConnectionsByProject: {},
         },
         branch: { active: "preview" },
         app: {
@@ -250,6 +251,113 @@ describe("project commands", () => {
     expect(JSON.parse(result.stdout).error.code).toBe("LOCAL_STATE_STALE");
   });
 
+  it("connects a GitHub repository to an explicit project in fixture mode", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    await login(cwd, stateDir);
+
+    const result = await executeCli({
+      argv: ["project", "connect-repo", "git@github.com:prisma/prisma-cli.git", "--project", "proj_123", "--json"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+    const payload = JSON.parse(result.stdout);
+    const state = JSON.parse(await readFile(path.join(stateDir, "state.json"), "utf8"));
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(payload).toMatchObject({
+      ok: true,
+      command: "project.connect-repo",
+      result: {
+        project: {
+          id: "proj_123",
+          name: "Acme Dashboard",
+        },
+        repositoryConnection: {
+          provider: "github",
+          repository: {
+            fullName: "prisma/prisma-cli",
+            url: "https://github.com/prisma/prisma-cli",
+          },
+          status: "pending",
+        },
+      },
+      warnings: [],
+      nextSteps: [],
+    });
+    expect(state.project.repositoryConnectionsByProject.proj_123.repository.fullName).toBe("prisma/prisma-cli");
+  });
+
+  it("disconnects a GitHub repository from an explicit project in fixture mode", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    await login(cwd, stateDir);
+    await executeCli({
+      argv: ["project", "connect-repo", "https://github.com/prisma/prisma-cli", "--project", "proj_123"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+
+    const result = await executeCli({
+      argv: ["project", "disconnect-repo", "--project", "proj_123", "--json"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+    const state = JSON.parse(await readFile(path.join(stateDir, "state.json"), "utf8"));
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: true,
+      command: "project.disconnect-repo",
+      result: {
+        repositoryConnection: {
+          repository: {
+            fullName: "prisma/prisma-cli",
+          },
+        },
+      },
+      warnings: [],
+      nextSteps: [],
+    });
+    expect(state.project.repositoryConnectionsByProject.proj_123).toBeUndefined();
+  });
+
+  it("returns REPO_PROVIDER_UNSUPPORTED for non-GitHub repository URLs", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    await login(cwd, stateDir);
+
+    const result = await executeCli({
+      argv: ["project", "connect-repo", "https://gitlab.com/prisma/prisma-cli", "--project", "proj_123", "--json"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+
+    expect(result.exitCode).toBe(2);
+    expect(JSON.parse(result.stdout).error.code).toBe("REPO_PROVIDER_UNSUPPORTED");
+  });
+
+  it("returns PROJECT_UNRESOLVED for repository connection without a resolved project", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    await login(cwd, stateDir);
+
+    const result = await executeCli({
+      argv: ["project", "connect-repo", "https://github.com/prisma/prisma-cli", "--json"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.stdout).error.code).toBe("PROJECT_UNRESOLVED");
+  });
+
   it("shows Public Beta project help without project link", async () => {
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");
@@ -266,11 +374,25 @@ describe("project commands", () => {
       stateDir,
       fixturePath,
     });
-    const stderr = stripAnsi(`${projectHelp.stderr}\n${showHelp.stderr}`);
+    const connectRepoHelp = await executeCli({
+      argv: ["project", "connect-repo", "--help"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+    const disconnectRepoHelp = await executeCli({
+      argv: ["project", "disconnect-repo", "--help"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+    const stderr = stripAnsi(`${projectHelp.stderr}\n${showHelp.stderr}\n${connectRepoHelp.stderr}\n${disconnectRepoHelp.stderr}`);
 
     expect(projectHelp.exitCode).toBe(0);
     expect(stderr).toContain("project → Manage and inspect your Prisma projects");
     expect(stderr).toContain("Show which project is active for this directory");
+    expect(stderr).toContain("Connect the resolved project to a GitHub repository");
+    expect(stderr).toContain("Disconnect the GitHub repository from the resolved project");
     expect(stderr).not.toContain("project link");
     expect(stderr).not.toContain("linked project");
   });


### PR DESCRIPTION
## summary

adds the cli foundation for connecting a resolved prisma project to a github repository through the server-side github app installation flow.

- adds `prisma git connect [git-url]`
- adds `prisma git disconnect`
- detects the github repo from `git remote origin` when no url is passed
- supports explicit project selection with `--project <id-or-name>`
- lists workspace github app installations via the management api
- creates an install intent when no usable github app installation exists
- opens the github app install url and waits for approval in interactive mode
- returns `REPO_INSTALLATION_REQUIRED` with the install url in json, ci, or non-interactive mode
- handles stale/unavailable github app installation rows by starting a fresh install intent
- links the project through `POST /v1/source-repositories` with `projectId`, `providerRepositoryId`, and `installationId`
- makes repeated `git connect` runs idempotent when the project is already linked to the same repo

## cli examples

```sh
prisma git connect
prisma git connect git@github.com:prisma/prisma-cli.git --project proj_123
prisma git connect https://github.com/prisma/prisma-cli --project proj_123
prisma git disconnect --project proj_123
```

## not included

- github webhook branch/pr automation
- automatic app build/deploy/preview behavior
- monorepo multi-app detection