### PR TITLE
Fix auth user display to use email

### DIFF
--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -102,8 +102,6 @@ In `--json`, `result` uses this shape:
   "authenticated": true,
   "provider": "github",
   "user": {
-    "id": "usr_123",
-    "name": "Alice Example",
     "email": "alice@example.com"
   },
   "workspace": {
@@ -118,7 +116,7 @@ Rules:
 
 - `authenticated` is always present
 - `provider` is `github`, `google`, or `null`
-- `user` is the current user or `null`
+- `user` contains the current user email or is `null`
 - `workspace` is the active workspace or `null`
 - `linkedProjectId` is the linked project id for the current repo or `null`
 - signed-out state is an empty auth state, not an error

--- a/packages/cli/src/lib/auth/auth-ops.ts
+++ b/packages/cli/src/lib/auth/auth-ops.ts
@@ -13,6 +13,11 @@ function decodeJwtPayload(token: string): Record<string, unknown> {
   }
 }
 
+function emailFromClaims(claims: Record<string, unknown>): string | null {
+  const email = claims.email;
+  return typeof email === "string" && email.trim().length > 0 ? email.trim() : null;
+}
+
 export async function performLogin(env: NodeJS.ProcessEnv): Promise<void> {
   await login({ tokenStorage: new FileTokenStorage(env), env });
 }
@@ -32,6 +37,7 @@ export async function readAuthState(env: NodeJS.ProcessEnv): Promise<AuthStateRe
   }
 
   const claims = decodeJwtPayload(tokens.accessToken);
+  const email = emailFromClaims(claims);
 
   const client = await requireComputeAuth(env);
   let workspaceId = tokens.workspaceId;
