### PR TITLE
fix(auth): honor PRISMA_API_TOKEN in readAuthState for CI/headless use

### DIFF
--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -50,12 +50,12 @@ Out of scope for the current preview:
 
 The CLI accepts two authentication sources, in this fixed precedence:
 
-1. `PRISMA_API_TOKEN` environment variable — long-lived service token, intended for CI and other headless contexts.
+1. `PRISMA_SERVICE_TOKEN` environment variable — long-lived service token, intended for CI and other headless contexts.
 2. Stored OAuth session — created by `prisma-cli auth login`, kept in the OS-appropriate credentials store, refreshed automatically.
 
-When `PRISMA_API_TOKEN` is set, the token is fully sufficient for authenticated commands. The CLI does not read any locally stored OAuth session in that case, so behavior is identical on a fresh runner and a developer machine that happens to be signed in. The active workspace is derived from the token's `sub` claim; no additional flag or environment variable is required for the common case where the token is scoped to a single workspace.
+When `PRISMA_SERVICE_TOKEN` is set, the token is fully sufficient for authenticated commands. The CLI does not read any locally stored OAuth session in that case, so behavior is identical on a fresh runner and a developer machine that happens to be signed in. The active workspace is derived from the token's `sub` claim; no additional flag or environment variable is required for the common case where the token is scoped to a single workspace.
 
-`auth login` and `auth logout` operate on the stored OAuth session. They do not affect the `PRISMA_API_TOKEN` environment variable.
+`auth login` and `auth logout` operate on the stored OAuth session. They do not affect the `PRISMA_SERVICE_TOKEN` environment variable.
 
 ## Context Resolution
 

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -53,7 +53,7 @@ The CLI accepts two authentication sources, in this fixed precedence:
 1. `PRISMA_SERVICE_TOKEN` environment variable — long-lived service token, intended for CI and other headless contexts.
 2. Stored OAuth session — created by `prisma-cli auth login`, kept in the OS-appropriate credentials store, refreshed automatically.
 
-When `PRISMA_SERVICE_TOKEN` is set, the token is fully sufficient for authenticated commands. The CLI does not read any locally stored OAuth session in that case, so behavior is identical on a fresh runner and a developer machine that happens to be signed in. The active workspace is derived from the token's `sub` claim; no additional flag or environment variable is required for the common case where the token is scoped to a single workspace.
+When `PRISMA_SERVICE_TOKEN` is set and non-empty, the token is fully sufficient for authenticated commands. If `PRISMA_SERVICE_TOKEN` is set but empty or only whitespace, commands fail with an auth configuration error instead of falling back to stored OAuth. The CLI does not read any locally stored OAuth session when a non-empty service token is present, so behavior is identical on a fresh runner and a developer machine that happens to be signed in. The active workspace is derived from the token's `sub` claim; no additional flag or environment variable is required for the common case where the token is scoped to a single workspace.
 
 `auth login` and `auth logout` operate on the stored OAuth session. They do not affect the `PRISMA_SERVICE_TOKEN` environment variable.
 

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -46,6 +46,17 @@ Out of scope for the current preview:
 - Public Beta does not read or write `prisma.config.ts`, `.prisma/settings.json`, or any repo config file for Project -> Branch -> App resolution.
 - Remote commands do not silently change local context.
 
