### PR TITLE
feat(commands): added --version flag + version subcommand

### DIFF
--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -14,6 +14,12 @@ The preview package includes these command groups:
 - `branch`
 - `app`
 
+The preview package also includes one top-level utility command:
+
+- `version`
+
+`version` is intentionally outside the workflow groups: it reports CLI build and environment state, requires no auth, no project context, and no network, and is the canonical answer to "is this CLI installed and on the build I expect?"
+
 Out of scope for the current preview:
 
 - `init`
@@ -25,6 +31,7 @@ Out of scope for the current preview:
 ## Global Rules
 
 - Canonical shape is `prisma <group> <action>`.
+- `version` is the one top-level command outside that shape (see Scope above).
 - Every command supports `--json`.
 - Shared global flags are:
   - `--json`
@@ -36,6 +43,9 @@ Out of scope for the current preview:
   - `-y`, `--yes`
   - `--color`
   - `--no-color`
+- Universal utility flags also work at the program level:
+  - `--help` — prints help for the root program or the named command and exits 0.
+  - `--version` — prints the CLI version and exits 0. Honors `--json` for the structured envelope. No short alias (`-v` is reserved for `--verbose`; `-V` is avoided as a near-collision).
 - Long flags use kebab-case.
 - Boolean negation uses `--no-<flag>`.
 - `--json` and non-interactive mode must not block on prompts.
@@ -123,6 +133,78 @@ Rules:
 - `user` contains the current user email or is `null`
 - `workspace` is the active workspace or `null`
 - signed-out state is an empty auth state, not an error
+
+## `prisma-cli version`
+
+Purpose:
+
+- report the installed CLI build and a small block of host environment metadata
+
+Behavior:
+
+- requires no auth, no project context, and no network
+- reads the package's own version from its bundled metadata
+- reports CLI name, CLI version, Node.js version, OS platform, OS architecture, and a best-effort `invocation` label (`bunx`, `npx`, `global`, `dev`, or `unknown`)
+- uses the `show` output pattern (see `output-conventions.md`)
+- fails only when the bundled CLI metadata cannot be read; this is treated as `VERSION_UNAVAILABLE` and is not expected in practice
+
+In `--json`, `result` uses this shape:
+
+```json
+{
+  "cli": {
+    "name": "prisma-cli",
+    "version": "3.0.0-alpha.3"
+  },
+  "node": {
+    "version": "v24.14.1"
+  },
+  "os": {
+    "platform": "darwin",
+    "arch": "arm64"
+  },
+  "invocation": "bunx"
+}
+```
+
+Rules:
+
+- `cli.name` is the published package's `bin` name (`prisma-cli` in the current preview).
+- `cli.version` is the published package version.
+- `node.version` mirrors `process.version` exactly, including the leading `v`.
+- `os.platform` and `os.arch` mirror `process.platform` and `process.arch`.
+- `invocation` is best-effort and may be `null` when no signal is conclusive.
+
+Examples:
+
+```bash
+prisma-cli version
+prisma-cli version --json
+```
+
+## `prisma-cli --version`
+
+Purpose:
+
+- universal smoke-test flag at the root of the program
+
+Behavior:
+
+- prints the CLI version and exits 0
+- requires no auth, no project context, and no network
+- works before any subcommand parsing — bare `prisma-cli --version` is sufficient
+- in human mode, prints a single line to stdout: `prisma-cli <version>`
+- in `--json` mode, emits the standard success envelope (see Command Result Envelopes) with `command: "version"` and `result.version: "<version>"`
+- `--version` is documented as a universal utility flag in Global Rules, not as a shared global flag (it is an early-exit utility, not a per-command modifier)
+
+Examples:
+
+```bash
+prisma-cli --version
+prisma-cli --version --json
+```
+
+`prisma-cli version` is the richer environment report; `prisma-cli --version` is the terse one-liner. Both report the same `cli.version`. Use the flag for quick checks, the subcommand for support tickets and bug reports.
 
 ## `prisma-cli auth login`
 

--- a/docs/product/error-conventions.md
+++ b/docs/product/error-conventions.md
@@ -163,6 +163,7 @@ These codes are the minimum stable set for the MVP:
 - `BUILD_FAILED`
 - `RUN_FAILED`
 - `DEPLOY_FAILED`
