### PR TITLE
chore(deps): update compute sdk to 0.18.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.2.0",
-    "@prisma/compute-sdk": "^0.17.0",
+    "@prisma/compute-sdk": "^0.18.0",
     "c12": "4.0.0-beta.4",
     "@prisma/credentials-store": "^7.7.0",
     "@prisma/management-api-sdk": "^1.27.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       '@prisma/compute-sdk':
-        specifier: ^0.17.0
-        version: 0.17.0(@prisma/management-api-sdk@1.27.0)
+        specifier: ^0.18.0
+        version: 0.18.0(@prisma/management-api-sdk@1.27.0)
       '@prisma/credentials-store':
         specifier: ^7.7.0
         version: 7.7.0
@@ -283,8 +283,8 @@ packages:
   '@oxc-project/types@0.124.0':
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
-  '@prisma/compute-sdk@0.17.0':
-    resolution: {integrity: sha512-YfCmszlEMYndDyVT17jiAZEHOMXlVq/lJKv9cc6KT9Zn2rPdR/MKvsPhQZg4E44vgJuPXMKieULOKUwFz0aj2g==}
+  '@prisma/compute-sdk@0.18.0':
+    resolution: {integrity: sha512-Cuq2mt08kpjfA99tLsSX3eyr2gdIp6QPkfApdT6Q5nnaez3OlAAkd4uJ/trBBTjWP+c8Xj1ZLXAb1QuE4ea0pw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@prisma/management-api-sdk': '>=1.23.0'
@@ -1312,7 +1312,7 @@ snapshots:
 
   '@oxc-project/types@0.124.0': {}
 
-  '@prisma/compute-sdk@0.17.0(@prisma/management-api-sdk@1.27.0)':
+  '@prisma/compute-sdk@0.18.0(@prisma/management-api-sdk@1.27.0)':
     dependencies:
       '@prisma/management-api-sdk': 1.27.0
       better-result: 2.8.2


### PR DESCRIPTION
## Summary

- updates @prisma/compute-sdk to the released 0.18.0 package
- refreshes the pnpm lockfile resolution

## Why

Pulls in the archive symlink preservation fix from prisma/project-compute#75 so Next.js standalone apps with pnpm symlinks deploy correctly.

## Verification

- npm view @prisma/compute-sdk version => 0.18.0
- pnpm test
- pnpm build:cli