+## Authentication
+
+The CLI accepts two authentication sources, in this fixed precedence:
+
+1. `PRISMA_API_TOKEN` environment variable — long-lived service token, intended for CI and other headless contexts.
+2. Stored OAuth session — created by `prisma-cli auth login`, kept in the OS-appropriate credentials store, refreshed automatically.
+
+When `PRISMA_API_TOKEN` is set, the token is fully sufficient for authenticated commands. The CLI does not read any locally stored OAuth session in that case, so behavior is identical on a fresh runner and a developer machine that happens to be signed in. The active workspace is derived from the token's `sub` claim; no additional flag or environment variable is required for the common case where the token is scoped to a single workspace.
+
+`auth login` and `auth logout` operate on the stored OAuth session. They do not affect the `PRISMA_API_TOKEN` environment variable.
+
 ## Context Resolution
 
 ### Project

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -1442,7 +1442,11 @@ async function resolveProjectContext(
     createProject: options?.allowCreate
       ? async (name) => {
           const project = await provider.createProject({ name }).catch((error) => {
-            throw deployFailedError("Failed to create project for first deploy", error, ["prisma-cli app deploy"]);
+            throw createProjectOnFirstDeployError({
+              error,
+              inferredName: name,
+              workspaceName: authState.workspace!.name,
+            });
           });
           return {
             id: project.id,
@@ -1618,6 +1622,80 @@ function deployFailedError(summary: string, error: unknown, nextSteps: string[])
     exitCode: 1,
     nextSteps,
   });
+}
+
+/**
+ * `app deploy` falls into "create a new project on first deploy" when no
+ * existing project matches the package.json name (or the cwd basename as a
+ * fallback). When the create call fails the user often doesn't realise the
+ * CLI was attempting to create a project at all — they thought the deploy
+ * would find an existing project. Surface that context, and recommend the
+ * explicit `--project` flag as the unambiguous way out.
+ */
+function createProjectOnFirstDeployError(options: {
+  error: unknown;
+  inferredName: string;
+  workspaceName: string;
+}): CliError {
+  const { error, inferredName, workspaceName } = options;
+  const status = extractHttpStatus(error);
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  const inferredContext = `No existing project matched the package.json name \`${inferredName}\`, so the CLI attempted to create one.`;
+  const nextSteps = [
+    "prisma-cli project list",
+    "prisma-cli app deploy --project <id-or-name>",
+  ];
+
+  if (status === 401 || status === 403) {
+    return new CliError({
+      code: "AUTH_FORBIDDEN",
+      domain: "auth",
+      summary: "Could not create a new project for this deploy",
+      why: `${inferredContext} The platform rejected the create (HTTP ${status}).`,
+      fix: `Pass --project <id-or-name> to deploy into an existing project, or grant the service token project-create permission on workspace \`${workspaceName}\`.`,
+      debug: formatDebugDetails(error),
+      exitCode: 1,
+      nextSteps,
+    });
+  }
+
+  return new CliError({
+    code: "DEPLOY_FAILED",
+    domain: "app",
+    summary: "Could not create a new project for this deploy",
+    why: `${inferredContext} ${errorMessage}`.trim(),
+    fix: "Pass --project <id-or-name> to deploy into an existing project, or retry after addressing the platform error above.",
+    debug: formatDebugDetails(error),
+    exitCode: 1,
+    nextSteps,
+  });
+}
+
+function extractHttpStatus(error: unknown): number | null {
+  if (!error || typeof error !== "object") {
+    return null;
+  }
+
+  const candidate = error as { statusCode?: unknown; status?: unknown; message?: unknown };
+  if (typeof candidate.statusCode === "number") {
+    return candidate.statusCode;
+  }
+  if (typeof candidate.status === "number") {
+    return candidate.status;
+  }
+
+  // The compute-sdk re-throws AuthenticationError / ApiError as plain
+  // Error instances whose `message` carries the "(HTTP <code>)" suffix.
+  // Match that suffix as a last resort so this UX still triggers for
+  // service tokens running through that path.
+  if (typeof candidate.message === "string") {
+    const match = /\(HTTP (\d{3})\)/.exec(candidate.message);
+    if (match) {
+      return Number.parseInt(match[1], 10);
+    }
+  }
+
+  return null;
 }
 
 function noDeploymentsError(summary: string, why: string): CliError {

--- a/packages/cli/src/lib/auth/auth-ops.ts
+++ b/packages/cli/src/lib/auth/auth-ops.ts
@@ -1,7 +1,10 @@
 import { FileTokenStorage } from "../../adapters/token-storage";
 import type { AuthStateResult } from "../../types/auth";
+import { SERVICE_TOKEN_ENV_VAR } from "./client";
 import { requireComputeAuth } from "./guard";
 import { login } from "./login";
+
+const WORKSPACE_SUB_PREFIX = "workspace:";
 
 function decodeJwtPayload(token: string): Record<string, unknown> {
   try {
@@ -18,11 +21,30 @@ function emailFromClaims(claims: Record<string, unknown>): string | null {
   return typeof email === "string" && email.trim().length > 0 ? email.trim() : null;
 }
 
+function workspaceIdFromClaims(claims: Record<string, unknown>): string | null {
+  const sub = claims.sub;
+  if (typeof sub !== "string") return null;
+  if (!sub.startsWith(WORKSPACE_SUB_PREFIX)) return null;
+  const id = sub.slice(WORKSPACE_SUB_PREFIX.length).trim();
+  return id.length > 0 ? id : null;
+}
+
 export async function performLogin(env: NodeJS.ProcessEnv): Promise<void> {
   await login({ tokenStorage: new FileTokenStorage(env), env });
 }
 
 export async function readAuthState(env: NodeJS.ProcessEnv): Promise<AuthStateResult> {
+  // PRISMA_API_TOKEN is the headless / CI auth surface. When it is set, derive
+  // auth state from the token itself and intentionally skip FileTokenStorage,
+  // so behavior is independent of any OAuth session that happens to be stored
+  // on the runner. This matches the precedence already documented on
+  // `requireComputeAuth` and keeps `auth whoami` and downstream commands
+  // (e.g. `app deploy`) reading the same source of truth.
+  const serviceToken = env[SERVICE_TOKEN_ENV_VAR]?.trim();
+  if (serviceToken) {
+    return readServiceTokenAuthState(serviceToken, env);
+  }
+
   const tokenStorage = new FileTokenStorage(env);
   const tokens = await tokenStorage.getTokens();
 
@@ -36,16 +58,50 @@ export async function readAuthState(env: NodeJS.ProcessEnv): Promise<AuthStateRe
   }
 
   const claims = decodeJwtPayload(tokens.accessToken);
-  const email = emailFromClaims(claims);
+  return buildAuthState({ workspaceIdFromCredential: tokens.workspaceId, claims, env });
+}
+
+async function readServiceTokenAuthState(
+  token: string,
+  env: NodeJS.ProcessEnv,
+): Promise<AuthStateResult> {
+  const claims = decodeJwtPayload(token);
+  const workspaceId = workspaceIdFromClaims(claims);
+
+  if (!workspaceId) {
+    // Token has no workspace subject we can resolve. Surface signed-out state
+    // so commands that require auth produce the standard AUTH_REQUIRED error
+    // with a clear path forward, rather than crashing or silently deploying
+    // to an unintended target.
+    return {
+      authenticated: false,
+      provider: null,
+      user: null,
+      workspace: null,
+    };
+  }
+
+  return buildAuthState({ workspaceIdFromCredential: workspaceId, claims, env });
+}
+
+async function buildAuthState({
+  workspaceIdFromCredential,
+  claims,
+  env,
+}: {
+  workspaceIdFromCredential: string;
+  claims: Record<string, unknown>;
+  env: NodeJS.ProcessEnv;
+}): Promise<AuthStateResult> {
+  let workspaceId = workspaceIdFromCredential;
+  let workspaceName = workspaceIdFromCredential;
 
   const client = await requireComputeAuth(env);
-  let workspaceId = tokens.workspaceId;
-  let workspaceName = tokens.workspaceId;
 
   if (client) {
     try {
       const { data } = await client.GET("/v1/workspaces/{id}", {
-        params: { path: { id: tokens.workspaceId } },
+        params: { path: { id: workspaceIdFromCredential } },
       });
       if (data?.data?.id) {
         workspaceId = data.data.id;
@@ -58,6 +114,7 @@ export async function readAuthState(env: NodeJS.ProcessEnv): Promise<AuthStateRe
     }
   }
 
+  const email = emailFromClaims(claims);
   return {
     authenticated: true,
     provider: null,

--- a/packages/cli/src/lib/auth/auth-ops.ts
+++ b/packages/cli/src/lib/auth/auth-ops.ts
@@ -34,14 +34,20 @@ export async function performLogin(env: NodeJS.ProcessEnv): Promise<void> {
 }
 
 export async function readAuthState(env: NodeJS.ProcessEnv): Promise<AuthStateResult> {
-  // PRISMA_API_TOKEN is the headless / CI auth surface. When it is set, derive
+  // PRISMA_SERVICE_TOKEN is the headless / CI auth surface. When it is set, derive
   // auth state from the token itself and intentionally skip FileTokenStorage,
   // so behavior is independent of any OAuth session that happens to be stored
   // on the runner. This matches the precedence already documented on
   // `requireComputeAuth` and keeps `auth whoami` and downstream commands
   // (e.g. `app deploy`) reading the same source of truth.
-  const serviceToken = env[SERVICE_TOKEN_ENV_VAR]?.trim();
-  if (serviceToken) {
+  const rawServiceToken = env[SERVICE_TOKEN_ENV_VAR];
+  if (rawServiceToken !== undefined) {
+    const serviceToken = rawServiceToken.trim();
+    if (serviceToken.length === 0) {
+      throw new Error(
+        `${SERVICE_TOKEN_ENV_VAR} is set but empty. Provide a valid token or unset the variable.`,
+      );
+    }
     return readServiceTokenAuthState(serviceToken, env);
   }
 
@@ -119,6 +125,7 @@ async function buildAuthState({
       }
       if (data?.data?.id) {
         workspaceId = data.data.id;
+        workspaceName = data.data.id;
       }
       if (data?.data?.name) {
         workspaceName = data.data.name;

--- a/packages/cli/src/lib/auth/auth-ops.ts
+++ b/packages/cli/src/lib/auth/auth-ops.ts
@@ -100,9 +100,23 @@ async function buildAuthState({
 
   if (client) {
     try {
-      const { data } = await client.GET("/v1/workspaces/{id}", {
+      const { data, response } = await client.GET("/v1/workspaces/{id}", {
         params: { path: { id: workspaceIdFromCredential } },
       });
+      // A 401 from the workspace lookup means the credential the caller
+      // presented is fundamentally invalid (revoked, wrong signing key,
+      // expired) — surface signed-out state instead of returning a
+      // workspace shape that makes a broken token look fine. Other
+      // statuses (404/5xx/network) keep the silent fallback so transient
+      // lookup failures do not turn `auth whoami` into a hard error.
+      if (response?.status === 401) {
+        return {
+          authenticated: false,
+          provider: null,
+          user: null,
+          workspace: null,
+        };
+      }
       if (data?.data?.id) {
         workspaceId = data.data.id;
       }

--- a/packages/cli/src/lib/auth/client.ts
+++ b/packages/cli/src/lib/auth/client.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 export const CLIENT_ID = "cmm3lndn701oo0uefvxzo0ivw";
 export const DEFAULT_API_BASE_URL = "https://api.prisma.io";
-export const SERVICE_TOKEN_ENV_VAR = "PRISMA_API_TOKEN";
+export const SERVICE_TOKEN_ENV_VAR = "PRISMA_SERVICE_TOKEN";
 export const AUTH_FILE_ENV_VAR = "PRISMA_COMPUTE_AUTH_FILE";
 
 export function getApiBaseUrl(env: NodeJS.ProcessEnv = process.env): string {

--- a/packages/cli/src/lib/auth/guard.ts
+++ b/packages/cli/src/lib/auth/guard.ts
@@ -11,7 +11,7 @@ import { CLIENT_ID, getApiBaseUrl, SERVICE_TOKEN_ENV_VAR } from "./client";
  * Resolve authentication and return a ManagementApiClient.
  *
  * Priority:
- *   1. PRISMA_API_TOKEN env var → service token (CI / headless)
+ *   1. PRISMA_SERVICE_TOKEN env var → service token (CI / headless)
  *   2. Stored OAuth tokens     → SDK with auto-refresh
  *
  * Returns null if not authenticated.

--- a/packages/cli/src/lib/project/resolution.ts
+++ b/packages/cli/src/lib/project/resolution.ts
@@ -113,6 +113,14 @@ export function projectNotFoundError(projectRef: string, workspace: AuthWorkspac
 }
 
 export function projectAmbiguousError(projectRef: string | null, matches: ProjectCandidate[]): CliError {
+  const firstMatch = matches[0];
+  const nextSteps = ["prisma-cli project list"];
+  if (firstMatch) {
+    // Surface the matched id verbatim so the user can see the exact
+    // shape of the disambiguation flag instead of guessing.
+    nextSteps.push(`prisma-cli app deploy --project ${firstMatch.id}`);
+  }
+
   return new CliError({
     code: "PROJECT_AMBIGUOUS",
     domain: "project",
@@ -125,7 +133,7 @@ export function projectAmbiguousError(projectRef: string | null, matches: Projec
       matches: matches.map((project) => ({ id: project.id, name: project.name })),
     },
     exitCode: 1,
-    nextSteps: ["prisma-cli project list"],
+    nextSteps,
   });
 }
 

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -2316,7 +2316,7 @@ describe("app controller", () => {
       stateDir,
       env: {
         ...process.env,
-        PRISMA_API_TOKEN: "token",
+        PRISMA_SERVICE_TOKEN: "token",
         PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
       },
     });

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -662,6 +662,102 @@ describe("app controller", () => {
     await expect(readPrismaConfig(cwd)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("surfaces AUTH_FORBIDDEN when create-on-first-deploy is rejected with 401", async () => {
+    // When the deploy lands in the auto-create-on-first-deploy branch
+    // (because no existing project matched the package.json name) and the
+    // platform rejects the create with 401/403, we don't want to surface
+    // the generic "Failed to create project for first deploy / retry the
+    // command" message — that hides that the CLI is inferring projects
+    // from package.json, and "retry" is unhelpful for a permissions
+    // failure. We surface an AUTH_FORBIDDEN error that explains the
+    // inference and recommends --project as the explicit fix.
+    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+    const createProject = vi.fn().mockRejectedValue(new Error("Authentication failed (HTTP 401)"));
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/preview-provider", () => ({
+      createPreviewAppProvider: vi.fn(() => ({
+        createProject,
+        listApps: vi.fn().mockResolvedValue([]),
+        deployApp: vi.fn(),
+        listDeployments: vi.fn(),
+        showDeployment: vi.fn(),
+      })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runAppDeploy } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      isTTY: false,
+      env: {
+        ...process.env,
+        PRISMA_CLI_TEST_REMEMBER_PROJECT_ID: "",
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await expect(runAppDeploy(context, "hello-world")).rejects.toMatchObject({
+      code: "AUTH_FORBIDDEN",
+      domain: "auth",
+      summary: "Could not create a new project for this deploy",
+      why: expect.stringContaining("No existing project matched the package.json name"),
+      fix: expect.stringContaining("--project <id-or-name>"),
+      nextSteps: expect.arrayContaining(["prisma-cli app deploy --project <id-or-name>"]),
+    });
+  });
+
+  it("rewrites the DEPLOY_FAILED message when a non-auth error rejects create-on-first-deploy", async () => {
+    // For non-401/403 create failures, keep the existing DEPLOY_FAILED
+    // code but use the new wording so it's clear the CLI was trying to
+    // create a project (because nothing matched the package.json name)
+    // and suggest --project as an unambiguous fix.
+    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+    const createProject = vi.fn().mockRejectedValue(new Error("Internal Server Error (HTTP 503)"));
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/preview-provider", () => ({
+      createPreviewAppProvider: vi.fn(() => ({
+        createProject,
+        listApps: vi.fn().mockResolvedValue([]),
+        deployApp: vi.fn(),
+        listDeployments: vi.fn(),
+        showDeployment: vi.fn(),
+      })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runAppDeploy } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      isTTY: false,
+      env: {
+        ...process.env,
+        PRISMA_CLI_TEST_REMEMBER_PROJECT_ID: "",
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await expect(runAppDeploy(context, "hello-world")).rejects.toMatchObject({
+      code: "DEPLOY_FAILED",
+      domain: "app",
+      summary: "Could not create a new project for this deploy",
+      why: expect.stringContaining("No existing project matched the package.json name"),
+      fix: expect.stringContaining("--project <id-or-name>"),
+      nextSteps: expect.arrayContaining(["prisma-cli app deploy --project <id-or-name>"]),
+    });
+  });
+
   it("reuses the saved app selection on a second deploy", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
     const listApps = vi.fn().mockResolvedValue([

--- a/packages/cli/tests/auth-ops.test.ts
+++ b/packages/cli/tests/auth-ops.test.ts
@@ -179,6 +179,77 @@ describe("readAuthState", () => {
     expect(getTokens).not.toHaveBeenCalled();
   });
 
+  it("returns signed-out state when the workspace lookup is rejected with HTTP 401", async () => {
+    // A 401 on the workspace lookup means the credential is fundamentally
+    // broken (revoked, wrong signing key, expired). The previous behavior
+    // swallowed the failure and returned a fake workspace where id == name,
+    // which made `auth whoami` look fine for a token the API was already
+    // rejecting. Now `auth whoami` reports the truth and downstream
+    // commands trigger the standard AUTH_REQUIRED flow.
+    const requireComputeAuth = vi.fn().mockResolvedValue({
+      GET: vi.fn().mockResolvedValue({
+        data: undefined,
+        error: { message: "Unauthorized" },
+        response: { status: 401 } as Response,
+      }),
+    });
+
+    vi.doMock("../src/adapters/token-storage", () => ({
+      FileTokenStorage: vi.fn().mockImplementation(() => ({
+        getTokens: vi.fn(),
+      })),
+    }));
+    vi.doMock("../src/lib/auth/guard", () => ({ requireComputeAuth }));
+
+    const { readAuthState } = await import("../src/lib/auth/auth-ops");
+    const token = encodeJwt({ sub: "workspace:clitq5hfg0000qv0gtg9nv9fy" });
+
+    await expect(
+      readAuthState({ PRISMA_API_TOKEN: token } as NodeJS.ProcessEnv),
+    ).resolves.toEqual({
+      authenticated: false,
+      provider: null,
+      user: null,
+      workspace: null,
+    });
+  });
+
+  it("falls back to the workspace id when the API lookup fails with a non-401 status", async () => {
+    // Non-401 lookup failures (404/5xx/network) leave the existing UX in
+    // place: the credential is presumably valid but the workspace lookup
+    // didn't succeed, so we keep authenticated state and use the
+    // workspace id as a placeholder name.
+    const requireComputeAuth = vi.fn().mockResolvedValue({
+      GET: vi.fn().mockResolvedValue({
+        data: undefined,
+        error: { message: "Internal Server Error" },
+        response: { status: 503 } as Response,
+      }),
+    });
+
+    vi.doMock("../src/adapters/token-storage", () => ({
+      FileTokenStorage: vi.fn().mockImplementation(() => ({
+        getTokens: vi.fn(),
+      })),
+    }));
+    vi.doMock("../src/lib/auth/guard", () => ({ requireComputeAuth }));
+
+    const { readAuthState } = await import("../src/lib/auth/auth-ops");
+    const token = encodeJwt({ sub: "workspace:clitq5hfg0000qv0gtg9nv9fy" });
+
+    await expect(
+      readAuthState({ PRISMA_API_TOKEN: token } as NodeJS.ProcessEnv),
+    ).resolves.toEqual({
+      authenticated: true,
+      provider: null,
+      user: null,
+      workspace: {
+        id: "clitq5hfg0000qv0gtg9nv9fy",
+        name: "clitq5hfg0000qv0gtg9nv9fy",
+      },
+    });
+  });
+
   it("falls back to the workspace id when the API lookup fails for a service token", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue({
       GET: vi.fn().mockRejectedValue(new Error("network down")),

--- a/packages/cli/tests/auth-ops.test.ts
+++ b/packages/cli/tests/auth-ops.test.ts
@@ -100,7 +100,42 @@ describe("readAuthState", () => {
     });
   });
 
-  it("derives authenticated state from PRISMA_API_TOKEN without consulting FileTokenStorage", async () => {
+  it("uses the canonical workspace id as the fallback name when the API omits a name", async () => {
+    const getTokens = vi.fn().mockResolvedValue({
+      workspaceId: "cmmxlp7ae1251zyfs8mdpnavm",
+      accessToken: encodeJwt({ sub: "user:usr_123" }),
+      refreshToken: "refresh-token",
+    });
+    const requireComputeAuth = vi.fn().mockResolvedValue({
+      GET: vi.fn().mockResolvedValue({
+        data: {
+          data: {
+            id: "wksp_cmmxlp7ae1251zyfs8mdpnavm",
+          },
+        },
+      }),
+    });
+
+    vi.doMock("../src/adapters/token-storage", () => ({
+      FileTokenStorage: vi.fn().mockImplementation(() => ({
+        getTokens,
+      })),
+    }));
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+
+    const { readAuthState } = await import("../src/lib/auth/auth-ops");
+
+    await expect(readAuthState({} as NodeJS.ProcessEnv)).resolves.toMatchObject({
+      workspace: {
+        id: "wksp_cmmxlp7ae1251zyfs8mdpnavm",
+        name: "wksp_cmmxlp7ae1251zyfs8mdpnavm",
+      },
+    });
+  });
+
+  it("derives authenticated state from PRISMA_SERVICE_TOKEN without consulting FileTokenStorage", async () => {
     const getTokens = vi.fn();
     const requireComputeAuth = vi.fn().mockResolvedValue({
       GET: vi.fn().mockImplementation((pathName: string, request?: { params?: { path?: { id?: string } } }) => {
@@ -132,7 +167,7 @@ describe("readAuthState", () => {
     const token = encodeJwt({ sub: "workspace:clitq5hfg0000qv0gtg9nv9fy", email: "service@example.com" });
 
     await expect(
-      readAuthState({ PRISMA_API_TOKEN: token } as NodeJS.ProcessEnv),
+      readAuthState({ PRISMA_SERVICE_TOKEN: token } as NodeJS.ProcessEnv),
     ).resolves.toEqual({
       authenticated: true,
       provider: null,
@@ -146,7 +181,7 @@ describe("readAuthState", () => {
     expect(getTokens).not.toHaveBeenCalled();
   });
 
-  it("ignores a stored OAuth session when PRISMA_API_TOKEN is set", async () => {
+  it("ignores a stored OAuth session when PRISMA_SERVICE_TOKEN is set", async () => {
     // Regression: a locally cached OAuth login for one workspace must not win
     // over the service token scoped to a different workspace. Otherwise CI
     // deploys silently target whichever workspace the developer last logged
@@ -172,7 +207,7 @@ describe("readAuthState", () => {
     const { readAuthState } = await import("../src/lib/auth/auth-ops");
     const token = encodeJwt({ sub: "workspace:clitq5hfg0000qv0gtg9nv9fy" });
 
-    const result = await readAuthState({ PRISMA_API_TOKEN: token } as NodeJS.ProcessEnv);
+    const result = await readAuthState({ PRISMA_SERVICE_TOKEN: token } as NodeJS.ProcessEnv);
 
     expect(result.authenticated).toBe(true);
     expect(result.workspace?.id).toBe("wksp_clitq5hfg0000qv0gtg9nv9fy");
@@ -205,7 +240,7 @@ describe("readAuthState", () => {
     const token = encodeJwt({ sub: "workspace:clitq5hfg0000qv0gtg9nv9fy" });
 
     await expect(
-      readAuthState({ PRISMA_API_TOKEN: token } as NodeJS.ProcessEnv),
+      readAuthState({ PRISMA_SERVICE_TOKEN: token } as NodeJS.ProcessEnv),
     ).resolves.toEqual({
       authenticated: false,
       provider: null,
@@ -238,7 +273,7 @@ describe("readAuthState", () => {
     const token = encodeJwt({ sub: "workspace:clitq5hfg0000qv0gtg9nv9fy" });
 
     await expect(
-      readAuthState({ PRISMA_API_TOKEN: token } as NodeJS.ProcessEnv),
+      readAuthState({ PRISMA_SERVICE_TOKEN: token } as NodeJS.ProcessEnv),
     ).resolves.toEqual({
       authenticated: true,
       provider: null,
@@ -266,7 +301,7 @@ describe("readAuthState", () => {
     const token = encodeJwt({ sub: "workspace:clitq5hfg0000qv0gtg9nv9fy" });
 
     await expect(
-      readAuthState({ PRISMA_API_TOKEN: token } as NodeJS.ProcessEnv),
+      readAuthState({ PRISMA_SERVICE_TOKEN: token } as NodeJS.ProcessEnv),
     ).resolves.toEqual({
       authenticated: true,
       provider: null,
@@ -278,7 +313,7 @@ describe("readAuthState", () => {
     });
   });
 
-  it("returns signed-out state when PRISMA_API_TOKEN does not carry a workspace subject", async () => {
+  it("returns signed-out state when PRISMA_SERVICE_TOKEN does not carry a workspace subject", async () => {
     const getTokens = vi.fn();
     vi.doMock("../src/adapters/token-storage", () => ({
       FileTokenStorage: vi.fn().mockImplementation(() => ({ getTokens })),
@@ -291,7 +326,7 @@ describe("readAuthState", () => {
     const token = encodeJwt({ sub: "user:usr_123" });
 
     await expect(
-      readAuthState({ PRISMA_API_TOKEN: token } as NodeJS.ProcessEnv),
+      readAuthState({ PRISMA_SERVICE_TOKEN: token } as NodeJS.ProcessEnv),
     ).resolves.toEqual({
       authenticated: false,
       provider: null,
@@ -301,7 +336,7 @@ describe("readAuthState", () => {
     expect(getTokens).not.toHaveBeenCalled();
   });
 
-  it("treats an empty PRISMA_API_TOKEN as unset and falls back to FileTokenStorage", async () => {
+  it("treats an empty PRISMA_SERVICE_TOKEN as invalid and does not fall back to FileTokenStorage", async () => {
     const getTokens = vi.fn().mockResolvedValue(null);
 
     vi.doMock("../src/adapters/token-storage", () => ({
@@ -314,13 +349,10 @@ describe("readAuthState", () => {
     const { readAuthState } = await import("../src/lib/auth/auth-ops");
 
     await expect(
-      readAuthState({ PRISMA_API_TOKEN: "   " } as NodeJS.ProcessEnv),
-    ).resolves.toEqual({
-      authenticated: false,
-      provider: null,
-      user: null,
-      workspace: null,
-    });
-    expect(getTokens).toHaveBeenCalled();
+      readAuthState({ PRISMA_SERVICE_TOKEN: "   " } as NodeJS.ProcessEnv),
+    ).rejects.toThrow(
+      "PRISMA_SERVICE_TOKEN is set but empty. Provide a valid token or unset the variable.",
+    );
+    expect(getTokens).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/tests/auth-ops.test.ts
+++ b/packages/cli/tests/auth-ops.test.ts
@@ -7,6 +7,11 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+function encodeJwt(claims: Record<string, unknown>): string {
+  const payload = Buffer.from(JSON.stringify(claims), "utf8").toString("base64url");
+  return `header.${payload}.signature`;
+}
+
 describe("readAuthState", () => {
   it("normalizes the workspace id to the canonical API id and returns the user email", async () => {
     const getTokens = vi.fn().mockResolvedValue({
@@ -43,7 +48,7 @@ describe("readAuthState", () => {
 
     const { readAuthState } = await import("../src/lib/auth/auth-ops");
 
-    await expect(readAuthState(process.env)).resolves.toEqual({
+    await expect(readAuthState({} as NodeJS.ProcessEnv)).resolves.toEqual({
       authenticated: true,
       provider: null,
       user: {
@@ -85,7 +90,7 @@ describe("readAuthState", () => {
 
     const { readAuthState } = await import("../src/lib/auth/auth-ops");
 
-    await expect(readAuthState(process.env)).resolves.toMatchObject({
+    await expect(readAuthState({} as NodeJS.ProcessEnv)).resolves.toMatchObject({
       authenticated: true,
       user: null,
       workspace: {
@@ -93,5 +98,158 @@ describe("readAuthState", () => {
         name: "Sandpit",
       },
     });
+  });
+
+  it("derives authenticated state from PRISMA_API_TOKEN without consulting FileTokenStorage", async () => {
+    const getTokens = vi.fn();
+    const requireComputeAuth = vi.fn().mockResolvedValue({
+      GET: vi.fn().mockImplementation((pathName: string, request?: { params?: { path?: { id?: string } } }) => {
+        if (pathName === "/v1/workspaces/{id}" && request?.params?.path?.id === "clitq5hfg0000qv0gtg9nv9fy") {
+          return {
+            data: {
+              data: {
+                id: "wksp_clitq5hfg0000qv0gtg9nv9fy",
+                name: "Prisma Platform",
+              },
+            },
+          };
+        }
+
+        throw new Error(`Unexpected path ${pathName}`);
+      }),
+    });
+
+    vi.doMock("../src/adapters/token-storage", () => ({
+      FileTokenStorage: vi.fn().mockImplementation(() => ({
+        getTokens,
+      })),
+    }));
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+
+    const { readAuthState } = await import("../src/lib/auth/auth-ops");
+    const token = encodeJwt({ sub: "workspace:clitq5hfg0000qv0gtg9nv9fy", email: "service@example.com" });
+
+    await expect(
+      readAuthState({ PRISMA_API_TOKEN: token } as NodeJS.ProcessEnv),
+    ).resolves.toEqual({
+      authenticated: true,
+      provider: null,
+      user: { email: "service@example.com" },
+      workspace: {
+        id: "wksp_clitq5hfg0000qv0gtg9nv9fy",
+        name: "Prisma Platform",
+      },
+    });
+
+    expect(getTokens).not.toHaveBeenCalled();
+  });
+
+  it("ignores a stored OAuth session when PRISMA_API_TOKEN is set", async () => {
+    // Regression: a locally cached OAuth login for one workspace must not win
+    // over the service token scoped to a different workspace. Otherwise CI
+    // deploys silently target whichever workspace the developer last logged
+    // into.
+    const getTokens = vi.fn().mockResolvedValue({
+      workspaceId: "wksp_local_oauth_workspace",
+      accessToken: encodeJwt({ sub: "user:usr_local", email: "dev@example.com" }),
+      refreshToken: "refresh-token",
+    });
+    const requireComputeAuth = vi.fn().mockResolvedValue({
+      GET: vi.fn().mockResolvedValue({
+        data: {
+          data: { id: "wksp_clitq5hfg0000qv0gtg9nv9fy", name: "Prisma Platform" },
+        },
+      }),
+    });
+
+    vi.doMock("../src/adapters/token-storage", () => ({
+      FileTokenStorage: vi.fn().mockImplementation(() => ({ getTokens })),
+    }));
+    vi.doMock("../src/lib/auth/guard", () => ({ requireComputeAuth }));
+
+    const { readAuthState } = await import("../src/lib/auth/auth-ops");
+    const token = encodeJwt({ sub: "workspace:clitq5hfg0000qv0gtg9nv9fy" });
+
+    const result = await readAuthState({ PRISMA_API_TOKEN: token } as NodeJS.ProcessEnv);
+
+    expect(result.authenticated).toBe(true);
+    expect(result.workspace?.id).toBe("wksp_clitq5hfg0000qv0gtg9nv9fy");
+    expect(getTokens).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the workspace id when the API lookup fails for a service token", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue({
+      GET: vi.fn().mockRejectedValue(new Error("network down")),
+    });
+
+    vi.doMock("../src/adapters/token-storage", () => ({
+      FileTokenStorage: vi.fn().mockImplementation(() => ({
+        getTokens: vi.fn(),
+      })),
+    }));
+    vi.doMock("../src/lib/auth/guard", () => ({ requireComputeAuth }));
+
+    const { readAuthState } = await import("../src/lib/auth/auth-ops");
+    const token = encodeJwt({ sub: "workspace:clitq5hfg0000qv0gtg9nv9fy" });
+
+    await expect(
+      readAuthState({ PRISMA_API_TOKEN: token } as NodeJS.ProcessEnv),
+    ).resolves.toEqual({
+      authenticated: true,
+      provider: null,
+      user: null,
+      workspace: {
+        id: "clitq5hfg0000qv0gtg9nv9fy",
+        name: "clitq5hfg0000qv0gtg9nv9fy",
+      },
+    });
+  });
+
+  it("returns signed-out state when PRISMA_API_TOKEN does not carry a workspace subject", async () => {
+    const getTokens = vi.fn();
+    vi.doMock("../src/adapters/token-storage", () => ({
+      FileTokenStorage: vi.fn().mockImplementation(() => ({ getTokens })),
+    }));
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth: vi.fn(),
+    }));
+
+    const { readAuthState } = await import("../src/lib/auth/auth-ops");
+    const token = encodeJwt({ sub: "user:usr_123" });
+
+    await expect(
+      readAuthState({ PRISMA_API_TOKEN: token } as NodeJS.ProcessEnv),
+    ).resolves.toEqual({
+      authenticated: false,
+      provider: null,
+      user: null,
+      workspace: null,
+    });
+    expect(getTokens).not.toHaveBeenCalled();
+  });
+
+  it("treats an empty PRISMA_API_TOKEN as unset and falls back to FileTokenStorage", async () => {
+    const getTokens = vi.fn().mockResolvedValue(null);
+
+    vi.doMock("../src/adapters/token-storage", () => ({
+      FileTokenStorage: vi.fn().mockImplementation(() => ({ getTokens })),
+    }));
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth: vi.fn(),
+    }));
+
+    const { readAuthState } = await import("../src/lib/auth/auth-ops");
+
+    await expect(
+      readAuthState({ PRISMA_API_TOKEN: "   " } as NodeJS.ProcessEnv),
+    ).resolves.toEqual({
+      authenticated: false,
+      provider: null,
+      user: null,
+      workspace: null,
+    });
+    expect(getTokens).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #18.

## Summary

`PRISMA_API_TOKEN` is documented on [`requireComputeAuth`](https://github.com/prisma/prisma-cli/blob/main/packages/cli/src/lib/auth/guard.ts) as the headless / CI auth surface, but `readAuthState` reads exclusively from `FileTokenStorage`. The token is therefore sufficient to build a `ManagementApiClient` but not to satisfy `requireAuthenticatedAuthState`. Two symptoms follow:

- On a clean CI runner, `app deploy` (and every other command that resolves project context) fails with `AUTH_REQUIRED` even with a valid `PRISMA_API_TOKEN` set, because no OAuth file exists.
- On a developer machine with any stored OAuth session, that workspace wins over the token's `sub` claim, so deploys can silently target the wrong workspace. We hit this in the wild: a token scoped to workspace A, a stale login for workspace B, and `app deploy` created a new orphan project under B.

This PR makes `readAuthState` honor `PRISMA_API_TOKEN` the same way `requireComputeAuth` already does:

1. If `PRISMA_API_TOKEN` is set, decode the JWT, parse the workspace id from `sub` (`workspace:<id>`), and build the synthetic `AuthStateResult` from there — skipping `FileTokenStorage` entirely.
2. Hydrate `workspace.name` from `GET /v1/workspaces/{id}` when the API is reachable, falling back to the id on failure (matches existing OAuth-path behavior).
3. If the token has no `workspace:` subject, return signed-out state so callers produce the standard `AUTH_REQUIRED` error rather than crashing or deploying somewhere unintended.

The OAuth-file path is unchanged when `PRISMA_API_TOKEN` is unset or empty.

## Behavior comparison

With `PRISMA_API_TOKEN=<token scoped to workspace clitq5...>` and a locally stored OAuth login for an unrelated workspace `cmoijyfgr...`:

| CLI | `auth whoami --json` workspace |
| --- | --- |
| `@prisma/cli@preview` (alpha.4) | `cmoijyfgr0wlm3ucagwc75f3f` (the local OAuth file wins) |
| This PR | `clitq5hfg0000qv0gtg9nv9fy` (the service token wins) |

## Docs

Adds an Authentication section to `docs/product/command-spec.md` documenting the two auth sources and their precedence, since the document-driven development rule requires product docs to be the source of truth.

## Industry precedent

Standard CLI behavior: when the token env var is set, it is fully sufficient for headless operation and locally cached credentials are ignored.

- Vercel: `VERCEL_TOKEN` (plus `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` for explicit scope)
- GitHub CLI: `GH_TOKEN`
- Fly.io: `FLY_API_TOKEN`
- Doppler: `DOPPLER_TOKEN`
- Stripe: `STRIPE_API_KEY`

The Prisma JWT already encodes the workspace in `sub`, so no `PRISMA_WORKSPACE_ID` env var is needed for the common case where the token is scoped to a single workspace.

## Tests

- `derives authenticated state from PRISMA_API_TOKEN without consulting FileTokenStorage`
- `ignores a stored OAuth session when PRISMA_API_TOKEN is set` (regression test for the wrong-workspace scenario)
- `falls back to the workspace id when the API lookup fails for a service token`
- `returns signed-out state when PRISMA_API_TOKEN does not carry a workspace subject`
- `treats an empty PRISMA_API_TOKEN as unset and falls back to FileTokenStorage`

Full suite (`pnpm test`): 192 passed.

## Manual verification

Built locally and ran against the platform with a real service token:

```bash
# token sub: workspace:clitq5hfg0000qv0gtg9nv9fy
$ PRISMA_API_TOKEN=$TOKEN node packages/cli/dist/cli.js auth whoami --json
{
  "ok": true,
  "command": "auth.whoami",
  "result": {
    "authenticated": true,
    "provider": null,
    "user": null,
    "workspace": { "id": "clitq5hfg0000qv0gtg9nv9fy", "name": "clitq5hfg0000qv0gtg9nv9fy" }
  },
  "warnings": [],
  "nextSteps": []
}
```

Same invocation against `@prisma/cli@preview` (alpha.4) reports the local OAuth file's workspace, confirming the regression and the fix.

## Out of scope (follow-up)

`auth login` and `auth logout` still operate on `FileTokenStorage` regardless of `PRISMA_API_TOKEN`. That is documented in the new spec section but the UX could be tightened (e.g. `auth login` short-circuits to the env-derived state with a warning when the env var is set). Happy to do that as a separate PR if you'd like.