### PR TITLE
Stream app deployment logs

### DIFF
--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -436,8 +436,12 @@ Purpose:
 Behavior:
 
 - requires auth and project context
-- resolves the selected app and deployment
-- returns `FEATURE_UNAVAILABLE` when logs are unavailable in the current preview
+- resolves the selected app and the deployment currently serving live traffic
+- streams raw app log lines to stdout in human mode
+- writes CLI status and errors to stderr
+- when `--deployment` is provided, streams logs for that exact deployment
+- when both `--app` and `--deployment` are provided, verifies the deployment belongs to the selected app
+- returns `FEATURE_UNAVAILABLE` only when the platform cannot provide logs for the resolved deployment
 
 Examples:
 

--- a/docs/product/output-conventions.md
+++ b/docs/product/output-conventions.md
@@ -345,6 +345,10 @@ Required conventions:
 - the final event is either success or error
 - non-streaming commands should continue to use a single JSON object rather than NDJSON
 
+In human mode, `app logs` is a special case: raw app log lines are the primary
+streamed payload and go to stdout so they can be piped or redirected. CLI
+context, status, decoration, and errors stay on stderr.
+
 ## Data Conventions
 
 - ids are opaque and stable

--- a/packages/cli/src/commands/app/index.ts
+++ b/packages/cli/src/commands/app/index.ts
@@ -43,7 +43,7 @@ import {
 } from "../../presenters/app";
 import { attachCommandDescriptor } from "../../shell/command-meta";
 import { addCompactGlobalFlags, addGlobalFlags } from "../../shell/global-flags";