+- `VERSION_UNAVAILABLE`
 
 Recommended meanings:
 
@@ -184,6 +185,7 @@ Recommended meanings:
 - `BUILD_FAILED`: build failed before a healthy deployment existed
 - `RUN_FAILED`: local framework run command could not be started or exited unsuccessfully
 - `DEPLOY_FAILED`: deployment or post-build health failed
+- `VERSION_UNAVAILABLE`: CLI could not read its own bundled package metadata to report a version (defensive; not expected in normal installs)
 
 ## Exit Codes
 

--- a/docs/product/output-conventions.md
+++ b/docs/product/output-conventions.md
@@ -62,6 +62,7 @@ Current MVP commands map to patterns like this:
 
 | Command | Pattern |
 | --- | --- |
+| `version` | `show` |
 | `auth login` | `mutate` |
 | `auth logout` | `mutate` |
 | `auth whoami` | `show` |

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,16 +1,22 @@
 import process from "node:process";
 
-import { Command, CommanderError } from "commander";
+import { Command, CommanderError, Option } from "commander";
 
 import { createAppCommand } from "./commands/app";
 import { createAuthCommand } from "./commands/auth";
 import { createBranchCommand } from "./commands/branch";
 
 import { createProjectCommand } from "./commands/project";
+import { createVersionCommand } from "./commands/version";
+import { runVersion } from "./controllers/version";
+import { getCliName, getCliVersion } from "./lib/version";
 import { attachCommandDescriptor } from "./shell/command-meta";
+import { CliError } from "./shell/errors";
 import { addCompactGlobalFlags } from "./shell/global-flags";
+import { writeHumanError, writeJsonError, writeJsonSuccess } from "./shell/output";
 import { disposePromptState } from "./shell/prompt";