@@ -56,11 +62,7 @@ export async function readAuthState(env: NodeJS.ProcessEnv): Promise<AuthStateRe
   return {
     authenticated: true,
     provider: null,
-    user: {
-      id: (claims.sub as string) ?? "",
-      name: (claims.name as string) ?? "",
-      email: (claims.email as string) ?? "",
-    },
+    user: email ? { email } : null,
     workspace: {
       id: workspaceId,
       name: workspaceName,

--- a/packages/cli/src/presenters/auth.ts
+++ b/packages/cli/src/presenters/auth.ts
@@ -17,7 +17,7 @@ export function renderAuthSuccess(
     }
 
     if (result.user) {
-      rows.push({ key: "user", value: `${result.user.name} <${result.user.email}>` });
+      rows.push({ key: "user", value: result.user.email });
     }
 
     if (result.workspace?.name) {
@@ -58,7 +58,7 @@ export function renderAuthSuccess(
       fields: result.authenticated
         ? [
             { key: "status", value: "signed in", tone: "success" as const },
-            ...(result.user ? [{ key: "user", value: `${result.user.name} <${result.user.email}>` }] : []),
+            ...(result.user ? [{ key: "user", value: result.user.email }] : []),
             ...(result.provider ? [{ key: "provider", value: providerLabel(result.provider) }] : []),
             ...(result.workspace?.name ? [{ key: "workspace", value: result.workspace.name }] : []),
           ]

--- a/packages/cli/src/types/auth.ts
+++ b/packages/cli/src/types/auth.ts
@@ -1,8 +1,6 @@
 export type AuthProviderId = "github" | "google";
 
 export interface AuthUser {
-  id: string;
-  name: string;
   email: string;
 }
 

--- a/packages/cli/src/use-cases/auth.ts
+++ b/packages/cli/src/use-cases/auth.ts
@@ -122,7 +122,9 @@ async function resolveCurrentAuthState(dependencies: AuthUseCaseDependencies): P
   return {
     authenticated: true,
     provider: provider.id,
-    user,
+    user: {
+      email: user.email,
+    },
     workspace,
     linkedProjectId,
   };

--- a/packages/cli/src/use-cases/contracts.ts
+++ b/packages/cli/src/use-cases/contracts.ts
@@ -7,6 +7,11 @@ export interface ProviderInfo {
   name: string;
 }
 
+export interface IdentityUser extends AuthUser {
+  id: string;
+  name: string;
+}
+
 export interface ProjectRecord extends ProjectSummary {
   workspaceId: string;
 }
@@ -33,9 +38,9 @@ export interface AuthSessionRecord {
 export interface IdentityGateway {
   listProviders(): ProviderInfo[];
   getProvider(providerId: string): ProviderInfo | undefined;
-  listUsersForProvider(providerId: AuthProviderId): AuthUser[];
-  getUser(userId: string): AuthUser | undefined;
-  getUserForProvider(providerId: AuthProviderId, userId: string): AuthUser | undefined;
+  listUsersForProvider(providerId: AuthProviderId): IdentityUser[];
+  getUser(userId: string): IdentityUser | undefined;
+  getUserForProvider(providerId: AuthProviderId, userId: string): IdentityUser | undefined;
   listUserWorkspaces(userId: string): AuthWorkspace[];
   getWorkspace(workspaceId: string): AuthWorkspace | undefined;
   getUserWorkspace(userId: string, workspaceId: string): AuthWorkspace | undefined;
@@ -93,8 +98,8 @@ export interface AuthUseCases {
   logout(): Promise<AuthStateResult>;
   listProviders(): Promise<ProviderInfo[]>;
   resolveProvider(providerId: string): Promise<ProviderInfo>;
-  listUsersForProvider(providerId: AuthProviderId): Promise<AuthUser[]>;
-  resolveUserForProvider(providerId: AuthProviderId, userId: string): Promise<AuthUser>;
+  listUsersForProvider(providerId: AuthProviderId): Promise<IdentityUser[]>;
+  resolveUserForProvider(providerId: AuthProviderId, userId: string): Promise<IdentityUser>;
   listWorkspacesForUser(userId: string): Promise<AuthWorkspace[]>;
   resolveWorkspaceForUser(userId: string, workspaceId: string): Promise<AuthWorkspace>;
 }

--- a/packages/cli/tests/auth-login.test.ts
+++ b/packages/cli/tests/auth-login.test.ts
@@ -16,6 +16,12 @@ describe("auth login callback", () => {
     expect(result.body).toContain('<meta charset="utf-8">');
   });
 
+  it("requests the supported Management API OAuth scopes", async () => {
+    const result = await requestSuccessPage({ workspaceName: "Acme Corp" });
+
+    expect(result.loginScope).toBe("workspace:admin offline_access");
+  });
+
   it("renders the workspace name when it resolves", async () => {
     const result = await requestSuccessPage({ workspaceName: "Acme Corp" });
 
@@ -63,8 +69,9 @@ describe("auth login callback", () => {
 async function requestSuccessPage(options: {
   workspaceName?: string;
   workspaceLookupError?: Error;
-}): Promise<{ contentType: string | null; body: string }> {
+}): Promise<{ contentType: string | null; body: string; loginScope: string | undefined }> {
   let redirectUri: string | undefined;
+  let loginScope: string | undefined;
   let contentType: string | null = null;
   let body = "";
   const tokenStorage: TokenStorage = {
@@ -83,10 +90,13 @@ async function requestSuccessPage(options: {
       redirectUri = sdkOptions.redirectUri;
 
       return {
-        getLoginUrl: vi.fn().mockResolvedValue({
-          url: "https://auth.example.test/login",
-          state: "state_123",
-          verifier: "verifier_123",
+        getLoginUrl: vi.fn().mockImplementation((options: { scope: string }) => {
+          loginScope = options.scope;
+          return {
+            url: "https://auth.example.test/login",
+            state: "state_123",
+            verifier: "verifier_123",
+          };
         }),
         handleCallback: vi.fn().mockResolvedValue(undefined),
         client: {
@@ -127,5 +137,5 @@ async function requestSuccessPage(options: {
     },
   });
 
-  return { contentType, body };
+  return { contentType, body, loginScope };
 }

--- a/packages/cli/tests/auth-ops.test.ts
+++ b/packages/cli/tests/auth-ops.test.ts
@@ -8,11 +8,11 @@ afterEach(() => {
 });
 
 describe("readAuthState", () => {
-  it("normalizes the workspace id to the canonical API id", async () => {
+  it("normalizes the workspace id to the canonical API id and returns the user email", async () => {
     const getTokens = vi.fn().mockResolvedValue({
       workspaceId: "cmmxlp7ae1251zyfs8mdpnavm",
       accessToken:
-        "header.eyJzdWIiOiJ1c2VyOmNsaXQ0YnNxMTAwMjBvMDBoNDUzcWo1cTEifQ.signature",
+        "header.eyJzdWIiOiJ1c2VyOmNsaXQ0YnNxMTAwMjBvMDBoNDUzcWo1cTEiLCJlbWFpbCI6Imx1YW5AZXhhbXBsZS5jb20ifQ.signature",
       refreshToken: "refresh-token",
     });
     const requireComputeAuth = vi.fn().mockResolvedValue({
@@ -47,15 +47,52 @@ describe("readAuthState", () => {
       authenticated: true,
       provider: null,
       user: {
-        id: "user:clit4bsq10020o00h453qj5q1",
-        name: "",
-        email: "",
+        email: "luan@example.com",
       },
       workspace: {
         id: "wksp_cmmxlp7ae1251zyfs8mdpnavm",
         name: "Sandpit",
       },
       linkedProjectId: null,
+    });
+  });
+
+  it("keeps authenticated state but omits the user when the token has no email claim", async () => {
+    const getTokens = vi.fn().mockResolvedValue({
+      workspaceId: "cmmxlp7ae1251zyfs8mdpnavm",
+      accessToken:
+        "header.eyJzdWIiOiJ1c2VyOmNsaXQ0YnNxMTAwMjBvMDBoNDUzcWo1cTEifQ.signature",
+      refreshToken: "refresh-token",
+    });
+    const requireComputeAuth = vi.fn().mockResolvedValue({
+      GET: vi.fn().mockResolvedValue({
+        data: {
+          data: {
+            id: "wksp_cmmxlp7ae1251zyfs8mdpnavm",
+            name: "Sandpit",
+          },
+        },
+      }),
+    });
+
+    vi.doMock("../src/adapters/token-storage", () => ({
+      FileTokenStorage: vi.fn().mockImplementation(() => ({
+        getTokens,
+      })),
+    }));
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+
+    const { readAuthState } = await import("../src/lib/auth/auth-ops");
+
+    await expect(readAuthState(process.env)).resolves.toMatchObject({
+      authenticated: true,
+      user: null,
+      workspace: {
+        id: "wksp_cmmxlp7ae1251zyfs8mdpnavm",
+        name: "Sandpit",
+      },
     });
   });
 });

--- a/packages/cli/tests/auth-real-mode.test.ts
+++ b/packages/cli/tests/auth-real-mode.test.ts
@@ -22,8 +22,6 @@ describe("real auth mode", () => {
       authenticated: true,
       provider: null,
       user: {
-        id: "usr_real",
-        name: "Real User",
         email: "real@example.com",
       },
       workspace: {
@@ -141,8 +139,6 @@ describe("real auth mode", () => {
         authenticated: true,
         provider: null,
         user: {
-          id: "usr_real",
-          name: "Real User",
           email: "real@example.com",
         },
         workspace: null,
@@ -155,5 +151,38 @@ describe("real auth mode", () => {
     expect(plain).toContain("user:");
     expect(plain).not.toContain("provider:");
     expect(plain).not.toContain("workspace:");
+  });
+
+  it("omits the user row when a real auth state has no email", async () => {
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+
+    const output = renderAuthSuccess(
+      context,
+      getCommandDescriptor("auth.whoami"),
+      "auth.whoami",
+      {
+        authenticated: true,
+        provider: null,
+        user: null,
+        workspace: {
+          id: "ws_real",
+          name: "Real Workspace",
+        },
+        linkedProjectId: null,
+      },
+    ).join("");
+
+    const plain = stripAnsi(output);
+
+    expect(plain).toContain("status:     signed in");
+    expect(plain).not.toContain("user:");
+    expect(plain).not.toContain("<>");
   });
 });

--- a/packages/cli/tests/auth-usecases.test.ts
+++ b/packages/cli/tests/auth-usecases.test.ts
@@ -31,8 +31,6 @@ describe("auth use cases", () => {
       authenticated: true,
       provider: "github",
       user: {
-        id: "usr_456",
-        name: "Bob Example",
         email: "bob@example.com",
       },
       workspace: {

--- a/packages/cli/tests/auth.test.ts
+++ b/packages/cli/tests/auth.test.ts
@@ -39,7 +39,7 @@ describe("auth commands", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toBe("");
     expect(result.stderr).toBe(
-      "auth login → Starting an authenticated CLI session.\n\n│  provider:   GitHub\n│  user:       Bob Example <bob@example.com>\n│  workspace:  Acme Inc\n\n◇ Applying authentication session changes...\n✔ Applied 1 operation(s)\n  Session stored in local CLI state.\n",
+      "auth login → Starting an authenticated CLI session.\n\n│  provider:   GitHub\n│  user:       bob@example.com\n│  workspace:  Acme Inc\n\n◇ Applying authentication session changes...\n✔ Applied 1 operation(s)\n  Session stored in local CLI state.\n",
     );
   });
 
@@ -71,8 +71,6 @@ describe("auth commands", () => {
         authenticated: true,
         provider: "github",
         user: {
-          id: "usr_456",
-          name: "Bob Example",
           email: "bob@example.com",
         },
         workspace: {

--- a/packages/cli/tests/project-real-mode.test.ts
+++ b/packages/cli/tests/project-real-mode.test.ts
@@ -17,8 +17,6 @@ describe("real project mode", () => {
       authenticated: true,
       provider: null,
       user: {
-        id: "usr_real",
-        name: "Real User",
         email: "real@example.com",
       },
       workspace: {
@@ -187,8 +185,6 @@ describe("real project mode", () => {
       authenticated: true,
       provider: null,
       user: {
-        id: "usr_real",
-        name: "Real User",
         email: "real@example.com",
       },
       workspace: {
@@ -269,8 +265,6 @@ describe("real project mode", () => {
       authenticated: true,
       provider: null,
       user: {
-        id: "usr_real",
-        name: "Real User",
         email: "real@example.com",
       },
       workspace: {
@@ -352,8 +346,6 @@ describe("real project mode", () => {
       authenticated: true,
       provider: null,
       user: {
-        id: "usr_real",
-        name: "Real User",
         email: "real@example.com",
       },
       workspace: {
@@ -427,8 +419,6 @@ describe("real project mode", () => {
       authenticated: true,
       provider: null,
       user: {
-        id: "usr_real",
-        name: "Real User",
         email: "real@example.com",
       },
       workspace: {
@@ -501,8 +491,6 @@ describe("real project mode", () => {
       authenticated: true,
       provider: null,
       user: {
-        id: "usr_real",
-        name: "Real User",
         email: "real@example.com",
       },
       workspace: {

--- a/packages/cli/tests/project-usecases.test.ts
+++ b/packages/cli/tests/project-usecases.test.ts
@@ -15,8 +15,6 @@ describe("project use cases", () => {
         authenticated: true,
         provider: "github",
         user: {
-          id: "usr_456",
-          name: "Bob Example",
           email: "bob@example.com",
         },
         workspace: {
@@ -75,8 +73,6 @@ describe("project use cases", () => {
           authenticated: true,
           provider: "github",
           user: {
-            id: "usr_456",
-            name: "Bob Example",
             email: "bob@example.com",
           },
           workspace: {


### PR DESCRIPTION
## Summary
- Display authenticated users by email only in auth human output and JSON results
- Preserve the supported Management API OAuth scope while extracting email from available token claims
- Omit the user row when no email claim exists instead of rendering empty placeholders or ids
- Update the auth result docs and regression tests for email-only user identity

## Validation
- pnpm --dir packages/cli test tests/auth-ops.test.ts tests/auth-real-mode.test.ts tests/auth.test.ts
- pnpm --dir packages/cli build
- git diff --check