-import { runCommand } from "../../shell/command-runner";
+import { runCommand, runStreamingCommand } from "../../shell/command-runner";
 import { configureRuntimeCommand, type CliRuntime } from "../../shell/runtime";
 import { PREVIEW_BUILD_TYPES } from "../../lib/app/preview-build";
 import type {
@@ -330,14 +330,11 @@ function createLogsCommand(runtime: CliRuntime): Command {
     const appName = (options as { app?: string }).app;
     const deploymentId = (options as { deployment?: string }).deployment;
 
-    await runCommand<never>(
+    await runStreamingCommand(
       runtime,
       "app.logs",
       options as Record<string, unknown>,
       (context) => runAppLogs(context, appName, deploymentId),
-      {
-        renderHuman: () => [],
-      },
     );
   });
 

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -1,13 +1,15 @@
 import path from "node:path";
 
 import open from "open";
-import type { PortMapping } from "@prisma/compute-sdk";
+import type { PortMapping, StreamRecord } from "@prisma/compute-sdk";
 
 import { UnsafeConfigWriteError, assertLinkedProjectIdWritable, readLinkedProjectId, writeLinkedProjectId } from "../adapters/config";
+import { FileTokenStorage } from "../adapters/token-storage";
 import { authRequiredError, CliError, featureUnavailableError, usageError } from "../shell/errors";
-import type { CommandSuccess } from "../shell/output";
+import { writeJsonEvent, type CommandSuccess } from "../shell/output";
 import { canPrompt, type CommandContext } from "../shell/runtime";
 import { textPrompt } from "../shell/prompt";
+import { renderCommandHeader } from "../shell/ui";
 import type {
   AppBuildResult,
   AppDeployResult,
@@ -24,6 +26,7 @@ import type {
   AppUpdateEnvResult,
 } from "../types/app";
 import { requireComputeAuth } from "../lib/auth/guard";
+import { getApiBaseUrl, SERVICE_TOKEN_ENV_VAR } from "../lib/auth/client";
 import { parseEnvAssignments } from "../lib/app/env-vars";
 import {
   DEFAULT_LOCAL_DEV_PORT,
@@ -649,14 +652,196 @@ export async function runAppOpen(
 
 export async function runAppLogs(
   context: CommandContext,
-  _appName: string | undefined,
-  _deploymentId: string | undefined,
-): Promise<never> {
+  appName: string | undefined,
+  deploymentId: string | undefined,
+): Promise<void> {
   ensurePreviewAppMode(context);
-  throw blockedPreviewAppCommandError(
-    "App logs are not available in this preview",
-    "The current preview cannot stream app logs yet.",
+
+  const projectId = await requireLinkedProjectId(context);
+  const provider = await requirePreviewAppProvider(context);
+  const target = deploymentId
+    ? await resolveExplicitLogDeployment(context, provider, projectId, appName, deploymentId)
+    : await resolveLiveLogDeployment(context, provider, projectId, appName);
+
+  if (!context.flags.json && !context.flags.quiet) {
+    const lines = renderCommandHeader(context.ui, {
+      commandLabel: "app logs",
+      description: "Streaming logs for the selected deployment.",
+      docsPath: "docs/product/command-spec.md#prisma-cli-app-logs---app-name---deployment-id",
+      rows: [
+        { key: "project", value: projectId },
+        { key: "app", value: target.app.name },
+        { key: "deployment", value: target.deployment.id },
+      ],
+    });
+    if (lines.length > 0) {
+      context.output.stderr.write(`${lines.join("\n")}\n`);
+    }
+  }
+
+  await provider.streamDeploymentLogs({
+    deploymentId: target.deployment.id,
+    onRecord: (record) => writeLogRecord(context, record),
+  }).catch((error) => {
+    throw deployFailedError("Failed to stream app logs", error, [
+      `prisma-cli app show-deploy ${target.deployment.id}`,
+      "prisma-cli app list-deploys",
+    ]);
+  });
+}
+
+async function resolveExplicitLogDeployment(
+  context: CommandContext,
+  provider: ReturnType<typeof createPreviewAppProvider>,
+  projectId: string,
+  appName: string | undefined,
+  deploymentId: string,
+): Promise<{ app: PreviewAppRecord; deployment: AppDeploymentSummary }> {
+  if (appName) {
+    const apps = await listApps(context, provider, projectId);
+    const selectedApp = await resolveExistingAppSelection(context, projectId, apps, appName);
+
+    if (!selectedApp) {
+      throw noDeploymentsError(
+        "No deployments available to stream logs",
+        "The linked project does not have any deployed app yet.",
+      );
+    }
+
+    const deploymentsResult = await provider.listDeployments(selectedApp.id).catch((error) => {
+      throw deployFailedError("Failed to list app deployments", error, ["prisma-cli app list-deploys"]);
+    });
+    const deployment = requireDeploymentForApp(deploymentsResult.deployments, deploymentId, selectedApp.name);
+
+    await context.stateStore.setSelectedApp(projectId, {
+      id: deploymentsResult.app.id,
+      name: deploymentsResult.app.name,
+    });
+
+    return {
+      app: deploymentsResult.app,
+      deployment,
+    };
+  }
+
+  const shown = await provider.showDeployment(deploymentId).catch((error) => {
+    throw deployFailedError("Failed to show deployment", error, ["prisma-cli app list-deploys"]);
+  });
+
+  if (!shown) {
+    throw new CliError({
+      code: "DEPLOYMENT_NOT_FOUND",
+      domain: "app",
+      summary: `Deployment "${deploymentId}" not found`,
+      why: "The requested deployment does not exist or is no longer available.",
+      fix: "Run prisma-cli app list-deploys to choose an available deployment id.",
+      exitCode: 1,
+      nextSteps: ["prisma-cli app list-deploys"],
+    });
+  }
+
+  if (!shown.app) {
+    throw new CliError({
+      code: "DEPLOYMENT_NOT_FOUND",
+      domain: "app",
+      summary: `Deployment "${deploymentId}" is not attached to an app`,
+      why: "The requested deployment could be found, but its app could not be resolved.",
+      fix: "Run prisma-cli app list-deploys to choose an available deployment id for the selected app.",
+      exitCode: 1,
+      nextSteps: ["prisma-cli app list-deploys"],
+    });
+  }
+
+  const apps = await listApps(context, provider, projectId);
+  const linkedProjectApp = apps.find((app) => app.id === shown.app?.id);
+  if (!linkedProjectApp) {
+    throw new CliError({
+      code: "DEPLOYMENT_NOT_FOUND",
+      domain: "app",
+      summary: `Deployment "${deploymentId}" not found in the linked project`,
+      why: "The requested deployment does not belong to an app in the linked project.",
+      fix: "Run prisma-cli app list-deploys to choose an available deployment id for this project.",
+      exitCode: 1,
+      nextSteps: ["prisma-cli app list-deploys"],
+    });
+  }
+
+  await context.stateStore.setSelectedApp(projectId, {
+    id: linkedProjectApp.id,
+    name: linkedProjectApp.name,
+  });
+
+  return {
+    app: linkedProjectApp,
+    deployment: shown.deployment,
+  };
+}
+
+async function resolveLiveLogDeployment(
+  context: CommandContext,
+  provider: ReturnType<typeof createPreviewAppProvider>,
+  projectId: string,
+  appName: string | undefined,
+): Promise<{ app: PreviewAppRecord; deployment: AppDeploymentSummary }> {
+  const apps = await listApps(context, provider, projectId);
+  const selectedApp = await resolveExistingAppSelection(context, projectId, apps, appName);
+
+  if (!selectedApp) {
+    throw noDeploymentsError(
+      "No deployments available to stream logs",
+      "The linked project does not have any deployed app yet.",
+    );
+  }
+
+  const deploymentsResult = await provider.listDeployments(selectedApp.id).catch((error) => {
+    throw deployFailedError("Failed to list app deployments", error, ["prisma-cli app list-deploys"]);
+  });
+  const currentLiveDeploymentId = await resolveCurrentLiveDeploymentId(
+    context,
+    projectId,
+    deploymentsResult.app,
+    deploymentsResult.deployments,
   );
+  const deployments = applyLiveDeploymentHint(deploymentsResult.deployments, currentLiveDeploymentId);
+  const deployment = currentLiveDeploymentId
+    ? deployments.find((candidate) => candidate.id === currentLiveDeploymentId) ?? null
+    : null;
+
+  await context.stateStore.setSelectedApp(projectId, {
+    id: deploymentsResult.app.id,
+    name: deploymentsResult.app.name,
+  });
+
+  if (!deployment) {
+    throw noDeploymentsError(
+      "No deployments available to stream logs",
+      `The selected app "${deploymentsResult.app.name}" does not have any deployments yet.`,
+    );
+  }
+
+  return {
+    app: deploymentsResult.app,
+    deployment,
+  };
+}
+
+function writeLogRecord(context: CommandContext, record: StreamRecord): void {
+  if (context.flags.json) {
+    writeJsonEvent(context.output, {
+      type: record.type,
+      command: "app.logs",
+      timestamp: new Date().toISOString(),
+      data: record,
+    });
+    return;
+  }
+
+  if (record.type === "log") {
+    context.output.stdout.write(record.text);
+    if (!record.text.endsWith("\n")) {
+      context.output.stdout.write("\n");
+    }
+  }
 }
 
 export async function runAppPromote(
@@ -1156,7 +1341,29 @@ async function requirePreviewAppProvider(context: CommandContext) {
     throw authRequiredError(["prisma-cli auth login"]);
   }
 
-  return createPreviewAppProvider(client);
+  return createPreviewAppProvider(client, createPreviewLogAuthOptions(context.runtime.env));
+}
+
+function createPreviewLogAuthOptions(env: NodeJS.ProcessEnv) {
+  const rawToken = env[SERVICE_TOKEN_ENV_VAR]?.trim();
+  if (rawToken) {
+    return {
+      baseUrl: getApiBaseUrl(env),
+      getToken: async () => rawToken,
+    };
+  }
+
+  const tokenStorage = new FileTokenStorage(env);
+  return {
+    baseUrl: getApiBaseUrl(env),
+    getToken: async () => {
+      const tokens = await tokenStorage.getTokens();
+      if (!tokens) {
+        throw new Error("Authentication token is no longer available. Run prisma-cli auth login and try again.");
+      }
+      return tokens.accessToken;
+    },
+  };
 }
 
 async function requireLinkedProjectId(context: CommandContext): Promise<string> {
@@ -1348,16 +1555,6 @@ function ensurePreviewAppMode(context: CommandContext) {
     "Preview app commands require live app deployment integration.",
     "Rerun without fixture mode enabled to use preview app deployment workflows.",
     ["prisma-cli auth login", "prisma-cli project link"],
-    "app",
-  );
-}
-
-function blockedPreviewAppCommandError(summary: string, why: string) {
-  return featureUnavailableError(
-    summary,
-    why,
-    "Use prisma-cli app show, prisma-cli app open, prisma-cli app deploy, or prisma-cli app list-deploys in the current preview.",
-    ["prisma-cli app show", "prisma-cli app list-deploys"],
     "app",
   );
 }

--- a/packages/cli/src/lib/app/preview-provider.ts
+++ b/packages/cli/src/lib/app/preview-provider.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 
-import { ApiError, ComputeClient } from "@prisma/compute-sdk";
-import type { PortMapping } from "@prisma/compute-sdk";
+import { ApiError, CancelledError, ComputeClient, streamLogs } from "@prisma/compute-sdk";
+import type { PortMapping, StreamRecord } from "@prisma/compute-sdk";
 import type { ManagementApiClient } from "@prisma/management-api-sdk";
 
 import { envVarNames } from "./env-vars";
@@ -93,9 +93,20 @@ export interface PreviewAppProvider {
     deployments: PreviewDeploymentRecord[];
   }>;
   showDeployment(deploymentId: string): Promise<PreviewShownDeploymentRecord | null>;
+  streamDeploymentLogs(options: {
+    deploymentId: string;
+    signal?: AbortSignal;
+    onRecord(record: StreamRecord): void;
+  }): Promise<void>;
 }
 
-export function createPreviewAppProvider(client: ManagementApiClient): PreviewAppProvider {
+export function createPreviewAppProvider(
+  client: ManagementApiClient,
+  options?: {
+    baseUrl?: string;
+    getToken?: () => Promise<string>;
+  },
+): PreviewAppProvider {
   const sdk = new ComputeClient(client);
 
   return {
@@ -372,6 +383,30 @@ export function createPreviewAppProvider(client: ManagementApiClient): PreviewAp
           live: null,
         },
       };
+    },
+
+    async streamDeploymentLogs(streamOptions) {
+      if (!options?.baseUrl || !options.getToken) {
+        throw new Error("Log streaming requires an authenticated API base URL and token.");
+      }
+
+      const result = await streamLogs(
+        {
+          baseUrl: options.baseUrl,
+          token: await options.getToken(),
+          versionId: streamOptions.deploymentId,
+          signal: streamOptions.signal,
+        },
+        streamOptions.onRecord,
+      );
+
+      if (result.isErr()) {
+        if (CancelledError.is(result.error)) {
+          return;
+        }
+
+        throw result.error;
+      }
     },
   };
 }

--- a/packages/cli/src/shell/command-runner.ts
+++ b/packages/cli/src/shell/command-runner.ts
@@ -3,7 +3,7 @@ import { getCommandDescriptor } from "./command-meta";
 import { CliError } from "./errors";
 import { resolveGlobalFlags } from "./global-flags";
 import type { CommandSuccess } from "./output";
-import { writeHumanError, writeHumanLines, writeJsonError, writeJsonSuccess } from "./output";
+import { cliErrorToJson, writeHumanError, writeHumanLines, writeJsonError, writeJsonEvent, writeJsonSuccess } from "./output";
 import { createCommandContext, type CliRuntime } from "./runtime";
 
 interface CommandPresenter<T> {
@@ -46,6 +46,51 @@ export async function runCommand<T>(
     if (error instanceof CliError) {
       if (flags.json) {
         writeJsonError(context.output, commandName, error);
+      } else {
+        writeHumanError(context.output, context.ui, error, { trace: flags.trace });
+      }
+
+      process.exitCode = error.exitCode;
+      return;
+    }
+
+    throw error;
+  }
+}
+
+export async function runStreamingCommand(
+  runtime: CliRuntime,
+  commandName: string,
+  options: Record<string, unknown>,
+  handler: (context: Awaited<ReturnType<typeof createCommandContext>>) => Promise<void>,
+): Promise<void> {
+  const flags = resolveGlobalFlags(runtime.argv, options);
+  const context = await createCommandContext(runtime, flags);
+
+  try {
+    await handler(context);
+
+    if (flags.json) {
+      writeJsonEvent(context.output, {
+        type: "success",
+        command: commandName,
+        timestamp: new Date().toISOString(),
+        result: null,
+        warnings: [],
+        nextSteps: [],
+      });
+    }
+  } catch (error) {
+    if (error instanceof CliError) {
+      if (flags.json) {
+        writeJsonEvent(context.output, {
+          type: "error",
+          command: commandName,
+          timestamp: new Date().toISOString(),
+          error: cliErrorToJson(error),
+          warnings: [],
+          nextSteps: error.nextSteps,
+        });
       } else {
         writeHumanError(context.output, context.ui, error, { trace: flags.trace });
       }

--- a/packages/cli/src/shell/output.ts
+++ b/packages/cli/src/shell/output.ts
@@ -20,23 +20,31 @@ export function writeJsonSuccess<T>(output: CliOutput, success: CommandSuccess<T
   output.stdout.write(`${JSON.stringify({ ok: true, ...success }, null, 2)}\n`);
 }
 
+export function writeJsonEvent(output: CliOutput, event: Record<string, unknown>): void {
+  output.stdout.write(`${JSON.stringify(event)}\n`);
+}
+
+export function cliErrorToJson(error: CliError) {
+  return {
+    code: error.code,
+    domain: error.domain,
+    severity: error.severity,
+    summary: error.summary,
+    why: error.why,
+    fix: error.fix,
+    where: error.where,
+    meta: error.meta,
+    docsUrl: error.docsUrl,
+  };
+}
+
 export function writeJsonError(output: CliOutput, command: string, error: CliError): void {
   output.stdout.write(
     `${JSON.stringify(
       {
         ok: false,
         command,
-        error: {
-          code: error.code,
-          domain: error.domain,
-          severity: error.severity,
-          summary: error.summary,
-          why: error.why,
-          fix: error.fix,
-          where: error.where,
-          meta: error.meta,
-          docsUrl: error.docsUrl,
-        },
+        error: cliErrorToJson(error),
         warnings: [],
         nextSteps: error.nextSteps,
       },

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -2060,11 +2060,41 @@ describe("app controller", () => {
     });
   });
 
-  it("returns FEATURE_UNAVAILABLE for logs in real mode", async () => {
+  it("logs streams the live deployment for the selected app", async () => {
+    const readLinkedProjectId = vi.fn().mockResolvedValue("proj_123");
     const requireComputeAuth = vi.fn().mockResolvedValue({ token: "token" });
+    const listApps = vi.fn().mockResolvedValue([
+      { id: "app_1", name: "hello-world", region: "eu-central-1", liveDeploymentId: "dep_live" },
+    ]);
+    const listDeployments = vi.fn().mockResolvedValue({
+      app: { id: "app_1", name: "hello-world", region: "eu-central-1", liveDeploymentId: "dep_live" },
+      deployments: [
+        { id: "dep_old", status: "stopped", createdAt: "2026-05-01T00:00:00Z", url: null, live: null },
+        { id: "dep_live", status: "running", createdAt: "2026-05-02T00:00:00Z", url: "https://example.prisma.app", live: null },
+      ],
+    });
+    const streamDeploymentLogs = vi.fn().mockImplementation(async (options: { onRecord(record: unknown): void }) => {
+      options.onRecord({ type: "log", text: "hello from live\n", byteStart: 0, byteEnd: 16 });
+    });
+
+    vi.doMock("../src/adapters/config", async () => {
+      const actual = await vi.importActual<typeof import("../src/adapters/config")>("../src/adapters/config");
+      return {
+        ...actual,
+        readLinkedProjectId,
+      };
+    });
 
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/preview-provider", () => ({
+      createPreviewAppProvider: vi.fn(() => ({
+        listApps,
+        listDeployments,
+        showDeployment: vi.fn(),
+        streamDeploymentLogs,
+      })),
     }));
 
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
@@ -2080,9 +2110,196 @@ describe("app controller", () => {
       },
     });
 
-    await expect(runAppLogs(context, undefined, undefined)).rejects.toMatchObject({
-      code: "FEATURE_UNAVAILABLE",
+    const stdout = context.output.stdout as unknown as { buffer: string };
+
+    await runAppLogs(context, "hello-world", undefined);
+
+    expect(streamDeploymentLogs).toHaveBeenCalledWith(expect.objectContaining({
+      deploymentId: "dep_live",
+    }));
+    expect(stdout.buffer).toBe("hello from live\n");
+  });
+
+  it("logs streams an explicit deployment for the selected app", async () => {
+    const readLinkedProjectId = vi.fn().mockResolvedValue("proj_123");
+    const requireComputeAuth = vi.fn().mockResolvedValue({ token: "token" });
+    const listApps = vi.fn().mockResolvedValue([
+      { id: "app_1", name: "hello-world", region: "eu-central-1", liveDeploymentId: "dep_live" },
+    ]);
+    const listDeployments = vi.fn().mockResolvedValue({
+      app: { id: "app_1", name: "hello-world", region: "eu-central-1", liveDeploymentId: "dep_live" },
+      deployments: [
+        { id: "dep_old", status: "stopped", createdAt: "2026-05-01T00:00:00Z", url: null, live: null },
+        { id: "dep_live", status: "running", createdAt: "2026-05-02T00:00:00Z", url: "https://example.prisma.app", live: null },
+      ],
+    });
+    const streamDeploymentLogs = vi.fn().mockImplementation(async (options: { onRecord(record: unknown): void }) => {
+      options.onRecord({ type: "log", text: "old log\n", byteStart: 0, byteEnd: 8 });
+    });
+
+    vi.doMock("../src/adapters/config", async () => {
+      const actual = await vi.importActual<typeof import("../src/adapters/config")>("../src/adapters/config");
+      return {
+        ...actual,
+        readLinkedProjectId,
+      };
+    });
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/preview-provider", () => ({
+      createPreviewAppProvider: vi.fn(() => ({
+        listApps,
+        listDeployments,
+        showDeployment: vi.fn(),
+        streamDeploymentLogs,
+      })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runAppLogs } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const { context, stdout } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await runAppLogs(context, "hello-world", "dep_old");
+
+    expect(streamDeploymentLogs).toHaveBeenCalledWith(expect.objectContaining({
+      deploymentId: "dep_old",
+    }));
+    expect(stdout.buffer).toBe("old log\n");
+  });
+
+  it("logs rejects an explicit deployment that does not belong to the selected app", async () => {
+    const readLinkedProjectId = vi.fn().mockResolvedValue("proj_123");
+    const requireComputeAuth = vi.fn().mockResolvedValue({ token: "token" });
+    const listApps = vi.fn().mockResolvedValue([
+      { id: "app_1", name: "hello-world", region: "eu-central-1", liveDeploymentId: "dep_live" },
+    ]);
+    const listDeployments = vi.fn().mockResolvedValue({
+      app: { id: "app_1", name: "hello-world", region: "eu-central-1", liveDeploymentId: "dep_live" },
+      deployments: [
+        { id: "dep_live", status: "running", createdAt: "2026-05-02T00:00:00Z", url: "https://example.prisma.app", live: null },
+      ],
+    });
+    const streamDeploymentLogs = vi.fn();
+
+    vi.doMock("../src/adapters/config", async () => {
+      const actual = await vi.importActual<typeof import("../src/adapters/config")>("../src/adapters/config");
+      return {
+        ...actual,
+        readLinkedProjectId,
+      };
+    });
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/preview-provider", () => ({
+      createPreviewAppProvider: vi.fn(() => ({
+        listApps,
+        listDeployments,
+        showDeployment: vi.fn(),
+        streamDeploymentLogs,
+      })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runAppLogs } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await expect(runAppLogs(context, "hello-world", "dep_other")).rejects.toMatchObject({
+      code: "DEPLOYMENT_NOT_FOUND",
       domain: "app",
+    });
+    expect(streamDeploymentLogs).not.toHaveBeenCalled();
+  });
+
+  it("logs emits newline-delimited JSON events in --json mode", async () => {
+    const readLinkedProjectId = vi.fn().mockResolvedValue("proj_123");
+    const requireComputeAuth = vi.fn().mockResolvedValue({ token: "token" });
+    const listApps = vi.fn().mockResolvedValue([
+      { id: "app_1", name: "hello-world", region: "eu-central-1", liveDeploymentId: "dep_live" },
+    ]);
+    const listDeployments = vi.fn().mockResolvedValue({
+      app: { id: "app_1", name: "hello-world", region: "eu-central-1", liveDeploymentId: "dep_live" },
+      deployments: [
+        { id: "dep_live", status: "running", createdAt: "2026-05-02T00:00:00Z", url: "https://example.prisma.app", live: null },
+      ],
+    });
+    const streamDeploymentLogs = vi.fn().mockImplementation(async (options: { onRecord(record: unknown): void }) => {
+      options.onRecord({ type: "log", text: "json log\n", byteStart: 0, byteEnd: 9 });
+      options.onRecord({ type: "terminal", kind: "end", code: "done", message: "done", retryable: false, cursor: null });
+    });
+
+    vi.doMock("../src/adapters/config", async () => {
+      const actual = await vi.importActual<typeof import("../src/adapters/config")>("../src/adapters/config");
+      return {
+        ...actual,
+        readLinkedProjectId,
+      };
+    });
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/preview-provider", () => ({
+      createPreviewAppProvider: vi.fn(() => ({
+        listApps,
+        listDeployments,
+        showDeployment: vi.fn(),
+        streamDeploymentLogs,
+      })),
+    }));
+
+    const { createTempCwd, executeCli } = await import("./helpers");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+
+    const result = await executeCli({
+      argv: ["app", "logs", "--app", "hello-world", "--json"],
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_API_TOKEN: "token",
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    const events = result.stdout.trim().split("\n").map((line) => JSON.parse(line));
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(events).toHaveLength(3);
+    expect(events[0]).toMatchObject({
+      type: "log",
+      command: "app.logs",
+      data: {
+        text: "json log\n",
+      },
+    });
+    expect(events[1]).toMatchObject({
+      type: "terminal",
+      command: "app.logs",
+    });
+    expect(events[2]).toMatchObject({
+      type: "success",
+      command: "app.logs",
     });
   });
 

--- a/packages/cli/tests/app.test.ts
+++ b/packages/cli/tests/app.test.ts
@@ -65,6 +65,12 @@ describe("app commands", () => {
       stateDir,
       fixturePath,
     });
+    const logsHelp = await executeCli({
+      argv: ["app", "logs", "--help"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
     const listDeploysHelp = await executeCli({
       argv: ["app", "list-deploys", "--help"],
       cwd,
@@ -136,6 +142,10 @@ describe("app commands", () => {
     expect(openHelp.exitCode).toBe(0);
     expect(openHelp.stderr).toContain("Open the app's live URL");
     expect(openHelp.stderr).toContain("$ prisma-cli app open");
+
+    expect(logsHelp.exitCode).toBe(0);
+    expect(logsHelp.stderr).toContain("Stream logs for the app's current deployment");
+    expect(logsHelp.stderr).toContain("$ prisma-cli app logs --deployment dep_123");
 
     expect(listDeploysHelp.exitCode).toBe(0);
     expect(listDeploysHelp.stderr).toContain("List deployments for the app");


### PR DESCRIPTION
This PR enables app log streaming,
- resolves live or explicit deployment targets before streaming
- emit raw logs on stdout and NDJSON events for --json

### Tests
- pnpm --filter @prisma/cli test
- pnpm --filter @prisma/cli build