-import { configureRuntimeCommand, type CliRuntime } from "./shell/runtime";
+import { configureRuntimeCommand, createCommandContext, type CliRuntime } from "./shell/runtime";
+import { createShellUi } from "./shell/ui";
 
 export interface RunCliOptions extends Partial<CliRuntime> {
   argv?: string[];
@@ -22,6 +28,10 @@ export async function runCli(options: RunCliOptions = {}): Promise<number> {
   process.exitCode = 0;
 
   try {
+    if (runtime.argv.includes("--version")) {
+      return await handleVersionFlag(runtime);
+    }
+
     const bareHelpCommand = resolveBareHelpCommand(program, runtime.argv);
 
     if (bareHelpCommand) {
@@ -49,16 +59,67 @@ export function createProgram(runtime: CliRuntime): Command {
 
   addCompactGlobalFlags(program);
 
+  program.addOption(new Option("--version", "Print the CLI version and exit."));
+
   program
     .name("prisma")
     .showSuggestionAfterError();
 
+  program.addCommand(createVersionCommand(runtime));
   program.addCommand(createAuthCommand(runtime));
   program.addCommand(createBranchCommand(runtime));
   program.addCommand(createProjectCommand(runtime));
   program.addCommand(createAppCommand(runtime));
 
   return program;
+}
+
+async function handleVersionFlag(runtime: CliRuntime): Promise<number> {
+  const wantsJson = runtime.argv.includes("--json");
+  const output = { stdout: runtime.stdout, stderr: runtime.stderr };
+
+  try {
+    if (wantsJson) {
+      const context = await createCommandContext(runtime, buildVersionFlagFlags(runtime));
+      const success = await runVersion(context);
+      writeJsonSuccess(output, {
+        command: success.command,
+        result: { version: success.result.cli.version },
+        warnings: success.warnings,
+        nextSteps: success.nextSteps,
+      });
+      return 0;
+    }
+
+    const versionLine = `${getCliName()} ${getCliVersion()}`;
+    runtime.stdout.write(`${versionLine}\n`);
+    return 0;
+  } catch (error) {
+    if (error instanceof CliError) {
+      if (wantsJson) {
+        writeJsonError(output, "version", error);
+      } else {
+        const ui = createShellUi(runtime, buildVersionFlagFlags(runtime));
+        writeHumanError(output, ui, error, { trace: false });
+      }
+
+      return error.exitCode;
+    }
+
+    throw error;
+  }
+}
+
+function buildVersionFlagFlags(runtime: CliRuntime) {
+  return {
+    json: runtime.argv.includes("--json"),
+    quiet: false,
+    verbose: false,
+    trace: false,
+    yes: false,
+    interactive: undefined,
+    color: undefined,
+  };
 }
 
 function resolveBareHelpCommand(program: Command, argv: string[]): Command | null {
@@ -70,7 +131,19 @@ function resolveBareHelpCommand(program: Command, argv: string[]): Command | nul
     return null;
   }
 
-  return program.commands.find((command) => command.name() === argv[0]) ?? null;
+  const candidate = program.commands.find((command) => command.name() === argv[0]) ?? null;
+
+  if (!candidate) {
+    return null;
+  }
+
+  // Group commands (with subcommands) print help when invoked bare.
+  // Leaf commands (no subcommands) own their own action and must execute.
+  if (candidate.commands.length === 0) {
+    return null;
+  }
+
+  return candidate;
 }
 
 function resolveRuntime(options: RunCliOptions): CliRuntime {

--- a/packages/cli/src/commands/version/index.ts
+++ b/packages/cli/src/commands/version/index.ts
@@ -1,0 +1,29 @@
+import { Command } from "commander";
+
+import { runVersion } from "../../controllers/version";
+import { renderVersionSuccess } from "../../presenters/version";
+import { attachCommandDescriptor } from "../../shell/command-meta";
+import { runCommand } from "../../shell/command-runner";
+import { addGlobalFlags } from "../../shell/global-flags";
+import { configureRuntimeCommand, type CliRuntime } from "../../shell/runtime";
+import type { VersionResult } from "../../types/version";
+
+export function createVersionCommand(runtime: CliRuntime): Command {
+  const command = attachCommandDescriptor(configureRuntimeCommand(new Command("version"), runtime), "version");
+
+  addGlobalFlags(command);
+
+  command.action(async (options) => {
+    await runCommand<VersionResult>(
+      runtime,
+      "version",
+      options as Record<string, unknown>,
+      (context) => runVersion(context),
+      {
+        renderHuman: (context, descriptor, result) => renderVersionSuccess(context, descriptor, result),
+      },
+    );
+  });
+
+  return command;
+}

--- a/packages/cli/src/controllers/version.ts
+++ b/packages/cli/src/controllers/version.ts
@@ -1,0 +1,15 @@
+import { buildVersionResult } from "../lib/version";
+import type { CommandSuccess } from "../shell/output";
+import type { CommandContext } from "../shell/runtime";
+import type { VersionResult } from "../types/version";
+
+export async function runVersion(context: CommandContext): Promise<CommandSuccess<VersionResult>> {
+  const result = buildVersionResult(context.runtime.env, context.runtime.argv);
+
+  return {
+    command: "version",
+    result,
+    warnings: [],
+    nextSteps: [],
+  };
+}

--- a/packages/cli/src/lib/version.ts
+++ b/packages/cli/src/lib/version.ts
@@ -1,0 +1,91 @@
+import { createRequire } from "node:module";
+import process from "node:process";
+
+import { CliError } from "../shell/errors";
+import type { VersionInvocation, VersionResult } from "../types/version";
+
+interface PackageMetadata {
+  name?: string;
+  version?: string;
+}
+
+const requireFromHere = createRequire(import.meta.url);
+
+function readPackageMetadata(): PackageMetadata {
+  try {
+    return requireFromHere("../../package.json") as PackageMetadata;
+  } catch {
+    return {};
+  }
+}
+
+export function getCliVersion(): string {
+  const pkg = readPackageMetadata();
+
+  if (!pkg.version) {
+    throw new CliError({
+      code: "VERSION_UNAVAILABLE",
+      domain: "cli",
+      summary: "CLI version metadata is missing from the installed package",
+      why: "The bundled package.json could not be read or did not contain a version field.",
+      fix: "Reinstall the CLI from the npm registry, or check your install path is intact.",
+      exitCode: 1,
+    });
+  }
+
+  return pkg.version;
+}
+
+// Published bin name is the agreed user-facing identifier for the preview.
+// We hard-code "prisma-cli" because the bin name and the npm package name differ:
+// the npm package is "@prisma/cli", but the binary on PATH is "prisma-cli".
+export function getCliName(): string {
+  return "prisma-cli";
+}
+
+export function detectInvocation(env: NodeJS.ProcessEnv, argv: readonly string[]): VersionInvocation {
+  if (env.npm_config_user_agent?.startsWith("bun")) {
+    return "bunx";
+  }
+
+  if (env.npm_lifecycle_event === "npx" || env.npm_execpath?.includes("/_npx/") || env.npm_config_user_agent?.startsWith("npm")) {
+    return "npx";
+  }
+
+  const entry = argv[1] ?? "";
+
+  if (entry.endsWith(".ts") || entry.includes("/tsx/")) {
+    return "dev";
+  }
+
+  if (entry.includes("/_npx/")) {
+    return "npx";
+  }
+
+  if (entry.includes("/.bun/")) {
+    return "bunx";
+  }
+
+  if (entry.includes("/node_modules/.bin/") || entry.endsWith("/prisma-cli")) {
+    return "global";
+  }
+
+  return "unknown";
+}
+
+export function buildVersionResult(env: NodeJS.ProcessEnv, argv: readonly string[]): VersionResult {
+  return {
+    cli: {
+      name: getCliName(),
+      version: getCliVersion(),
+    },
+    node: {
+      version: process.version,
+    },
+    os: {
+      platform: process.platform,
+      arch: process.arch,
+    },
+    invocation: detectInvocation(env, argv),
+  };
+}

--- a/packages/cli/src/presenters/version.ts
+++ b/packages/cli/src/presenters/version.ts
@@ -1,0 +1,24 @@
+import { renderShow } from "../output/patterns";
+import type { CommandDescriptor } from "../shell/command-meta";
+import type { CommandContext } from "../shell/runtime";
+import type { VersionResult } from "../types/version";
+
+export function renderVersionSuccess(
+  context: CommandContext,
+  descriptor: CommandDescriptor,
+  result: VersionResult,
+): string[] {
+  return renderShow(
+    {
+      title: "Showing CLI build and environment.",
+      descriptor,
+      fields: [
+        { key: result.cli.name, value: result.cli.version },
+        { key: "node", value: result.node.version },
+        { key: "os", value: `${result.os.platform} ${result.os.arch}` },
+        { key: "invocation", value: result.invocation, tone: result.invocation === "unknown" ? "dim" : "default" },
+      ],
+    },
+    context.ui,
+  );
+}

--- a/packages/cli/src/shell/command-meta.ts
+++ b/packages/cli/src/shell/command-meta.ts
@@ -21,6 +21,12 @@ const DESCRIPTORS: CommandDescriptor[] = [
       "Deploy your app with isolated infrastructure for every branch",
   },
   {
+    id: "version",
+    path: ["prisma", "version"],
+    description: "Show CLI build and environment",
+    examples: ["prisma-cli version", "prisma-cli version --json"],
+  },
+  {
     id: "auth",
     path: ["prisma", "auth"],
     description: "Manage local authentication for the CLI",

--- a/packages/cli/src/shell/global-flags.ts
+++ b/packages/cli/src/shell/global-flags.ts
@@ -17,6 +17,7 @@ export const COMPACT_GLOBAL_OPTION_FLAGS = [
   "--trace",
   "--no-interactive",
   "-y, --yes",
+  "--version",
 ];
 
 export function addGlobalFlags(command: Command): Command {

--- a/packages/cli/src/types/version.ts
+++ b/packages/cli/src/types/version.ts
@@ -1,0 +1,20 @@
+export interface VersionResult {
+  cli: {
+    name: string;
+    version: string;
+  };
+  node: {
+    version: string;
+  };
+  os: {
+    platform: string;
+    arch: string;
+  };
+  invocation: VersionInvocation;
+}
+
+export type VersionInvocation = "bunx" | "npx" | "global" | "dev" | "unknown";
+
+export interface VersionFlagResult {
+  version: string;
+}

--- a/packages/cli/tests/version.test.ts
+++ b/packages/cli/tests/version.test.ts
@@ -1,0 +1,170 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+import process from "node:process";
+
+import { describe, expect, it } from "vitest";
+
+import { createTempCwd, executeCli } from "./helpers";
+
+const requireFromHere = createRequire(import.meta.url);
+const pkg = requireFromHere("../package.json") as { version: string };
+const fixturePath = path.resolve("fixtures/mock-api.json");
+
+describe("version", () => {
+  it("prints the CLI version to stdout when --version is passed", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+
+    const result = await executeCli({
+      argv: ["--version"],
+      cwd,
+      stateDir,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe(`prisma-cli ${pkg.version}\n`);
+  });
+
+  it("emits the stable success envelope when --version --json is passed", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+
+    const result = await executeCli({
+      argv: ["--version", "--json"],
+      cwd,
+      stateDir,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toEqual({
+      ok: true,
+      command: "version",
+      result: {
+        version: pkg.version,
+      },
+      warnings: [],
+      nextSteps: [],
+    });
+  });
+
+  it("renders the show pattern when the version subcommand runs", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+
+    const result = await executeCli({
+      argv: ["version"],
+      cwd,
+      stateDir,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("version → Showing CLI build and environment.");
+    expect(result.stderr).toContain(`prisma-cli:  ${pkg.version}`);
+    expect(result.stderr).toContain(`node:        ${process.version}`);
+    expect(result.stderr).toContain(`os:          ${process.platform} ${process.arch}`);
+    expect(result.stderr).toContain("invocation:");
+  });
+
+  it("emits the full structured result when version --json is passed", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+
+    const result = await executeCli({
+      argv: ["version", "--json"],
+      cwd,
+      stateDir,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+
+    const payload = JSON.parse(result.stdout);
+    expect(payload).toMatchObject({
+      ok: true,
+      command: "version",
+      result: {
+        cli: {
+          name: "prisma-cli",
+          version: pkg.version,
+        },
+        node: {
+          version: process.version,
+        },
+        os: {
+          platform: process.platform,
+          arch: process.arch,
+        },
+      },
+      warnings: [],
+      nextSteps: [],
+    });
+    expect(["bunx", "npx", "global", "dev", "unknown"]).toContain(payload.result.invocation);
+  });
+
+  it("requires no auth, no project context, and no network for the subcommand", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+
+    // No fixturePath is provided — this exercises real mode without a mock API,
+    // which would fail for any command that needs auth or platform calls.
+    const result = await executeCli({
+      argv: ["version", "--json"],
+      cwd,
+      stateDir,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout).ok).toBe(true);
+  });
+
+  it("requires no auth, no project context, and no network for the flag", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+
+    const result = await executeCli({
+      argv: ["--version", "--json"],
+      cwd,
+      stateDir,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout).ok).toBe(true);
+  });
+
+  it("includes version in the root --help output", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+
+    const result = await executeCli({
+      argv: ["--help"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain("version  Show CLI build and environment");
+    expect(result.stderr).toContain("--version");
+    expect(result.stderr).toContain("Print the CLI version and exit.");
+  });
+
+  it("--version overrides subcommand parsing when both are present", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+
+    // --version is a top-level utility flag and takes precedence over any
+    // subcommand path. Mirrors the same pattern as --help.
+    const result = await executeCli({
+      argv: ["auth", "login", "--version"],
+      cwd,
+      stateDir,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe(`prisma-cli ${pkg.version}\n`);
+    expect(result.stderr).toBe("");
+  });
+});


### PR DESCRIPTION
Closes [PRO-174](https://linear.app/prisma-company/issue/PRO-174/cli-version-and-version-are-not-exposed-in-prismaclipreview)

## Summary

Adds version discovery to the preview CLI so users, support, and agents can confirm the installed build without auth, project context, or network access.

## What changed

- Added root `prisma-cli --version` for a terse smoke-test output.
- Added `prisma-cli version` for a richer CLI + environment report.
- Added JSON support for both paths using the existing success envelope.
- Documented the command/flag contract, output pattern, and defensive `VERSION_UNAVAILABLE` error.
- Added tests covering human output, JSON output, help visibility, no-network/no-auth behavior, and invocation detection.

## Validation

- `pnpm --filter @prisma/cli test`
- `pnpm --filter @prisma/cli build`
- Manual smoke: `--version`, `--version --json`, `version --json`, and root `--help`