### PR TITLE
feat(app): revised deploy path

### DIFF
--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -74,27 +74,36 @@ When `PRISMA_SERVICE_TOKEN` is set and non-empty, the token is fully sufficient 
 Commands resolve project context in this order:
 
 1. explicit `--project <id-or-name>` when present
-2. durable platform mapping when available
-3. remembered local project context, revalidated against platform data
-4. `package.json` name matched exactly against accessible project id, name, or slug
-5. unambiguous project creation for commands that are allowed to create projects
-6. prompt in interactive mode, or structured failure in `--json` / `--no-interactive` mode
+2. `PRISMA_PROJECT_ID` when set for headless deploys
+3. `.prisma/local.json` project pin when present, revalidated against platform data
+4. durable platform mapping when available
+5. remembered local project context, revalidated against platform data
+6. `package.json` name matched exactly against accessible project id, name, or slug
+7. unambiguous project creation for commands that are allowed to create projects
+8. prompt in interactive mode, or structured failure in `--json` / `--no-interactive` mode
 
 `--project` is an escape hatch for ambiguous or unavailable automatic
 resolution, not a setup step. Only `app deploy` may create a missing project,
 and only when the inferred name is unambiguous.
+When `PRISMA_PROJECT_ID` is set, `app deploy` skips `.prisma/local.json` reads
+and does not write a new pin.
 
 ### App Selection
 
 Preview app commands that need an app resolve it in this order:
 
 1. `--app <name>`
-2. locally selected app for the resolved project when it still exists
-3. inferred app name from `package.json#name`
-4. current directory name
-5. create the inferred app when no existing app matches
-6. interactive picker only when multiple matching apps make the target ambiguous
-7. `APP_AMBIGUOUS` in non-interactive or `--json` mode when unresolved
+2. `PRISMA_APP_ID` when set for headless deploys
+3. `.prisma/local.json` default app pin when present, revalidated against platform data
+4. locally selected app for non-deploy commands when it still exists
+5. inferred app name from `package.json#name`
+6. current directory name
+7. create the inferred app when no existing app matches
+8. interactive picker only when multiple matching apps make the target ambiguous
+9. `APP_AMBIGUOUS` in non-interactive or `--json` mode when unresolved
+
+When `PRISMA_APP_ID` is set, `app deploy` skips `.prisma/local.json` reads and
+does not write a new pin.
 
 ### Branch
 
@@ -477,7 +486,7 @@ prisma-cli app run --build-type nextjs
 prisma-cli app run --build-type bun --entry server.ts --port 3000
 ```
 
-## `prisma-cli app deploy --project <id-or-name> --app <name> --branch <name> --framework <nextjs|hono|tanstack-start> --http-port <port> --env <name=value>`
+## `prisma-cli app deploy --project <id-or-name> --app <name> --branch <name> --framework <nextjs|hono|tanstack-start> --entry <path> --http-port <port> --env <name=value>`
 
 Purpose:
 
@@ -486,9 +495,9 @@ Purpose:
 Behavior:
 
 - requires auth
-- resolves or creates project context from `--project`, `package.json#name`, or current directory name
+- resolves or creates project context from `--project`, `PRISMA_PROJECT_ID`, `.prisma/local.json`, `package.json#name`, or current directory name
 - resolves branch context from `--branch`, local Git branch, or `main`
-- resolves or creates app context from `--app`, remembered app state, `package.json#name`, or current directory name
+- resolves or creates app context from `--app`, `PRISMA_APP_ID`, `.prisma/local.json`, `package.json#name`, or current directory name
 - does not prompt when there is no real choice; zero matching apps creates the inferred app
 - detects supported frameworks and shows the resolved framework/runtime settings before deploy
 - asks `Customize settings? (y/N)` only in interactive first-deploy flows, and only asks for Framework and HTTP port when the user opts in

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -89,17 +89,20 @@ and only when the inferred name is unambiguous.
 Preview app commands that need an app resolve it in this order:
 
 1. `--app <name>`
-2. locally selected app for the resolved project
-3. interactive select-or-create flow in TTY mode
-4. `USAGE_ERROR` in non-interactive or `--json` mode when unresolved
+2. locally selected app for the resolved project when it still exists
+3. inferred app name from `package.json#name`
+4. current directory name
+5. create the inferred app when no existing app matches
+6. interactive picker only when multiple matching apps make the target ambiguous
+7. `APP_AMBIGUOUS` in non-interactive or `--json` mode when unresolved
 
 ### Branch
 
 Commands that use branch context resolve it in this order:
 
-1. explicit branch argument when the command accepts one
-2. active branch context in local CLI state
-3. `preview`
+1. explicit branch argument or `--branch <name>` when the command accepts one
+2. active Git branch for local deploy workflows
+3. `main`
 
 `local` is local CLI context only. It is never a branch or deploy target.
 Production is a protected durable branch and must require explicit user intent.
@@ -474,7 +477,7 @@ prisma-cli app run --build-type nextjs
 prisma-cli app run --build-type bun --entry server.ts --port 3000
 ```
 
-## `prisma-cli app deploy --app <name> --entry <path> --build-type <auto|bun|nextjs|nuxt|astro|tanstack-start> --http-port <port> --env <name=value>`
+## `prisma-cli app deploy --project <id-or-name> --app <name> --branch <name> --framework <nextjs|hono|tanstack-start> --http-port <port> --env <name=value>`
 
 Purpose:
 
@@ -483,10 +486,15 @@ Purpose:
 Behavior:
 
 - requires auth
-- resolves or creates project context
-- resolves or creates app context when required
+- resolves or creates project context from `--project`, `package.json#name`, or current directory name
+- resolves branch context from `--branch`, local Git branch, or `main`
+- resolves or creates app context from `--app`, remembered app state, `package.json#name`, or current directory name
+- does not prompt when there is no real choice; zero matching apps creates the inferred app
+- detects supported frameworks and shows the resolved framework/runtime settings before deploy
+- asks `Customize settings? (y/N)` only in interactive first-deploy flows, and only asks for Framework and HTTP port when the user opts in
 - accepts repeated `--env NAME=VALUE` flags
-- uses the same supported build strategies as `app build`
+- maps user-facing framework names to deploy build strategies
+- accepts `--build-type <auto|bun|nextjs|nuxt|astro|tanstack-start>` as a legacy passthrough, but `--framework` wins when both are passed
 - does not print secret values
 - returns app, deployment id, URL, and next steps
 
@@ -494,11 +502,9 @@ Examples:
 
 ```bash
 prisma-cli app deploy
-prisma-cli app deploy --app hello-world --env DATABASE_URL=postgresql://example
-prisma-cli app deploy --app hello-world --build-type nextjs --http-port 3000
-prisma-cli app deploy --app hello-world --build-type nuxt
-prisma-cli app deploy --app hello-world --build-type astro
-prisma-cli app deploy --app hello-world --build-type tanstack-start
+prisma-cli app deploy --app my-app --env DATABASE_URL=postgresql://example
+prisma-cli app deploy --framework nextjs --http-port 3000
+prisma-cli app deploy --branch feat-login --framework hono --http-port 3000
 ```
 
 ## `prisma-cli project env`

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -53,7 +53,7 @@ Out of scope for the current preview:
 - Long flags use kebab-case.
 - Boolean negation uses `--no-<flag>`.
 - `--json` and non-interactive mode must not block on prompts.
-- Public Beta does not read or write `prisma.config.ts`, `.prisma/settings.json`, or any repo config file for Project -> Branch -> App resolution.
+- Public Beta does not read or write committed config files such as `prisma.config.ts` or `.prisma/settings.json` for Project -> Branch -> App resolution. `.prisma/local.json` is a gitignored local pin/cache, not a declarative repo config file.
 - Remote commands do not silently change local context.
 
 ## Authentication
@@ -94,16 +94,19 @@ Preview app commands that need an app resolve it in this order:
 
 1. `--app <name>`
 2. `PRISMA_APP_ID` when set for headless deploys
-3. `.prisma/local.json` default app pin when present, revalidated against platform data
-4. locally selected app for non-deploy commands when it still exists
-5. inferred app name from `package.json#name`
-6. current directory name
-7. create the inferred app when no existing app matches
-8. interactive picker only when multiple matching apps make the target ambiguous
-9. `APP_AMBIGUOUS` in non-interactive or `--json` mode when unresolved
+3. locally selected app for non-deploy commands when it still exists in the resolved branch
+4. inferred app name from `package.json#name`
+5. current directory name
+6. create the inferred app in the resolved branch when no existing app matches
+7. interactive picker only when multiple matching apps make the target ambiguous
+8. `APP_AMBIGUOUS` in non-interactive or `--json` mode when unresolved
 
 When `PRISMA_APP_ID` is set, `app deploy` skips `.prisma/local.json` reads and
 does not write a new pin.
+
+`.prisma/local.json` pins the directory to a Workspace and Project only. It does
+not pin an App ID. App services are branch-scoped; a service ID from `main`
+must not be reused automatically when the user deploys from `feat/billing`.
 
 ### Branch
 
@@ -496,8 +499,8 @@ Behavior:
 
 - requires auth
 - resolves or creates project context from `--project`, `PRISMA_PROJECT_ID`, `.prisma/local.json`, `package.json#name`, or current directory name
-- resolves branch context from `--branch`, local Git branch, or `main`
-- resolves or creates app context from `--app`, `PRISMA_APP_ID`, `.prisma/local.json`, `package.json#name`, or current directory name
+- resolves or creates branch context from `--branch`, local Git branch, or `main`
+- resolves or creates app context inside the resolved branch from `--app`, `PRISMA_APP_ID`, `package.json#name`, or current directory name
 - does not prompt when there is no real choice; zero matching apps creates the inferred app
 - detects supported frameworks and shows the resolved framework/runtime settings before deploy
 - asks `Customize settings? (y/N)` only in interactive first-deploy flows, and only asks for Framework and HTTP port when the user opts in

--- a/docs/product/error-conventions.md
+++ b/docs/product/error-conventions.md
@@ -150,8 +150,10 @@ These codes are the minimum stable set for the MVP:
 - `PROJECT_UNRESOLVED`
 - `PROJECT_NOT_FOUND`
 - `PROJECT_AMBIGUOUS`
+- `APP_AMBIGUOUS`
 - `LOCAL_STATE_STALE`
 - `BRANCH_NOT_DEPLOYABLE`
+- `FRAMEWORK_NOT_DETECTED`
 - `DEPLOYMENT_NOT_FOUND`
 - `NO_DEPLOYMENTS`
 - `NO_PREVIOUS_DEPLOYMENT`
@@ -178,8 +180,10 @@ Recommended meanings:
 - `PROJECT_UNRESOLVED`: command needs project context and none could be resolved
 - `PROJECT_NOT_FOUND`: requested project does not exist or is not accessible
 - `PROJECT_AMBIGUOUS`: multiple safe project candidates matched
+- `APP_AMBIGUOUS`: multiple apps matched the inferred or explicit app target
 - `LOCAL_STATE_STALE`: remembered local project context no longer matches platform data and continuing would be ambiguous
 - `BRANCH_NOT_DEPLOYABLE`: command tried to deploy to a non-deployable branch context
+- `FRAMEWORK_NOT_DETECTED`: app deploy could not detect a supported Beta framework and no explicit framework/build type was provided
 - `DEPLOYMENT_NOT_FOUND`: requested deployment id does not exist
 - `NO_DEPLOYMENTS`: command resolved a branch or app but found no deployments
 - `NO_PREVIOUS_DEPLOYMENT`: rollback could not find an earlier deployment for the selected app

--- a/docs/product/output-conventions.md
+++ b/docs/product/output-conventions.md
@@ -265,6 +265,8 @@ When a command acts on a project, branch, app, or deployment, the output should 
 Examples:
 
 - `app deploy` should state the resolved target that matters in the current slice
+- first `app deploy` should show Workspace, Project, Branch, App, Framework, and Runtime with source annotations before work begins
+- subsequent `app deploy` should show the resolved tuple without repeating first-run annotations
 - `app logs` should state the deployment it resolved
 - `app list-deploys` should state which app or branch is being listed
 

--- a/docs/product/resource-model.md
+++ b/docs/product/resource-model.md
@@ -215,9 +215,10 @@ this order:
 8. structured usage error when no app can be resolved non-interactively
 
 `.prisma/local.json` does not pin an app ID. The local pin binds the directory
-to a Workspace and Project; branches come from explicit targeting or Git, and
-apps are resolved within that branch. This avoids accidentally deploying
-feature-branch code into a service that belongs to `main`.
+to a Workspace and Project; branches come from explicit targeting, Git, or
+`main` when neither is available. Apps are resolved within that resolved branch,
+including the `main` fallback, which avoids accidentally deploying
+feature-branch code into a service owned by another branch.
 
 ### Branch Context Resolution
 

--- a/docs/product/resource-model.md
+++ b/docs/product/resource-model.md
@@ -36,7 +36,8 @@ Preview relevance:
 Rules:
 
 - `project` is not the same thing as `app`
-- Public Beta does not read or write `prisma.config.ts`, `.prisma/settings.json`, or any repo config file for project resolution
+- Public Beta does not read or write committed config files such as `prisma.config.ts` or `.prisma/settings.json` for project resolution
+- `.prisma/local.json` is a gitignored local pin/cache for Workspace and Project IDs; it is not a declarative repo config file
 - `app deploy` may create missing project context only when resolution is unambiguous
 - other commands must not create project context implicitly
 - everything under a project happens in a branch
@@ -99,8 +100,8 @@ accidental destructive actions.
 Rules:
 
 - `app` is not the same thing as `project`
-- the app belongs to the resolved project
-- app work is scoped by branch in the platform model
+- the app name is registered within the resolved project
+- the runtime app service is scoped by branch in the platform model
 - the app may be selected or created as part of app deployment workflows
 - app selection is local CLI state when needed for the preview package
 
@@ -179,7 +180,8 @@ Long-term, branch is where app and database relationships meet.
 - `local` is CLI context, not a branch or deploy target
 - `production` is protected and durable
 - every other named branch is preview by default
-- Public Beta does not use repo config files for Project -> Branch -> App resolution
+- Public Beta does not use committed repo config files for Project -> Branch -> App resolution
+- `.prisma/local.json` may cache Workspace and Project resolution, but Branch still comes from explicit targeting or Git and App is resolved inside the Branch
 
 ## Resolution Rules
 
@@ -200,12 +202,22 @@ as durable linking. Only `app deploy` may create projects implicitly.
 
 ### App Selection Resolution
 
-Preview app commands that need an app resolve it in this order:
+Preview app commands that need an app resolve it inside the resolved branch in
+this order:
 
 1. explicit `--app <name>`
-2. locally selected app for the resolved project
-3. interactive selection or creation in a TTY
-4. structured usage error when no app can be resolved non-interactively
+2. `PRISMA_APP_ID` when set for headless deploys
+3. locally selected app for non-deploy commands when it still exists in the resolved branch
+4. inferred app name from `package.json#name`
+5. current directory name
+6. create the inferred app service in the resolved branch when no existing app matches
+7. interactive selection only when multiple matching apps make the target ambiguous
+8. structured usage error when no app can be resolved non-interactively
+
+`.prisma/local.json` does not pin an app ID. The local pin binds the directory
+to a Workspace and Project; branches come from explicit targeting or Git, and
+apps are resolved within that branch. This avoids accidentally deploying
+feature-branch code into a service that belongs to `main`.
 
 ### Branch Context Resolution
 

--- a/packages/cli/src/commands/app/index.ts
+++ b/packages/cli/src/commands/app/index.ts
@@ -162,11 +162,17 @@ function createDeployCommand(runtime: CliRuntime): Command {
   command
     .addOption(new Option("--app <name>", "App name"))
     .addOption(new Option("--project <id-or-name>", "Project id or name"))
+    .addOption(new Option("--branch <name>", "Branch name"))
+    .addOption(
+      new Option("--framework <name>", "Framework to deploy")
+        .choices(["nextjs", "hono", "tanstack-start"]),
+    )
     .addOption(new Option("--entry <path>", "Entrypoint path for Bun or auto deploys"))
     .addOption(
-      new Option("--build-type <type>", "Deploy build type")
+      new Option("--build-type <type>", "Legacy deploy build type")
         .choices([...PREVIEW_BUILD_TYPES])
-        .default("auto"),
+        .default("auto")
+        .hideHelp(),
     )
     .addOption(new Option("--http-port <port>", "HTTP port override for the deployed app"))
     .addOption(
@@ -179,6 +185,8 @@ function createDeployCommand(runtime: CliRuntime): Command {
     const appName = (options as { app?: string }).app;
     const entry = (options as { entry?: string }).entry;
     const buildType = (options as { buildType?: string }).buildType;
+    const branchName = (options as { branch?: string }).branch;
+    const framework = (options as { framework?: string }).framework;
     const httpPort = (options as { httpPort?: string }).httpPort;
     const envAssignments = (options as { env?: string[] }).env;
     const projectRef = (options as { project?: string }).project;
@@ -189,8 +197,10 @@ function createDeployCommand(runtime: CliRuntime): Command {
       options as Record<string, unknown>,
       (context) => runAppDeploy(context, appName, {
         projectRef,
+        branchName,
         entrypoint: entry,
         buildType,
+        framework,
         httpPort,
         envAssignments,
       }),

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -265,6 +265,8 @@ export async function runAppDeploy(
   framework = customized.framework;
   runtime = customized.runtime;
 
+  // Customization can switch from a Bun-compatible framework to one that
+  // derives its entrypoint from build output, so validate --entry again after it.
   const buildType = framework.buildType;
   assertSupportedEntrypoint(buildType, options?.entrypoint, "deploy");
   const portMapping = parseDeployPortMapping(String(runtime.port));
@@ -1896,10 +1898,9 @@ async function resolveGitHeadPath(gitPath: string): Promise<string | null> {
     if (raw.startsWith(prefix)) {
       return path.join(path.resolve(path.dirname(gitPath), raw.slice(prefix.length).trim()), "HEAD");
     }
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "EISDIR" && (error as NodeJS.ErrnoException).code !== "EACCES") {
-      // ignore and try the normal directory shape below
-    }
+  } catch {
+    // Fall through to try the normal .git directory shape below.
+    // Common cases: EISDIR (normal git repo), EACCES, ENOENT.
   }
 
   try {
@@ -2023,7 +2024,7 @@ async function detectNextConfig(cwd: string): Promise<{ exists: boolean; standal
       const content = await readFile(filePath, "utf8");
       return {
         exists: true,
-        standalone: /\boutput\s*:\s*["']standalone["']/.test(content),
+        standalone: /\boutput\s*:\s*["'`]standalone["'`]/.test(content),
       };
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") {

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -1,3 +1,6 @@
+import { access, readFile } from "node:fs/promises";
+import path from "node:path";
+
 import open from "open";
 import type { PortMapping, StreamRecord } from "@prisma/compute-sdk";
 import type { ManagementApiClient } from "@prisma/management-api-sdk";
@@ -6,7 +9,7 @@ import { FileTokenStorage } from "../adapters/token-storage";
 import { authRequiredError, CliError, featureUnavailableError, usageError, workspaceRequiredError } from "../shell/errors";
 import { writeJsonEvent, type CommandSuccess } from "../shell/output";
 import { canPrompt, type CommandContext } from "../shell/runtime";
-import { textPrompt } from "../shell/prompt";
+import { confirmPrompt, selectPrompt, textPrompt } from "../shell/prompt";
 import { renderCommandHeader } from "../shell/ui";
 import type {
   AppBuildResult,
@@ -35,17 +38,16 @@ import {
   resolveLocalBuildType,
   runLocalApp,
 } from "../lib/app/local-dev";
-import { resolveProjectTarget } from "../lib/project/resolution";
+import { readBunPackageJson, type BunPackageJsonLike } from "../lib/app/bun-project";
+import { inferTargetName, resolveProjectTarget, type InferredTargetNameSource } from "../lib/project/resolution";
 import {
   executePreviewBuild,
   PREVIEW_BUILD_TYPES,
   RESOLVED_PREVIEW_BUILD_TYPES,
+  type ResolvedPreviewBuildType,
   type PreviewBuildType,
 } from "../lib/app/preview-build";
-import {
-  createPreviewDeployInteraction,
-  PREVIEW_DEFAULT_REGION,
-} from "../lib/app/preview-interaction";
+import { PREVIEW_DEFAULT_REGION } from "../lib/app/preview-interaction";
 import {
   createPreviewDeployProgress,
   createPreviewPromoteProgress,
@@ -55,6 +57,11 @@ import { createPreviewAppProvider, type PreviewAppRecord } from "../lib/app/prev
 import { requireAuthenticatedAuthState } from "./auth";
 import { listRealWorkspaceProjects } from "./project";
 import { createSelectPromptPort } from "./select-prompt-port";
+
+type DeployFramework = "nextjs" | "hono" | "tanstack-start";
+
+const DEPLOY_FRAMEWORKS = ["nextjs", "hono", "tanstack-start"] as const satisfies readonly DeployFramework[];
+const FRAMEWORK_DEFAULT_HTTP_PORT = 3000;
 
 function isRealMode(context: CommandContext): boolean {
   return !context.runtime.fixturePath && !context.runtime.env.PRISMA_CLI_MOCK_FIXTURE_PATH;
@@ -162,17 +169,29 @@ export async function runAppDeploy(
   appName: string | undefined,
   options?: {
     projectRef?: string;
+    branchName?: string;
     entrypoint?: string;
     buildType?: string;
+    framework?: string;
     httpPort?: string;
     envAssignments?: string[];
   },
 ): Promise<CommandSuccess<AppDeployResult>> {
   ensurePreviewAppMode(context);
 
-  const buildType = normalizeBuildType(options?.buildType);
-  assertSupportedEntrypoint(buildType, options?.entrypoint, "deploy");
-  const portMapping = parseDeployPortMapping(options?.httpPort);
+  const explicitBuildType = Boolean(options?.buildType && options.buildType !== "auto");
+  const inferredName = await inferTargetName(context.runtime.cwd);
+  const branch = await resolveDeployBranch(context, options?.branchName);
+  if (options?.httpPort) {
+    parseDeployHttpPort(options.httpPort);
+  }
+  let framework = await resolveDeployFramework(context, {
+    requestedFramework: options?.framework,
+    requestedBuildType: options?.buildType,
+    explicitBuildType,
+  });
+  let runtime = resolveDeployRuntime(options?.httpPort, framework);
+  assertSupportedEntrypoint(framework.buildType, options?.entrypoint, "deploy");
   const envVars = toOptionalEnvVars(
     parseEnvAssignments(options?.envAssignments, {
       commandName: "deploy",
@@ -180,9 +199,41 @@ export async function runAppDeploy(
   );
   const { provider, target, projectId } = await requireProviderAndProjectContext(context, options?.projectRef, {
     allowCreate: true,
+    branch,
   });
   const apps = await listApps(context, provider, projectId);
-  const selectedApp = await resolveDeploySelection(context, projectId, apps, appName);
+  const selectedApp = await resolveDeployAppSelection(context, projectId, apps, {
+    explicitAppName: appName,
+    inferredName,
+  });
+
+  await maybeRenderDeploySetupBlock(context, {
+    firstDeploy: selectedApp.firstDeploy,
+    workspaceName: target.workspace.name,
+    projectName: target.project.name,
+    projectAnnotation: annotationForProjectResolution(target.resolution),
+    branchName: target.branch.name,
+    branchAnnotation: branch.annotation,
+    appName: selectedApp.displayName,
+    appAnnotation: selectedApp.annotation,
+    framework,
+    runtime,
+  });
+
+  const customized = await maybeCustomizeDeploySettings(context, {
+    framework,
+    runtime,
+    firstDeploy: selectedApp.firstDeploy,
+    explicitFramework: Boolean(options?.framework),
+    explicitBuildType,
+    explicitHttpPort: Boolean(options?.httpPort),
+  });
+  framework = customized.framework;
+  runtime = customized.runtime;
+
+  const buildType = framework.buildType;
+  assertSupportedEntrypoint(buildType, options?.entrypoint, "deploy");
+  const portMapping = parseDeployPortMapping(String(runtime.port));
 
   const deployResult = await provider.deployApp({
     cwd: context.runtime.cwd,
@@ -194,7 +245,7 @@ export async function runAppDeploy(
     buildType,
     portMapping,
     envVars,
-    interaction: selectedApp.useInteractiveSelection ? createPreviewDeployInteraction(context) : undefined,
+    interaction: undefined,
     progress: createPreviewDeployProgress(context.output.stderr, !context.flags.json && !context.flags.quiet),
   }).catch((error) => {
     throw deployFailedError("App deploy failed", error, ["prisma-cli app list-deploys"]);
@@ -1024,69 +1075,166 @@ export async function runAppRemove(
   };
 }
 
-async function resolveDeploySelection(
+async function resolveDeployAppSelection(
   context: CommandContext,
   projectId: string,
   apps: PreviewAppRecord[],
-  explicitAppName: string | undefined,
+  options: {
+    explicitAppName: string | undefined;
+    inferredName: {
+      name: string;
+      source: InferredTargetNameSource;
+    };
+  },
 ): Promise<{
   appId?: string;
   appName?: string;
   region?: string;
-  useInteractiveSelection: boolean;
+  displayName: string;
+  annotation: string;
+  firstDeploy: boolean;
 }> {
-  if (explicitAppName) {
-    const matched = findAppByName(apps, explicitAppName);
+  const savedSelection = await context.stateStore.readSelectedApp(projectId);
+  const savedMatch = savedSelection
+    ? apps.find((app) => app.id === savedSelection.id) ?? findAppByName(apps, savedSelection.name)
+    : undefined;
+  const firstDeploy = !savedMatch;
 
+  if (options.explicitAppName) {
+    const matches = findAppsByName(apps, options.explicitAppName);
+    if (matches.length > 1) {
+      return resolveAmbiguousDeployApp(context, matches, options.explicitAppName, firstDeploy);
+    }
+    const matched = matches[0];
     if (matched) {
       return {
         appId: matched.id,
-        useInteractiveSelection: false,
+        displayName: matched.name,
+        annotation: "set by --app",
+        firstDeploy,
       };
     }
 
     return {
-      appName: explicitAppName,
+      appName: options.explicitAppName,
       region: PREVIEW_DEFAULT_REGION,
-      useInteractiveSelection: false,
+      displayName: options.explicitAppName,
+      annotation: "set by --app",
+      firstDeploy,
     };
   }
 
-  const savedSelection = await context.stateStore.readSelectedApp(projectId);
-  if (savedSelection) {
-    const matched = apps.find((app) => app.id === savedSelection.id) ?? findAppByName(apps, savedSelection.name);
-
-    if (matched) {
-      return {
-        appId: matched.id,
-        useInteractiveSelection: false,
-      };
-    }
-
-    if (!canPrompt(context)) {
-      throw usageError(
-        "Saved app selection is no longer available",
-        "The locally selected app could not be found in the resolved project.",
-        "Pass --app <name>, or rerun prisma-cli app deploy in a TTY to choose or create an app again.",
-        ["prisma-cli app deploy"],
-        "app",
-      );
-    }
+  if (savedMatch) {
+    return {
+      appId: savedMatch.id,
+      displayName: savedMatch.name,
+      annotation: "existing app on this branch",
+      firstDeploy,
+    };
   }
 
-  if (!canPrompt(context)) {
-    throw usageError(
-      "App deploy requires an app selection in non-interactive mode",
-      "This command cannot choose or create an app in the current mode.",
-      "Pass --app <name>, or rerun prisma-cli app deploy in a TTY to choose or create an app.",
-      ["prisma-cli app deploy --app hello-world"],
-      "app",
-    );
+  const matches = findAppsByName(apps, options.inferredName.name);
+  if (matches.length > 1) {
+    return resolveAmbiguousDeployApp(context, matches, options.inferredName.name, firstDeploy);
+  }
+
+  const matched = matches[0];
+  if (matched) {
+    return {
+      appId: matched.id,
+      displayName: matched.name,
+      annotation: "existing app on this branch",
+      firstDeploy,
+    };
   }
 
   return {
-    useInteractiveSelection: true,
+    appName: options.inferredName.name,
+    region: PREVIEW_DEFAULT_REGION,
+    displayName: options.inferredName.name,
+    annotation: options.inferredName.source === "package-name"
+      ? "created from package.json"
+      : "created from directory name",
+    firstDeploy,
   };
+}
+
+async function resolveAmbiguousDeployApp(
+  context: CommandContext,
+  matches: PreviewAppRecord[],
+  targetName: string,
+  firstDeploy: boolean,
+): Promise<{
+  appId?: string;
+  appName?: string;
+  region?: string;
+  displayName: string;
+  annotation: string;
+  firstDeploy: boolean;
+}> {
+  if (canPrompt(context)) {
+    const createNew = "__create_new_app__";
+    const cancel = "__cancel__";
+    const selected = await selectPrompt<PreviewAppRecord | typeof createNew | typeof cancel>({
+      input: context.runtime.stdin,
+      output: context.runtime.stderr,
+      message: `Multiple apps are named "${targetName}"`,
+      choices: [
+        ...sortApps(matches).map((app) => ({
+          label: `${app.name} (${app.id})`,
+          value: app,
+        })),
+        {
+          label: `Create a new app named "${targetName}"`,
+          value: createNew,
+        },
+        {
+          label: "Cancel",
+          value: cancel,
+        },
+      ],
+    });
+
+    if (selected === cancel) {
+      throw usageError(
+        "App selection canceled",
+        "The command was canceled before an app was selected.",
+        "Re-run the command and choose an app, or pass --app <name>.",
+        ["prisma-cli app deploy --app <name>"],
+        "app",
+      );
+    }
+
+    if (selected === createNew) {
+      return {
+        appName: targetName,
+        region: PREVIEW_DEFAULT_REGION,
+        displayName: targetName,
+        annotation: "created from package.json",
+        firstDeploy,
+      };
+    }
+
+    return {
+      appId: selected.id,
+      displayName: selected.name,
+      annotation: "selected by you",
+      firstDeploy,
+    };
+  }
+
+  throw new CliError({
+    code: "APP_AMBIGUOUS",
+    domain: "app",
+    summary: "App resolution is ambiguous",
+    why: `Multiple apps matched "${targetName}".`,
+    fix: "Pass --app <name> to choose the app explicitly.",
+    meta: {
+      candidates: matches.map((app) => ({ id: app.id, name: app.name })),
+    },
+    exitCode: 2,
+    nextSteps: ["prisma-cli app deploy --app <name>"],
+  });
 }
 
 async function resolveExistingAppSelection(
@@ -1405,7 +1553,10 @@ interface ResolvedAppProjectContext {
 async function requireProviderAndProjectContext(
   context: CommandContext,
   explicitProject: string | undefined,
-  options?: { allowCreate?: boolean },
+  options?: {
+    allowCreate?: boolean;
+    branch?: ResolvedDeployBranch;
+  },
 ): Promise<{
   client: ManagementApiClient;
   provider: ReturnType<typeof createPreviewAppProvider>;
@@ -1427,7 +1578,10 @@ async function resolveProjectContext(
   client: ManagementApiClient,
   provider: ReturnType<typeof createPreviewAppProvider>,
   explicitProject: string | undefined,
-  options?: { allowCreate?: boolean },
+  options?: {
+    allowCreate?: boolean;
+    branch?: ResolvedDeployBranch;
+  },
 ): Promise<ResolvedAppProjectContext> {
   const authState = await requireAuthenticatedAuthState(context);
   if (!authState.workspace) {
@@ -1459,19 +1613,465 @@ async function resolveProjectContext(
     prompt: createSelectPromptPort(context),
     remember: true,
   });
-  const branchName = await context.stateStore.read().then((state) => state.branch.active);
+  const branch = options?.branch ?? await resolveDeployBranch(context, undefined);
 
   return {
     ...resolved,
     branch: {
-      name: branchName,
-      kind: toBranchKind(branchName),
+      name: branch.name,
+      kind: toBranchKind(branch.name),
     },
   };
 }
 
 function toBranchKind(name: string): BranchKind {
-  return name === "production" ? "production" : "preview";
+  return name === "production" || name === "main" ? "production" : "preview";
+}
+
+interface ResolvedDeployBranch {
+  name: string;
+  annotation: string;
+}
+
+async function resolveDeployBranch(context: CommandContext, explicitBranchName: string | undefined): Promise<ResolvedDeployBranch> {
+  if (explicitBranchName) {
+    return {
+      name: explicitBranchName,
+      annotation: "set by --branch",
+    };
+  }
+
+  const gitBranch = await readLocalGitBranch(context.runtime.cwd);
+  if (gitBranch) {
+    return {
+      name: gitBranch,
+      annotation: "from local Git branch",
+    };
+  }
+
+  return {
+    name: "main",
+    annotation: "default",
+  };
+}
+
+async function readLocalGitBranch(cwd: string): Promise<string | null> {
+  const gitPath = path.join(cwd, ".git");
+  const headPath = await resolveGitHeadPath(gitPath);
+  if (!headPath) {
+    return null;
+  }
+
+  try {
+    const head = (await readFile(headPath, "utf8")).trim();
+    const refPrefix = "ref: refs/heads/";
+    if (head.startsWith(refPrefix)) {
+      return head.slice(refPrefix.length);
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+async function resolveGitHeadPath(gitPath: string): Promise<string | null> {
+  try {
+    const raw = await readFile(gitPath, "utf8");
+    const prefix = "gitdir:";
+    if (raw.startsWith(prefix)) {
+      return path.join(path.resolve(path.dirname(gitPath), raw.slice(prefix.length).trim()), "HEAD");
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EISDIR" && (error as NodeJS.ErrnoException).code !== "EACCES") {
+      // ignore and try the normal directory shape below
+    }
+  }
+
+  try {
+    await access(path.join(gitPath, "HEAD"));
+    return path.join(gitPath, "HEAD");
+  } catch {
+    return null;
+  }
+}
+
+interface ResolvedDeployFramework {
+  key: string;
+  buildType: ResolvedPreviewBuildType;
+  displayName: string;
+  annotation: string;
+}
+
+interface ResolvedDeployRuntime {
+  port: number;
+  annotation: string;
+}
+
+async function resolveDeployFramework(
+  context: CommandContext,
+  options: {
+    requestedFramework: string | undefined;
+    requestedBuildType: string | undefined;
+    explicitBuildType: boolean;
+  },
+): Promise<ResolvedDeployFramework> {
+  if (options.requestedFramework) {
+    return frameworkFromUserFacingValue(options.requestedFramework, "set by --framework");
+  }
+
+  if (options.explicitBuildType) {
+    const buildType = normalizeBuildType(options.requestedBuildType);
+    if (buildType !== "auto") {
+      return {
+        key: buildType,
+        buildType,
+        displayName: formatBuildTypeName(buildType),
+        annotation: "set by --build-type",
+      };
+    }
+  }
+
+  const detected = await detectDeployFramework(context.runtime.cwd);
+  if (detected) {
+    return detected;
+  }
+
+  throw frameworkNotDetectedError(context.runtime.cwd);
+}
+
+function resolveDeployRuntime(
+  requestedHttpPort: string | undefined,
+  framework: ResolvedDeployFramework,
+): ResolvedDeployRuntime {
+  if (requestedHttpPort) {
+    return {
+      port: parseDeployHttpPort(requestedHttpPort),
+      annotation: "set by --http-port",
+    };
+  }
+
+  return {
+    port: FRAMEWORK_DEFAULT_HTTP_PORT,
+    annotation: `${framework.displayName} default`,
+  };
+}
+
+async function detectDeployFramework(cwd: string): Promise<ResolvedDeployFramework | null> {
+  const packageJson = await readBunPackageJson(cwd);
+  const nextConfig = await detectNextConfig(cwd);
+
+  if (nextConfig.exists || hasPackageDependency(packageJson, "next")) {
+    return {
+      key: "nextjs",
+      buildType: "nextjs",
+      displayName: "Next.js",
+      annotation: nextConfig.standalone
+        ? "standalone output detected"
+        : nextConfig.exists
+          ? "detected from next.config"
+          : "detected from package.json",
+    };
+  }
+
+  if (hasPackageDependency(packageJson, "hono")) {
+    return {
+      key: "hono",
+      buildType: "bun",
+      displayName: "Hono",
+      annotation: "detected from package.json",
+    };
+  }
+
+  if (hasPackageDependency(packageJson, "@tanstack/start")) {
+    return {
+      key: "tanstack-start",
+      buildType: "tanstack-start",
+      displayName: "TanStack Start",
+      annotation: "detected from package.json",
+    };
+  }
+
+  return null;
+}
+
+async function detectNextConfig(cwd: string): Promise<{ exists: boolean; standalone: boolean }> {
+  const candidates = [
+    "next.config.js",
+    "next.config.mjs",
+    "next.config.cjs",
+    "next.config.ts",
+  ];
+
+  for (const candidate of candidates) {
+    const filePath = path.join(cwd, candidate);
+    try {
+      const content = await readFile(filePath, "utf8");
+      return {
+        exists: true,
+        standalone: /\boutput\s*:\s*["']standalone["']/.test(content),
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+
+  return {
+    exists: false,
+    standalone: false,
+  };
+}
+
+function hasPackageDependency(packageJson: BunPackageJsonLike | null, dependencyName: string): boolean {
+  return hasDependency(packageJson?.dependencies, dependencyName)
+    || hasDependency(packageJson?.devDependencies, dependencyName);
+}
+
+function hasDependency(dependencies: unknown, dependencyName: string): boolean {
+  return Boolean(
+    dependencies
+      && typeof dependencies === "object"
+      && dependencyName in dependencies,
+  );
+}
+
+function frameworkFromUserFacingValue(value: string, annotation: string): ResolvedDeployFramework {
+  switch (value.trim().toLowerCase()) {
+    case "next":
+    case "next.js":
+    case "nextjs":
+      return {
+        key: "nextjs",
+        buildType: "nextjs",
+        displayName: "Next.js",
+        annotation,
+      };
+    case "hono":
+      return {
+        key: "hono",
+        buildType: "bun",
+        displayName: "Hono",
+        annotation,
+      };
+    case "tanstack":
+    case "tanstack-start":
+    case "@tanstack/start":
+      return {
+        key: "tanstack-start",
+        buildType: "tanstack-start",
+        displayName: "TanStack Start",
+        annotation,
+      };
+    default:
+      throw frameworkNotDetectedError(undefined, value);
+  }
+}
+
+function frameworkNotDetectedError(cwd: string | undefined, requestedFramework?: string): CliError {
+  const supported = "Next.js, Hono, TanStack Start";
+  const directory = cwd ? ` in ${formatDeployDirectory(cwd)}` : "";
+
+  return new CliError({
+    code: "FRAMEWORK_NOT_DETECTED",
+    domain: "app",
+    summary: requestedFramework
+      ? `Unsupported framework "${requestedFramework}"`
+      : `Cannot detect a supported framework${directory}`,
+    why: `Supported Beta frameworks: ${supported}.`,
+    fix: "Add one of these frameworks as a dependency, or pass --framework <nextjs|hono|tanstack-start>.",
+    exitCode: 2,
+    nextSteps: [
+      "prisma-cli app deploy --framework nextjs",
+      "prisma-cli app deploy --framework hono",
+      "prisma-cli app deploy --framework tanstack-start",
+    ],
+  });
+}
+
+async function maybeRenderDeploySetupBlock(
+  context: CommandContext,
+  details: {
+    firstDeploy: boolean;
+    workspaceName: string;
+    projectName: string;
+    projectAnnotation: string;
+    branchName: string;
+    branchAnnotation: string;
+    appName: string;
+    appAnnotation: string;
+    framework: ResolvedDeployFramework;
+    runtime: ResolvedDeployRuntime;
+  },
+): Promise<void> {
+  if (context.flags.json || context.flags.quiet) {
+    return;
+  }
+
+  const title = `${details.firstDeploy ? "Set up" : "Deploying"} ${formatDeployDirectory(context.runtime.cwd)}`;
+  const rows = details.firstDeploy
+    ? [
+        { label: "Workspace", value: details.workspaceName },
+        { label: "Project", value: details.projectName, annotation: details.projectAnnotation },
+        { label: "Branch", value: details.branchName, annotation: details.branchAnnotation },
+        { label: "App", value: details.appName, annotation: details.appAnnotation },
+        { label: "Framework", value: details.framework.displayName, annotation: details.framework.annotation },
+        { label: "Runtime", value: `HTTP ${details.runtime.port}`, annotation: details.runtime.annotation },
+      ]
+    : [
+        { label: "Workspace", value: details.workspaceName },
+        { label: "Project", value: details.projectName },
+        { label: "Branch", value: details.branchName },
+        { label: "App", value: details.appName },
+      ];
+  const lines = details.firstDeploy
+    ? [title, "", ...renderDeploySetupRows(context, rows), ""]
+    : [title, ...renderDeploySetupRows(context, rows), ""];
+
+  context.output.stderr.write(`${lines.join("\n")}\n`);
+}
+
+async function maybeCustomizeDeploySettings(
+  context: CommandContext,
+  options: {
+    framework: ResolvedDeployFramework;
+    runtime: ResolvedDeployRuntime;
+    firstDeploy: boolean;
+    explicitFramework: boolean;
+    explicitBuildType: boolean;
+    explicitHttpPort: boolean;
+  },
+): Promise<{ framework: ResolvedDeployFramework; runtime: ResolvedDeployRuntime }> {
+  if (
+    !options.firstDeploy
+    || context.flags.yes
+    || options.explicitFramework
+    || options.explicitBuildType
+    || options.explicitHttpPort
+    || !canPrompt(context)
+  ) {
+    return {
+      framework: options.framework,
+      runtime: options.runtime,
+    };
+  }
+
+  const shouldCustomize = await confirmPrompt({
+    input: context.runtime.stdin,
+    output: context.runtime.stderr,
+    message: "Customize settings?",
+    initialValue: false,
+  });
+
+  if (!shouldCustomize) {
+    return {
+      framework: options.framework,
+      runtime: options.runtime,
+    };
+  }
+
+  const frameworkKey = await selectPrompt<DeployFramework>({
+    input: context.runtime.stdin,
+    output: context.runtime.stderr,
+    message: `Framework (${options.framework.displayName})`,
+    choices: DEPLOY_FRAMEWORKS.map((framework) => ({
+      label: frameworkDisplayName(framework),
+      value: framework,
+    })),
+  });
+  const framework = frameworkFromUserFacingValue(frameworkKey, "set by you");
+  const requestedPort = await textPrompt({
+    input: context.runtime.stdin,
+    output: context.runtime.stderr,
+    message: `HTTP port (${options.runtime.port})`,
+    placeholder: String(options.runtime.port),
+    validate: validateDeployHttpPortText,
+  });
+  const runtime = {
+    port: requestedPort.trim() ? parseDeployHttpPort(requestedPort) : options.runtime.port,
+    annotation: "set by you",
+  };
+  const changedRows = [
+    framework.key !== options.framework.key
+      ? { label: "Framework", value: framework.displayName, annotation: framework.annotation }
+      : null,
+    runtime.port !== options.runtime.port
+      ? { label: "Runtime", value: `HTTP ${runtime.port}`, annotation: runtime.annotation }
+      : null,
+  ].filter((row): row is { label: string; value: string; annotation: string } => Boolean(row));
+
+  if (changedRows.length > 0 && !context.flags.quiet && !context.flags.json) {
+    context.output.stderr.write(`${renderDeploySetupRows(context, changedRows).join("\n")}\n\n`);
+  }
+
+  return {
+    framework,
+    runtime,
+  };
+}
+
+function renderDeploySetupRows(
+  context: CommandContext,
+  rows: Array<{ label: string; value: string; annotation?: string }>,
+): string[] {
+  const labelWidth = Math.max(...rows.map((row) => row.label.length));
+  const valueWidth = Math.max(...rows.map((row) => row.value.length));
+
+  return rows.map((row) => {
+    const label = row.label.padEnd(labelWidth);
+    const value = row.value.padEnd(valueWidth);
+    const annotation = row.annotation ? `  ${context.ui.dim(row.annotation)}` : "";
+    return `  ${label}  ${value}${annotation}`.trimEnd();
+  });
+}
+
+function annotationForProjectResolution(resolution: ProjectResolution): string {
+  switch (resolution.projectSource) {
+    case "explicit":
+      return "set by --project";
+    case "created":
+      return resolution.targetNameSource === "directory-name"
+        ? "created from directory name"
+        : "created from package.json";
+    case "package-name":
+    case "directory-name":
+      return "linked to existing project";
+    case "platform-mapping":
+    case "remembered-local":
+      return "linked to existing project";
+    case "prompt":
+      return "selected by you";
+  }
+}
+
+function frameworkDisplayName(framework: DeployFramework): string {
+  switch (framework) {
+    case "nextjs":
+      return "Next.js";
+    case "hono":
+      return "Hono";
+    case "tanstack-start":
+      return "TanStack Start";
+  }
+}
+
+function validateDeployHttpPortText(value: string | undefined): string | undefined {
+  if (!value?.trim()) {
+    return undefined;
+  }
+
+  try {
+    parseDeployHttpPort(value);
+    return undefined;
+  } catch (error) {
+    return error instanceof CliError ? error.summary : String(error);
+  }
+}
+
+function formatDeployDirectory(cwd: string): string {
+  const basename = path.basename(cwd);
+  return basename ? `./${basename}` : ".";
 }
 
 async function readCurrentWorkspaceId(context: CommandContext): Promise<string | null> {
@@ -1583,6 +2183,10 @@ function parseDeployPortMapping(requestedPort: string | undefined): PortMapping 
     return undefined;
   }
 
+  return { http: parseDeployHttpPort(requestedPort) };
+}
+
+function parseDeployHttpPort(requestedPort: string): number {
   const port = Number.parseInt(requestedPort, 10);
   if (!Number.isInteger(port) || port <= 0 || port > 65535) {
     throw usageError(
@@ -1594,7 +2198,7 @@ function parseDeployPortMapping(requestedPort: string | undefined): PortMapping 
     );
   }
 
-  return { http: port };
+  return port;
 }
 
 function ensurePreviewAppMode(context: CommandContext) {
@@ -1792,6 +2396,10 @@ function isMissingProjectError(error: unknown): boolean {
 
 function findAppByName(apps: PreviewAppRecord[], name: string): PreviewAppRecord | undefined {
   return apps.find((app) => app.name === name);
+}
+
+function findAppsByName(apps: PreviewAppRecord[], name: string): PreviewAppRecord[] {
+  return apps.filter((app) => app.name === name);
 }
 
 function sortApps(apps: PreviewAppRecord[]): PreviewAppRecord[] {

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -229,13 +229,10 @@ export async function runAppDeploy(
     envProjectId,
     localPin,
   });
-  const apps = await listApps(context, provider, projectId);
+  const apps = await listApps(context, provider, projectId, target.branch.name);
   const selectedApp = await resolveDeployAppSelection(context, projectId, apps, {
     explicitAppName: appName,
     explicitAppId: envAppId,
-    pinnedAppId: localPin.kind === "present" && target.project.id === localPin.pin.projectId
-      ? localPin.pin.defaultAppId
-      : undefined,
     firstDeploy,
     inferName: () => inferTargetName(context.runtime.cwd),
   });
@@ -274,6 +271,7 @@ export async function runAppDeploy(
   const deployResult = await provider.deployApp({
     cwd: context.runtime.cwd,
     projectId,
+    branchName: target.branch.name,
     appId: selectedApp.appId,
     appName: selectedApp.appName,
     region: selectedApp.region,
@@ -297,7 +295,6 @@ export async function runAppDeploy(
     await writeLocalResolutionPin(context.runtime.cwd, {
       workspaceId: target.workspace.id,
       projectId: target.project.id,
-      defaultAppId: deployResult.app.id,
     });
     await ensureLocalResolutionPinGitignore(context.runtime.cwd);
   }
@@ -339,8 +336,8 @@ export async function runAppUpdateEnv(
     commandName: "update-env",
     requireAtLeastOne: true,
   });
-  const { provider, projectId } = await requireProviderAndProjectContext(context, projectRef);
-  const apps = await listApps(context, provider, projectId);
+  const { provider, target, projectId } = await requireProviderAndProjectContext(context, projectRef);
+  const apps = await listApps(context, provider, projectId, target.branch.name);
   const selectedApp = await resolveExistingAppSelection(context, projectId, apps, appName);
 
   if (!selectedApp) {
@@ -400,8 +397,8 @@ export async function runAppListEnv(
   ensurePreviewAppMode(context);
   emitLegacyEnvDeprecationWarning(context, "app list-env", "project env list");
 
-  const { provider, projectId } = await requireProviderAndProjectContext(context, projectRef);
-  const apps = await listApps(context, provider, projectId);
+  const { provider, target, projectId } = await requireProviderAndProjectContext(context, projectRef);
+  const apps = await listApps(context, provider, projectId, target.branch.name);
   const selectedApp = await resolveExistingAppSelection(context, projectId, apps, appName);
 
   if (!selectedApp) {
@@ -518,8 +515,8 @@ export async function runAppListDeploys(
 ): Promise<CommandSuccess<AppListDeploysResult>> {
   ensurePreviewAppMode(context);
 
-  const { provider, projectId } = await requireProviderAndProjectContext(context, projectRef);
-  const apps = await listApps(context, provider, projectId);
+  const { provider, target, projectId } = await requireProviderAndProjectContext(context, projectRef);
+  const apps = await listApps(context, provider, projectId, target.branch.name);
   const selectedApp = await resolveExistingAppSelection(context, projectId, apps, appName);
 
   if (!selectedApp) {
@@ -577,8 +574,8 @@ export async function runAppShow(
 ): Promise<CommandSuccess<AppShowResult>> {
   ensurePreviewAppMode(context);
 
-  const { provider, projectId } = await requireProviderAndProjectContext(context, projectRef);
-  const apps = await listApps(context, provider, projectId);
+  const { provider, target, projectId } = await requireProviderAndProjectContext(context, projectRef);
+  const apps = await listApps(context, provider, projectId, target.branch.name);
   const selectedApp = await resolveExistingAppSelection(context, projectId, apps, appName);
 
   if (!selectedApp) {
@@ -694,8 +691,8 @@ export async function runAppOpen(
 ): Promise<CommandSuccess<AppOpenResult>> {
   ensurePreviewAppMode(context);
 
-  const { provider, projectId } = await requireProviderAndProjectContext(context, projectRef);
-  const apps = await listApps(context, provider, projectId);
+  const { provider, target, projectId } = await requireProviderAndProjectContext(context, projectRef);
+  const apps = await listApps(context, provider, projectId, target.branch.name);
   const selectedApp = await resolveExistingAppSelection(context, projectId, apps, appName);
 
   if (!selectedApp) {
@@ -772,10 +769,10 @@ export async function runAppLogs(
 ): Promise<void> {
   ensurePreviewAppMode(context);
 
-  const { provider, projectId } = await requireProviderAndProjectContext(context, projectRef);
+  const { provider, target: resolvedTarget, projectId } = await requireProviderAndProjectContext(context, projectRef);
   const target = deploymentId
-    ? await resolveExplicitLogDeployment(context, provider, projectId, appName, deploymentId)
-    : await resolveLiveLogDeployment(context, provider, projectId, appName);
+    ? await resolveExplicitLogDeployment(context, provider, projectId, resolvedTarget.branch.name, appName, deploymentId)
+    : await resolveLiveLogDeployment(context, provider, projectId, resolvedTarget.branch.name, appName);
 
   if (!context.flags.json && !context.flags.quiet) {
     const lines = renderCommandHeader(context.ui, {
@@ -808,11 +805,12 @@ async function resolveExplicitLogDeployment(
   context: CommandContext,
   provider: ReturnType<typeof createPreviewAppProvider>,
   projectId: string,
+  branchName: string,
   appName: string | undefined,
   deploymentId: string,
 ): Promise<{ app: PreviewAppRecord; deployment: AppDeploymentSummary }> {
   if (appName) {
-    const apps = await listApps(context, provider, projectId);
+    const apps = await listApps(context, provider, projectId, branchName);
     const selectedApp = await resolveExistingAppSelection(context, projectId, apps, appName);
 
     if (!selectedApp) {
@@ -866,7 +864,7 @@ async function resolveExplicitLogDeployment(
     });
   }
 
-  const apps = await listApps(context, provider, projectId);
+  const apps = await listApps(context, provider, projectId, branchName);
   const resolvedProjectApp = apps.find((app) => app.id === shown.app?.id);
   if (!resolvedProjectApp) {
     throw new CliError({
@@ -895,9 +893,10 @@ async function resolveLiveLogDeployment(
   context: CommandContext,
   provider: ReturnType<typeof createPreviewAppProvider>,
   projectId: string,
+  branchName: string,
   appName: string | undefined,
 ): Promise<{ app: PreviewAppRecord; deployment: AppDeploymentSummary }> {
-  const apps = await listApps(context, provider, projectId);
+  const apps = await listApps(context, provider, projectId, branchName);
   const selectedApp = await resolveExistingAppSelection(context, projectId, apps, appName);
 
   if (!selectedApp) {
@@ -966,8 +965,8 @@ export async function runAppPromote(
 ): Promise<CommandSuccess<AppPromoteResult>> {
   ensurePreviewAppMode(context);
 
-  const { provider, projectId } = await requireProviderAndProjectContext(context, projectRef);
-  const apps = await listApps(context, provider, projectId);
+  const { provider, target, projectId } = await requireProviderAndProjectContext(context, projectRef);
+  const apps = await listApps(context, provider, projectId, target.branch.name);
   const selectedApp = await requireReleaseAppSelection(context, projectId, apps, appName, "promote");
   const deploymentsResult = await provider.listDeployments(selectedApp.id).catch((error) => {
     throw deployFailedError("Failed to list app deployments", error, ["prisma-cli app list-deploys"]);
@@ -1032,8 +1031,8 @@ export async function runAppRollback(
 ): Promise<CommandSuccess<AppRollbackResult>> {
   ensurePreviewAppMode(context);
 
-  const { provider, projectId } = await requireProviderAndProjectContext(context, projectRef);
-  const apps = await listApps(context, provider, projectId);
+  const { provider, target, projectId } = await requireProviderAndProjectContext(context, projectRef);
+  const apps = await listApps(context, provider, projectId, target.branch.name);
   const selectedApp = await requireReleaseAppSelection(context, projectId, apps, appName, "rollback");
   const deploymentsResult = await provider.listDeployments(selectedApp.id).catch((error) => {
     throw deployFailedError("Failed to list app deployments", error, ["prisma-cli app list-deploys"]);
@@ -1099,8 +1098,8 @@ export async function runAppRemove(
 ): Promise<CommandSuccess<AppRemoveResult>> {
   ensurePreviewAppMode(context);
 
-  const { provider, projectId } = await requireProviderAndProjectContext(context, projectRef);
-  const apps = await listApps(context, provider, projectId);
+  const { provider, target, projectId } = await requireProviderAndProjectContext(context, projectRef);
+  const apps = await listApps(context, provider, projectId, target.branch.name);
   const selectedApp = await requireReleaseAppSelection(context, projectId, apps, appName, "remove");
 
   await confirmAppRemoval(context, selectedApp);
@@ -1133,7 +1132,6 @@ async function resolveDeployAppSelection(
   options: {
     explicitAppName: string | undefined;
     explicitAppId: string | undefined;
-    pinnedAppId: string | undefined;
     firstDeploy: boolean;
     inferName: () => Promise<InferredTargetName>;
   },
@@ -1185,20 +1183,6 @@ async function resolveDeployAppSelection(
       appId: matched.id,
       displayName: matched.name,
       annotation: `from ${PRISMA_APP_ID_ENV_VAR}`,
-      firstDeploy: options.firstDeploy,
-    };
-  }
-
-  if (options.pinnedAppId) {
-    const matched = apps.find((app) => app.id === options.pinnedAppId);
-    if (!matched) {
-      throw localResolutionPinStaleError();
-    }
-
-    return {
-      appId: matched.id,
-      displayName: matched.name,
-      annotation: "from local pin",
       firstDeploy: options.firstDeploy,
     };
   }
@@ -1552,8 +1536,9 @@ async function listApps(
   context: CommandContext,
   provider: ReturnType<typeof createPreviewAppProvider>,
   projectId: string,
+  branchName?: string,
 ) {
-  return provider.listApps(projectId).then(sortApps).catch((error) => {
+  return provider.listApps(projectId, { branchName }).then(sortApps).catch((error) => {
     if (isMissingProjectError(error)) {
       throw new CliError({
         code: "PROJECT_NOT_FOUND",

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -39,7 +39,21 @@ import {
   runLocalApp,
 } from "../lib/app/local-dev";
 import { readBunPackageJson, type BunPackageJsonLike } from "../lib/app/bun-project";
-import { inferTargetName, resolveProjectTarget, type InferredTargetNameSource } from "../lib/project/resolution";
+import {
+  inferTargetName,
+  projectNotFoundError,
+  resolveProjectTarget,
+  type InferredTargetName,
+  type InferredTargetNameSource,
+  type ProjectCandidate,
+} from "../lib/project/resolution";
+import {
+  ensureLocalResolutionPinGitignore,
+  LOCAL_RESOLUTION_PIN_RELATIVE_PATH,
+  readLocalResolutionPin,
+  writeLocalResolutionPin,
+  type LocalResolutionPinReadResult,
+} from "../lib/project/local-pin";
 import {
   executePreviewBuild,
   PREVIEW_BUILD_TYPES,
@@ -62,6 +76,8 @@ type DeployFramework = "nextjs" | "hono" | "tanstack-start";
 
 const DEPLOY_FRAMEWORKS = ["nextjs", "hono", "tanstack-start"] as const satisfies readonly DeployFramework[];
 const FRAMEWORK_DEFAULT_HTTP_PORT = 3000;
+const PRISMA_PROJECT_ID_ENV_VAR = "PRISMA_PROJECT_ID";
+const PRISMA_APP_ID_ENV_VAR = "PRISMA_APP_ID";
 
 function isRealMode(context: CommandContext): boolean {
   return !context.runtime.fixturePath && !context.runtime.env.PRISMA_CLI_MOCK_FIXTURE_PATH;
@@ -179,8 +195,17 @@ export async function runAppDeploy(
 ): Promise<CommandSuccess<AppDeployResult>> {
   ensurePreviewAppMode(context);
 
+  const envProjectId = readDeployEnvOverride(context, PRISMA_PROJECT_ID_ENV_VAR);
+  const envAppId = readDeployEnvOverride(context, PRISMA_APP_ID_ENV_VAR);
+  const skipLocalPin = Boolean(envProjectId || envAppId);
+  const localPin = skipLocalPin
+    ? ({ kind: "missing" } satisfies LocalResolutionPinReadResult)
+    : await readLocalResolutionPin(context.runtime.cwd);
+  if (!skipLocalPin && localPin.kind === "invalid") {
+    throw localResolutionPinStaleError();
+  }
+
   const explicitBuildType = Boolean(options?.buildType && options.buildType !== "auto");
-  const inferredName = await inferTargetName(context.runtime.cwd);
   const branch = await resolveDeployBranch(context, options?.branchName);
   if (options?.httpPort) {
     parseDeployHttpPort(options.httpPort);
@@ -197,18 +222,27 @@ export async function runAppDeploy(
       commandName: "deploy",
     }),
   );
-  const { provider, target, projectId } = await requireProviderAndProjectContext(context, options?.projectRef, {
+  const firstDeploy = !skipLocalPin && localPin.kind === "missing";
+  const { provider, target, projectId } = await requireProviderAndDeployProjectContext(context, options?.projectRef, {
     allowCreate: true,
     branch,
+    envProjectId,
+    localPin,
   });
   const apps = await listApps(context, provider, projectId);
   const selectedApp = await resolveDeployAppSelection(context, projectId, apps, {
     explicitAppName: appName,
-    inferredName,
+    explicitAppId: envAppId,
+    pinnedAppId: localPin.kind === "present" && target.project.id === localPin.pin.projectId
+      ? localPin.pin.defaultAppId
+      : undefined,
+    firstDeploy,
+    inferName: () => inferTargetName(context.runtime.cwd),
   });
 
   await maybeRenderDeploySetupBlock(context, {
     firstDeploy: selectedApp.firstDeploy,
+    showSubsequentAnnotations: skipLocalPin,
     workspaceName: target.workspace.name,
     projectName: target.project.name,
     projectAnnotation: annotationForProjectResolution(target.resolution),
@@ -256,6 +290,15 @@ export async function runAppDeploy(
     name: deployResult.app.name,
   });
   await context.stateStore.setKnownLiveDeployment(projectId, deployResult.app.id, deployResult.deployment.id);
+  const shouldWriteLocalPin = firstDeploy && !skipLocalPin;
+  if (shouldWriteLocalPin) {
+    await writeLocalResolutionPin(context.runtime.cwd, {
+      workspaceId: target.workspace.id,
+      projectId: target.project.id,
+      defaultAppId: deployResult.app.id,
+    });
+    await ensureLocalResolutionPinGitignore(context.runtime.cwd);
+  }
 
   return {
     command: "app.deploy",
@@ -269,6 +312,12 @@ export async function runAppDeploy(
         name: deployResult.app.name,
       },
       deployment: deployResult.deployment,
+      localPin: shouldWriteLocalPin
+        ? {
+            path: LOCAL_RESOLUTION_PIN_RELATIVE_PATH,
+            written: true,
+          }
+        : undefined,
     },
     warnings: [],
     nextSteps: ["prisma-cli app list-deploys", `prisma-cli app show-deploy ${deployResult.deployment.id}`],
@@ -1081,10 +1130,10 @@ async function resolveDeployAppSelection(
   apps: PreviewAppRecord[],
   options: {
     explicitAppName: string | undefined;
-    inferredName: {
-      name: string;
-      source: InferredTargetNameSource;
-    };
+    explicitAppId: string | undefined;
+    pinnedAppId: string | undefined;
+    firstDeploy: boolean;
+    inferName: () => Promise<InferredTargetName>;
   },
 ): Promise<{
   appId?: string;
@@ -1094,16 +1143,10 @@ async function resolveDeployAppSelection(
   annotation: string;
   firstDeploy: boolean;
 }> {
-  const savedSelection = await context.stateStore.readSelectedApp(projectId);
-  const savedMatch = savedSelection
-    ? apps.find((app) => app.id === savedSelection.id) ?? findAppByName(apps, savedSelection.name)
-    : undefined;
-  const firstDeploy = !savedMatch;
-
   if (options.explicitAppName) {
     const matches = findAppsByName(apps, options.explicitAppName);
     if (matches.length > 1) {
-      return resolveAmbiguousDeployApp(context, matches, options.explicitAppName, firstDeploy);
+      return resolveAmbiguousDeployApp(context, matches, options.explicitAppName, options.firstDeploy);
     }
     const matched = matches[0];
     if (matched) {
@@ -1111,7 +1154,7 @@ async function resolveDeployAppSelection(
         appId: matched.id,
         displayName: matched.name,
         annotation: "set by --app",
-        firstDeploy,
+        firstDeploy: options.firstDeploy,
       };
     }
 
@@ -1120,22 +1163,48 @@ async function resolveDeployAppSelection(
       region: PREVIEW_DEFAULT_REGION,
       displayName: options.explicitAppName,
       annotation: "set by --app",
-      firstDeploy,
+      firstDeploy: options.firstDeploy,
     };
   }
 
-  if (savedMatch) {
+  if (options.explicitAppId) {
+    const matched = apps.find((app) => app.id === options.explicitAppId);
+    if (!matched) {
+      throw usageError(
+        "Selected app does not exist in the resolved project",
+        `The app "${options.explicitAppId}" from ${PRISMA_APP_ID_ENV_VAR} could not be found in resolved project "${projectId}".`,
+        `Unset ${PRISMA_APP_ID_ENV_VAR}, pass --app <name>, or choose an app from prisma-cli app list-deploys.`,
+        ["prisma-cli app list-deploys"],
+        "app",
+      );
+    }
+
     return {
-      appId: savedMatch.id,
-      displayName: savedMatch.name,
-      annotation: "existing app on this branch",
-      firstDeploy,
+      appId: matched.id,
+      displayName: matched.name,
+      annotation: `from ${PRISMA_APP_ID_ENV_VAR}`,
+      firstDeploy: options.firstDeploy,
     };
   }
 
-  const matches = findAppsByName(apps, options.inferredName.name);
+  if (options.pinnedAppId) {
+    const matched = apps.find((app) => app.id === options.pinnedAppId);
+    if (!matched) {
+      throw localResolutionPinStaleError();
+    }
+
+    return {
+      appId: matched.id,
+      displayName: matched.name,
+      annotation: "from local pin",
+      firstDeploy: options.firstDeploy,
+    };
+  }
+
+  const inferredName = await options.inferName();
+  const matches = findAppsByName(apps, inferredName.name);
   if (matches.length > 1) {
-    return resolveAmbiguousDeployApp(context, matches, options.inferredName.name, firstDeploy);
+    return resolveAmbiguousDeployApp(context, matches, inferredName.name, options.firstDeploy);
   }
 
   const matched = matches[0];
@@ -1144,18 +1213,18 @@ async function resolveDeployAppSelection(
       appId: matched.id,
       displayName: matched.name,
       annotation: "existing app on this branch",
-      firstDeploy,
+      firstDeploy: options.firstDeploy,
     };
   }
 
   return {
-    appName: options.inferredName.name,
+    appName: inferredName.name,
     region: PREVIEW_DEFAULT_REGION,
-    displayName: options.inferredName.name,
-    annotation: options.inferredName.source === "package-name"
+    displayName: inferredName.name,
+    annotation: inferredName.source === "package-name"
       ? "created from package.json"
       : "created from directory name",
-    firstDeploy,
+    firstDeploy: options.firstDeploy,
   };
 }
 
@@ -1573,6 +1642,31 @@ async function requireProviderAndProjectContext(
   };
 }
 
+async function requireProviderAndDeployProjectContext(
+  context: CommandContext,
+  explicitProject: string | undefined,
+  options: {
+    allowCreate?: boolean;
+    branch?: ResolvedDeployBranch;
+    envProjectId?: string;
+    localPin: LocalResolutionPinReadResult;
+  },
+): Promise<{
+  client: ManagementApiClient;
+  provider: ReturnType<typeof createPreviewAppProvider>;
+  target: ResolvedAppProjectContext;
+  projectId: string;
+}> {
+  const { client, provider } = await requirePreviewAppProviderWithClient(context);
+  const target = await resolveDeployProjectContext(context, client, provider, explicitProject, options);
+  return {
+    client,
+    provider,
+    target,
+    projectId: target.project.id,
+  };
+}
+
 async function resolveProjectContext(
   context: CommandContext,
   client: ManagementApiClient,
@@ -1621,6 +1715,126 @@ async function resolveProjectContext(
       name: branch.name,
       kind: toBranchKind(branch.name),
     },
+  };
+}
+
+async function resolveDeployProjectContext(
+  context: CommandContext,
+  client: ManagementApiClient,
+  provider: ReturnType<typeof createPreviewAppProvider>,
+  explicitProject: string | undefined,
+  options: {
+    allowCreate?: boolean;
+    branch?: ResolvedDeployBranch;
+    envProjectId?: string;
+    localPin: LocalResolutionPinReadResult;
+  },
+): Promise<ResolvedAppProjectContext> {
+  const authState = await requireAuthenticatedAuthState(context);
+  const workspace = authState.workspace;
+  if (!workspace) {
+    throw workspaceRequiredError();
+  }
+
+  const branch = options.branch ?? await resolveDeployBranch(context, undefined);
+  const projects = await listRealWorkspaceProjects(client, workspace);
+  const createProject = options.allowCreate
+    ? async (name: string) => {
+        const project = await provider.createProject({ name }).catch((error) => {
+          throw createProjectOnFirstDeployError({
+            error,
+            inferredName: name,
+            workspaceName: workspace.name,
+          });
+        });
+        return {
+          id: project.id,
+          name: project.name,
+          workspace,
+        };
+      }
+    : undefined;
+
+  if (explicitProject) {
+    const resolved = await resolveProjectTarget({
+      context,
+      workspace,
+      explicitProject,
+      listProjects: async () => projects,
+      createProject,
+      allowCreate: options.allowCreate,
+      prompt: createSelectPromptPort(context),
+      remember: true,
+    });
+    return withDeployBranch(resolved, branch);
+  }
+
+  if (options.envProjectId) {
+    const project = projects.find((candidate) => candidate.id === options.envProjectId);
+    if (!project) {
+      throw projectNotFoundError(options.envProjectId, workspace);
+    }
+    return withDeployBranch({
+      workspace,
+      project: toProjectSummary(project),
+      resolution: {
+        projectSource: "env",
+        targetName: options.envProjectId,
+        targetNameSource: "env",
+      },
+    }, branch);
+  }
+
+  if (options.localPin.kind === "present") {
+    if (options.localPin.pin.workspaceId !== workspace.id) {
+      throw localResolutionPinStaleError();
+    }
+
+    const project = projects.find((candidate) => candidate.id === options.localPin.pin.projectId);
+    if (!project) {
+      throw localResolutionPinStaleError();
+    }
+
+    return withDeployBranch({
+      workspace,
+      project: toProjectSummary(project),
+      resolution: {
+        projectSource: "local-pin",
+        targetName: project.name,
+        targetNameSource: "local-pin",
+      },
+    }, branch);
+  }
+
+  const resolved = await resolveProjectTarget({
+    context,
+    workspace,
+    listProjects: async () => projects,
+    createProject,
+    allowCreate: options.allowCreate,
+    prompt: createSelectPromptPort(context),
+    remember: true,
+  });
+  return withDeployBranch(resolved, branch);
+}
+
+function withDeployBranch(
+  target: Omit<ResolvedAppProjectContext, "branch">,
+  branch: ResolvedDeployBranch,
+): ResolvedAppProjectContext {
+  return {
+    ...target,
+    branch: {
+      name: branch.name,
+      kind: toBranchKind(branch.name),
+    },
+  };
+}
+
+function toProjectSummary(project: Pick<ProjectCandidate, "id" | "name">): ProjectSummary {
+  return {
+    id: project.id,
+    name: project.name,
   };
 }
 
@@ -1894,6 +2108,7 @@ async function maybeRenderDeploySetupBlock(
   context: CommandContext,
   details: {
     firstDeploy: boolean;
+    showSubsequentAnnotations?: boolean;
     workspaceName: string;
     projectName: string;
     projectAnnotation: string;
@@ -1921,9 +2136,9 @@ async function maybeRenderDeploySetupBlock(
       ]
     : [
         { label: "Workspace", value: details.workspaceName },
-        { label: "Project", value: details.projectName },
-        { label: "Branch", value: details.branchName },
-        { label: "App", value: details.appName },
+        { label: "Project", value: details.projectName, annotation: details.showSubsequentAnnotations ? details.projectAnnotation : undefined },
+        { label: "Branch", value: details.branchName, annotation: details.showSubsequentAnnotations ? details.branchAnnotation : undefined },
+        { label: "App", value: details.appName, annotation: details.showSubsequentAnnotations ? details.appAnnotation : undefined },
       ];
   const lines = details.firstDeploy
     ? [title, "", ...renderDeploySetupRows(context, rows), ""]
@@ -2030,6 +2245,10 @@ function annotationForProjectResolution(resolution: ProjectResolution): string {
   switch (resolution.projectSource) {
     case "explicit":
       return "set by --project";
+    case "env":
+      return `from ${PRISMA_PROJECT_ID_ENV_VAR}`;
+    case "local-pin":
+      return "from local pin";
     case "created":
       return resolution.targetNameSource === "directory-name"
         ? "created from directory name"
@@ -2226,6 +2445,26 @@ function deployFailedError(summary: string, error: unknown, nextSteps: string[])
     exitCode: 1,
     nextSteps,
   });
+}
+
+function localResolutionPinStaleError(): CliError {
+  return new CliError({
+    code: "LOCAL_STATE_STALE",
+    domain: "project",
+    summary: "Local project binding is stale",
+    why: `The target recorded in ${LOCAL_RESOLUTION_PIN_RELATIVE_PATH} is no longer available in the selected workspace.`,
+    fix: `Delete ${LOCAL_RESOLUTION_PIN_RELATIVE_PATH} and re-run to re-bootstrap.`,
+    meta: {
+      pinPath: LOCAL_RESOLUTION_PIN_RELATIVE_PATH,
+    },
+    exitCode: 1,
+    nextSteps: ["prisma-cli app deploy"],
+  });
+}
+
+function readDeployEnvOverride(context: CommandContext, name: string): string | undefined {
+  const value = context.runtime.env[name]?.trim();
+  return value ? value : undefined;
 }
 
 /**

--- a/packages/cli/src/lib/app/preview-interaction.ts
+++ b/packages/cli/src/lib/app/preview-interaction.ts
@@ -36,7 +36,6 @@ export function createPreviewDeployInteraction(context: CommandContext): DeployI
         input: context.runtime.stdin,
         output: context.runtime.stderr,
         message: "App name",
-        placeholder: "hello-world",
         validate: (value) => (!value?.trim() ? "App name is required" : undefined),
       }).then((value) => value.trim());
     },

--- a/packages/cli/src/lib/app/preview-provider.ts
+++ b/packages/cli/src/lib/app/preview-provider.ts
@@ -556,6 +556,21 @@ async function createBranchApp(
     } as never,
   });
   if (result.error || !result.data) {
+    if (result.response.status === 409) {
+      const existingApps = await listComputeServices(client, {
+        projectId: options.projectId,
+        branchGitName: options.branchName,
+      });
+      const matched = existingApps.find((app) => app.name === options.appName);
+      if (matched) {
+        return {
+          appId: matched.id,
+          appName: matched.name,
+          region: matched.region ?? options.region,
+        };
+      }
+    }
+
     throw apiCallError(`Failed to create app "${options.appName}"`, result.response, result.error);
   }
 

--- a/packages/cli/src/lib/app/preview-provider.ts
+++ b/packages/cli/src/lib/app/preview-provider.ts
@@ -12,6 +12,7 @@ export interface PreviewAppRecord {
   id: string;
   name: string;
   region: string | null;
+  branchId?: string | null;
   liveDeploymentId: string | null;
   liveUrl: string | null;
 }
@@ -58,7 +59,7 @@ export interface PreviewRemovedAppRecord {
 
 export interface PreviewAppProvider {
   createProject(options: { name: string }): Promise<PreviewProjectRecord>;
-  listApps(projectId: string): Promise<PreviewAppRecord[]>;
+  listApps(projectId: string, options?: { branchName?: string }): Promise<PreviewAppRecord[]>;
   removeApp(appId: string): Promise<PreviewRemovedAppRecord>;
   promoteDeployment(options: {
     appId: string;
@@ -68,6 +69,7 @@ export interface PreviewAppProvider {
   deployApp(options: {
     cwd: string;
     projectId: string;
+    branchName?: string;
     appId?: string;
     appName?: string;
     region?: string;
@@ -122,34 +124,11 @@ export function createPreviewAppProvider(
       };
     },
 
-    async listApps(projectId) {
-      const servicesResult = await sdk.listServices({ projectId });
-      if (servicesResult.isErr()) {
-        throw new Error(servicesResult.error.message);
-      }
-
-      const serviceDetails = await Promise.all(
-        servicesResult.value.map(async (service) => {
-          const detailResult = await sdk.showService({ serviceId: service.id });
-          return detailResult.isOk()
-            ? detailResult.value
-            : {
-                id: service.id,
-                name: service.name,
-                region: service.region,
-                latestVersionId: null,
-                serviceEndpointDomain: undefined,
-              };
-        }),
-      );
-
-      return serviceDetails.map((service) => ({
-        id: service.id,
-        name: service.name,
-        region: service.region ?? null,
-        liveDeploymentId: service.latestVersionId ?? null,
-        liveUrl: toAbsoluteUrl(service.serviceEndpointDomain ?? null),
-      }));
+    async listApps(projectId, options) {
+      return listComputeServices(client, {
+        projectId,
+        branchGitName: options?.branchName,
+      });
     },
 
     async removeApp(appId) {
@@ -190,6 +169,25 @@ export function createPreviewAppProvider(
     },
 
     async deployApp(options) {
+      const resolvedApp = options.appId
+        ? {
+            appId: options.appId,
+            appName: options.appName,
+            region: options.region,
+          }
+        : options.branchName && options.appName
+          ? await createBranchApp(client, {
+              projectId: options.projectId,
+              branchName: options.branchName,
+              appName: options.appName,
+              region: options.region,
+            })
+          : {
+              appId: undefined,
+              appName: options.appName,
+              region: options.region,
+            };
+
       const deployResult = await sdk.deploy({
         strategy: new PreviewBuildStrategy({
           appPath: path.resolve(options.cwd),
@@ -197,9 +195,9 @@ export function createPreviewAppProvider(
           buildType: options.buildType,
         }),
         projectId: options.projectId,
-        serviceId: options.appId,
-        serviceName: options.appName,
-        region: options.region,
+        serviceId: resolvedApp.appId,
+        serviceName: resolvedApp.appName,
+        region: resolvedApp.region,
         portMapping: options.portMapping,
         envVars: options.envVars,
         timeoutSeconds: 120,
@@ -409,6 +407,178 @@ export function createPreviewAppProvider(
       }
     },
   };
+}
+
+interface RawBranchRecord {
+  id: string;
+  gitName: string;
+  isDefault: boolean;
+}
+
+interface RawComputeServiceRecord {
+  id: string;
+  name: string;
+  region: {
+    id: string;
+    name?: string;
+  };
+  projectId: string;
+  branchId: string | null;
+  latestVersionId: string | null;
+  serviceEndpointDomain: string | null;
+}
+
+interface RawApiErrorBody {
+  error?: {
+    code?: string;
+    message?: string;
+    hint?: string;
+  };
+}
+
+async function listBranches(
+  client: ManagementApiClient,
+  options: {
+    projectId: string;
+    gitName: string;
+  },
+): Promise<RawBranchRecord[]> {
+  const result = await client.GET("/v1/projects/{projectId}/branches", {
+    params: {
+      path: { projectId: options.projectId },
+      query: { gitName: options.gitName },
+    },
+  });
+  if (result.error || !result.data) {
+    throw apiCallError("Failed to list branches", result.response, result.error);
+  }
+
+  return result.data.data as RawBranchRecord[];
+}
+
+async function resolveOrCreateBranch(
+  client: ManagementApiClient,
+  options: {
+    projectId: string;
+    gitName: string;
+  },
+): Promise<RawBranchRecord> {
+  const existing = (await listBranches(client, options))[0];
+  if (existing) {
+    return existing;
+  }
+
+  const result = await client.POST("/v1/projects/{projectId}/branches", {
+    params: {
+      path: { projectId: options.projectId },
+    },
+    body: {
+      gitName: options.gitName,
+      isDefault: options.gitName === "main",
+    },
+  });
+  if (result.error || !result.data) {
+    if (result.response.status === 409) {
+      const raced = (await listBranches(client, options))[0];
+      if (raced) {
+        return raced;
+      }
+    }
+
+    throw apiCallError(`Failed to create branch "${options.gitName}"`, result.response, result.error);
+  }
+
+  return result.data.data as RawBranchRecord;
+}
+
+async function listComputeServices(
+  client: ManagementApiClient,
+  options: {
+    projectId: string;
+    branchGitName?: string;
+  },
+): Promise<PreviewAppRecord[]> {
+  const services: RawComputeServiceRecord[] = [];
+  let cursor: string | undefined;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const result = await client.GET("/v1/compute-services", {
+      params: {
+        query: {
+          projectId: options.projectId,
+          branchGitName: options.branchGitName,
+          cursor,
+        },
+      },
+    });
+    if (result.error || !result.data) {
+      throw apiCallError("Failed to list apps", result.response, result.error);
+    }
+
+    services.push(...result.data.data as RawComputeServiceRecord[]);
+
+    if (!result.data.pagination.hasMore || !result.data.pagination.nextCursor) {
+      break;
+    }
+    cursor = result.data.pagination.nextCursor;
+  }
+
+  return services.map((service) => ({
+    id: service.id,
+    name: service.name,
+    region: service.region.id ?? null,
+    branchId: service.branchId,
+    liveDeploymentId: service.latestVersionId ?? null,
+    liveUrl: toAbsoluteUrl(service.serviceEndpointDomain ?? null),
+  }));
+}
+
+async function createBranchApp(
+  client: ManagementApiClient,
+  options: {
+    projectId: string;
+    branchName: string;
+    appName: string;
+    region?: string;
+  },
+): Promise<{ appId: string; appName: string; region: string | undefined }> {
+  const branch = await resolveOrCreateBranch(client, {
+    projectId: options.projectId,
+    gitName: options.branchName,
+  });
+  const result = await client.POST("/v1/compute-services", {
+    body: {
+      projectId: options.projectId,
+      branchId: branch.id,
+      displayName: options.appName,
+      ...(options.region ? { regionId: options.region } : {}),
+    } as never,
+  });
+  if (result.error || !result.data) {
+    throw apiCallError(`Failed to create app "${options.appName}"`, result.response, result.error);
+  }
+
+  const service = result.data.data as RawComputeServiceRecord;
+  return {
+    appId: service.id,
+    appName: service.name,
+    region: service.region.id ?? options.region,
+  };
+}
+
+function apiCallError(
+  summary: string,
+  response: Response,
+  error: RawApiErrorBody,
+): Error {
+  if (response.status === 404) {
+    return new Error("Resource Not Found");
+  }
+
+  const message = error.error?.message ?? `Management API returned HTTP ${response.status}.`;
+  const hint = error.error?.hint ? ` ${error.error.hint}` : "";
+  return new Error(`${summary}: ${message}${hint}`);
 }
 
 async function findAppForDeployment(

--- a/packages/cli/src/lib/project/local-pin.ts
+++ b/packages/cli/src/lib/project/local-pin.ts
@@ -1,0 +1,95 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export const LOCAL_RESOLUTION_PIN_RELATIVE_PATH = ".prisma/local.json";
+
+export interface LocalResolutionPin {
+  workspaceId: string;
+  projectId: string;
+  defaultAppId?: string;
+}
+
+export type LocalResolutionPinReadResult =
+  | { kind: "missing" }
+  | { kind: "invalid" }
+  | { kind: "present"; pin: LocalResolutionPin };
+
+export async function readLocalResolutionPin(cwd: string): Promise<LocalResolutionPinReadResult> {
+  try {
+    const raw = await readFile(path.join(cwd, LOCAL_RESOLUTION_PIN_RELATIVE_PATH), "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isLocalResolutionPin(parsed)) {
+      return { kind: "invalid" };
+    }
+
+    return {
+      kind: "present",
+      pin: parsed,
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { kind: "missing" };
+    }
+    if (error instanceof SyntaxError) {
+      return { kind: "invalid" };
+    }
+    throw error;
+  }
+}
+
+export async function writeLocalResolutionPin(
+  cwd: string,
+  pin: LocalResolutionPin,
+): Promise<void> {
+  const prismaDir = path.join(cwd, ".prisma");
+  await mkdir(prismaDir, { recursive: true });
+  const pinPath = path.join(cwd, LOCAL_RESOLUTION_PIN_RELATIVE_PATH);
+  const tmpPath = path.join(prismaDir, `local.${process.pid}.${Date.now()}.tmp`);
+  await writeFile(tmpPath, `${JSON.stringify(pin, null, 2)}\n`, "utf8");
+  await rename(tmpPath, pinPath);
+}
+
+export async function ensureLocalResolutionPinGitignore(cwd: string): Promise<void> {
+  const gitignorePath = path.join(cwd, ".gitignore");
+  let existing: string | null = null;
+
+  try {
+    existing = await readFile(gitignorePath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  if (existing === null) {
+    await writeFile(gitignorePath, ".prisma/\n", "utf8");
+    return;
+  }
+
+  const hasPrismaIgnore = existing
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .some((line) => line === ".prisma/" || line === ".prisma/local.json");
+  if (hasPrismaIgnore) {
+    return;
+  }
+
+  const next = existing.endsWith("\n") ? `${existing}.prisma/\n` : `${existing}\n.prisma/\n`;
+  await writeFile(gitignorePath, next, "utf8");
+}
+
+function isLocalResolutionPin(value: unknown): value is LocalResolutionPin {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<Record<keyof LocalResolutionPin, unknown>>;
+  return typeof candidate.workspaceId === "string"
+    && candidate.workspaceId.trim().length > 0
+    && typeof candidate.projectId === "string"
+    && candidate.projectId.trim().length > 0
+    && (
+      candidate.defaultAppId === undefined
+      || (typeof candidate.defaultAppId === "string" && candidate.defaultAppId.trim().length > 0)
+    );
+}

--- a/packages/cli/src/lib/project/local-pin.ts
+++ b/packages/cli/src/lib/project/local-pin.ts
@@ -82,6 +82,11 @@ function isLocalResolutionPin(value: unknown): value is LocalResolutionPin {
     return false;
   }
 
+  const keys = Object.keys(value);
+  if (keys.length !== 2 || !keys.includes("workspaceId") || !keys.includes("projectId")) {
+    return false;
+  }
+
   const candidate = value as Partial<Record<keyof LocalResolutionPin, unknown>>;
   return typeof candidate.workspaceId === "string"
     && candidate.workspaceId.trim().length > 0

--- a/packages/cli/src/lib/project/local-pin.ts
+++ b/packages/cli/src/lib/project/local-pin.ts
@@ -6,7 +6,6 @@ export const LOCAL_RESOLUTION_PIN_RELATIVE_PATH = ".prisma/local.json";
 export interface LocalResolutionPin {
   workspaceId: string;
   projectId: string;
-  defaultAppId?: string;
 }
 
 export type LocalResolutionPinReadResult =
@@ -87,9 +86,5 @@ function isLocalResolutionPin(value: unknown): value is LocalResolutionPin {
   return typeof candidate.workspaceId === "string"
     && candidate.workspaceId.trim().length > 0
     && typeof candidate.projectId === "string"
-    && candidate.projectId.trim().length > 0
-    && (
-      candidate.defaultAppId === undefined
-      || (typeof candidate.defaultAppId === "string" && candidate.defaultAppId.trim().length > 0)
-    );
+    && candidate.projectId.trim().length > 0;
 }

--- a/packages/cli/src/lib/project/resolution.ts
+++ b/packages/cli/src/lib/project/resolution.ts
@@ -18,6 +18,13 @@ export interface ResolvedProjectTarget {
   resolution: ProjectResolution;
 }
 
+export type InferredTargetNameSource = "package-name" | "directory-name";
+
+export interface InferredTargetName {
+  name: string;
+  source: InferredTargetNameSource;
+}
+
 export interface ResolveProjectOptions {
   context: CommandContext;
   workspace: AuthWorkspace;
@@ -31,12 +38,17 @@ export interface ResolveProjectOptions {
 
 export async function resolveProjectTarget(options: ResolveProjectOptions): Promise<ResolvedProjectTarget> {
   const projects = await options.listProjects();
+  const inferredName = await inferTargetName(options.context.runtime.cwd);
 
   if (options.explicitProject) {
     return rememberIfRequested(
       options,
       resolveExplicitProject(options.explicitProject, projects, options.workspace),
       "explicit",
+      {
+        targetName: options.explicitProject,
+        targetNameSource: "explicit",
+      },
     );
   }
 
@@ -45,40 +57,48 @@ export async function resolveProjectTarget(options: ResolveProjectOptions): Prom
     return rememberIfRequested(options, platformMapping, "platform-mapping");
   }
 
-  const remembered = await options.context.stateStore.readRememberedProject(options.workspace.id);
   let staleRemembered = false;
-  if (remembered) {
-    const matched = projects.find((project) => project.id === remembered.id);
-    if (matched) {
-      return rememberIfRequested(options, matched, "remembered-local");
+
+  if (!options.allowCreate) {
+    const rememberedResult = await resolveRememberedProject(options, projects);
+    if (rememberedResult.target) {
+      return rememberedResult.target;
     }
-    staleRemembered = true;
+    staleRemembered = rememberedResult.stale;
   }
 
-  const packageName = await readPackageName(options.context.runtime.cwd);
+  const packageName = inferredName.source === "package-name" ? inferredName.name : null;
   if (packageName) {
     const matches = projects.filter((project) => projectMatchesPackageName(project, packageName));
     if (matches.length === 1) {
-      return rememberIfRequested(options, matches[0], "package-name");
+      return rememberIfRequested(options, matches[0], "package-name", {
+        targetName: packageName,
+        targetNameSource: "package-name",
+      });
     }
     if (matches.length > 1) {
-      return resolveAmbiguousProject(options, matches, "package-name");
+      return resolveAmbiguousProject(options, matches, packageName, "package-name");
     }
   }
 
   if (options.allowCreate && options.createProject) {
-    const inferredName = packageName ?? path.basename(options.context.runtime.cwd);
-    if (inferredName) {
-      const existing = projects.filter((project) => projectMatchesPackageName(project, inferredName));
+    if (inferredName.name) {
+      const existing = projects.filter((project) => projectMatchesPackageName(project, inferredName.name));
       if (existing.length === 1) {
-        return rememberIfRequested(options, existing[0], "package-name");
+        return rememberIfRequested(options, existing[0], inferredName.source, {
+          targetName: inferredName.name,
+          targetNameSource: inferredName.source,
+        });
       }
       if (existing.length > 1) {
-        return resolveAmbiguousProject(options, existing, "package-name");
+        return resolveAmbiguousProject(options, existing, inferredName.name, inferredName.source);
       }
 
-      const created = await options.createProject(inferredName);
-      return rememberIfRequested(options, created, "created");
+      const created = await options.createProject(inferredName.name);
+      return rememberIfRequested(options, created, "created", {
+        targetName: inferredName.name,
+        targetNameSource: inferredName.source,
+      });
     }
   }
 
@@ -98,6 +118,35 @@ export async function resolveProjectTarget(options: ResolveProjectOptions): Prom
   }
 
   throw projectUnresolvedError();
+}
+
+async function resolveRememberedProject(
+  options: ResolveProjectOptions,
+  projects: ProjectCandidate[],
+): Promise<{ target: ResolvedProjectTarget | null; stale: boolean }> {
+  const remembered = await options.context.stateStore.readRememberedProject(options.workspace.id);
+  if (!remembered) {
+    return {
+      target: null,
+      stale: false,
+    };
+  }
+
+  const matched = projects.find((project) => project.id === remembered.id);
+  if (!matched) {
+    return {
+      target: null,
+      stale: true,
+    };
+  }
+
+  return {
+    target: await rememberIfRequested(options, matched, "remembered-local", {
+      targetName: remembered.name,
+      targetNameSource: "remembered-local",
+    }),
+    stale: false,
+  };
 }
 
 export function projectNotFoundError(projectRef: string, workspace: AuthWorkspace): CliError {
@@ -181,6 +230,25 @@ export async function readPackageName(cwd: string): Promise<string | null> {
   }
 }
 
+export async function inferTargetName(cwd: string): Promise<InferredTargetName> {
+  const packageName = await readPackageName(cwd);
+  if (packageName && isValidInferredTargetName(packageName)) {
+    return {
+      name: packageName,
+      source: "package-name",
+    };
+  }
+
+  return {
+    name: path.basename(cwd),
+    source: "directory-name",
+  };
+}
+
+function isValidInferredTargetName(value: string): boolean {
+  return /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(value);
+}
+
 export function sortProjects<T extends Pick<ProjectCandidate, "id" | "name">>(projects: T[]): T[] {
   return projects
     .slice()
@@ -206,6 +274,7 @@ function resolveAmbiguousProject(
   options: ResolveProjectOptions,
   matches: ProjectCandidate[],
   projectRef: string,
+  targetNameSource: InferredTargetNameSource,
 ): Promise<ResolvedProjectTarget> {
   if (options.prompt && canPrompt(options.context)) {
     return options.prompt
@@ -216,7 +285,10 @@ function resolveAmbiguousProject(
           value: project,
         })),
       })
-      .then((selected) => rememberIfRequested(options, selected, "prompt"));
+      .then((selected) => rememberIfRequested(options, selected, "prompt", {
+        targetName: projectRef,
+        targetNameSource,
+      }));
   }
 
   throw projectAmbiguousError(projectRef, matches);
@@ -234,6 +306,7 @@ async function rememberIfRequested(
   options: ResolveProjectOptions,
   project: ProjectCandidate,
   projectSource: ProjectSource,
+  resolutionDetails?: Omit<ProjectResolution, "projectSource">,
 ): Promise<ResolvedProjectTarget> {
   if (options.remember) {
     await options.context.stateStore.setRememberedProject({
@@ -248,6 +321,7 @@ async function rememberIfRequested(
     project: toProjectSummary(project),
     resolution: {
       projectSource,
+      ...resolutionDetails,
     },
   };
 }

--- a/packages/cli/src/presenters/app.ts
+++ b/packages/cli/src/presenters/app.ts
@@ -44,7 +44,7 @@ export function renderAppDeploy(
   descriptor: CommandDescriptor,
   result: AppDeployResult,
 ): string[] {
-  return renderShow(
+  const lines = renderShow(
     {
       title: "Deploying the selected app.",
       descriptor,
@@ -60,10 +60,15 @@ export function renderAppDeploy(
     },
     context.ui,
   );
+  if (result.localPin?.written) {
+    lines.push(`Bound this directory in ${result.localPin.path}. Subsequent commands target the same Project.`);
+  }
+  return lines;
 }
 
 export function serializeAppDeploy(result: AppDeployResult) {
-  return result;
+  const { localPin: _localPin, ...serialized } = result;
+  return serialized;
 }
 
 export function renderAppUpdateEnv(

--- a/packages/cli/src/presenters/project.ts
+++ b/packages/cli/src/presenters/project.ts
@@ -120,6 +120,10 @@ function formatProjectSource(source: ProjectShowResult["resolution"]["projectSou
   switch (source) {
     case "explicit":
       return "explicit";
+    case "env":
+      return "environment";
+    case "local-pin":
+      return "local pin";
     case "platform-mapping":
       return "platform mapping";
     case "remembered-local":

--- a/packages/cli/src/presenters/project.ts
+++ b/packages/cli/src/presenters/project.ts
@@ -130,6 +130,8 @@ function formatProjectSource(source: ProjectShowResult["resolution"]["projectSou
       return "remembered local context";
     case "package-name":
       return "package name";
+    case "directory-name":
+      return "directory name";
     case "created":
       return "created";
     case "prompt":

--- a/packages/cli/src/shell/command-meta.ts
+++ b/packages/cli/src/shell/command-meta.ts
@@ -62,7 +62,7 @@ const DESCRIPTORS: CommandDescriptor[] = [
     description: "Manage apps and deployments for a project",
     examples: [
       "prisma-cli app deploy",
-      "prisma-cli app deploy --app hello-world --build-type nextjs --http-port 3000",
+      "prisma-cli app deploy --app my-app --framework nextjs --http-port 3000",
     ],
   },
   {
@@ -141,9 +141,9 @@ const DESCRIPTORS: CommandDescriptor[] = [
     description: "Creates a new deployment for the app",
     examples: [
       "prisma-cli app deploy",
-      "prisma-cli app deploy --app hello-world --env DATABASE_URL=postgresql://example",
-      "prisma-cli app deploy --app hello-world --build-type nextjs --http-port 3000",
-      "prisma-cli app deploy --app hello-world --build-type nuxt",
+      "prisma-cli app deploy --app my-app --env DATABASE_URL=postgresql://example",
+      "prisma-cli app deploy --app my-app --framework nextjs --http-port 3000",
+      "prisma-cli app deploy --branch feat-login --framework hono",
     ],
   },
   {

--- a/packages/cli/src/shell/prompt.ts
+++ b/packages/cli/src/shell/prompt.ts
@@ -1,4 +1,4 @@
-import { isCancel, select, text } from "@clack/prompts";
+import { confirm, isCancel, select, text } from "@clack/prompts";
 import type { Readable, Writable } from "node:stream";
 
 import { usageError } from "./errors";
@@ -57,6 +57,30 @@ export async function textPrompt(options: {
       "Interactive prompt canceled",
       "The command was canceled before a value was entered.",
       "Re-run the command and provide a value to continue.",
+    );
+  }
+
+  return response;
+}
+
+export async function confirmPrompt(options: {
+  input: Readable;
+  output: Writable;
+  message: string;
+  initialValue?: boolean;
+}): Promise<boolean> {
+  const response = await confirm({
+    input: options.input,
+    output: options.output,
+    message: options.message,
+    initialValue: options.initialValue ?? false,
+  });
+
+  if (isCancel(response)) {
+    throw usageError(
+      "Interactive prompt canceled",
+      "The command was canceled before a confirmation was made.",
+      "Re-run the command and choose an option to continue.",
     );
   }
 

--- a/packages/cli/src/types/app.ts
+++ b/packages/cli/src/types/app.ts
@@ -29,6 +29,10 @@ export interface AppDeployResult {
     status: string;
     url: string | null;
   };
+  localPin?: {
+    path: string;
+    written: boolean;
+  };
 }
 
 export interface AppListEnvResult {

--- a/packages/cli/src/types/project.ts
+++ b/packages/cli/src/types/project.ts
@@ -10,11 +10,14 @@ export type ProjectSource =
   | "platform-mapping"
   | "remembered-local"
   | "package-name"
+  | "directory-name"
   | "created"
   | "prompt";
 
 export interface ProjectResolution {
   projectSource: ProjectSource;
+  targetName?: string | null;
+  targetNameSource?: "explicit" | "package-name" | "directory-name" | "remembered-local" | "platform-mapping" | "prompt";
 }
 
 export interface ProjectListResult {

--- a/packages/cli/src/types/project.ts
+++ b/packages/cli/src/types/project.ts
@@ -7,6 +7,8 @@ export interface ProjectSummary {
 
 export type ProjectSource =
   | "explicit"
+  | "env"
+  | "local-pin"
   | "platform-mapping"
   | "remembered-local"
   | "package-name"
@@ -17,7 +19,7 @@ export type ProjectSource =
 export interface ProjectResolution {
   projectSource: ProjectSource;
   targetName?: string | null;
-  targetNameSource?: "explicit" | "package-name" | "directory-name" | "remembered-local" | "platform-mapping" | "prompt";
+  targetNameSource?: "explicit" | "env" | "local-pin" | "package-name" | "directory-name" | "remembered-local" | "platform-mapping" | "prompt";
 }
 
 export interface ProjectListResult {

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -90,6 +90,7 @@ async function writeLocalPin(
   pin: {
     workspaceId: string;
     projectId: string;
+    // Legacy pins may still contain an app id; deploy resolution ignores it.
     defaultAppId?: string;
   } | string,
 ): Promise<void> {
@@ -342,9 +343,11 @@ describe("app controller", () => {
 
     const result = await runAppDeploy(context, undefined);
 
+    expect(listApps).toHaveBeenCalledWith("proj_my_app", { branchName: "feat-j1" });
     expect(deployApp).toHaveBeenCalledWith(
       expect.objectContaining({
         projectId: "proj_my_app",
+        branchName: "feat-j1",
         appName: "my-app",
         buildType: "nextjs",
         portMapping: { http: 3000 },
@@ -381,7 +384,6 @@ describe("app controller", () => {
     await expect(readLocalPin(cwd)).resolves.toEqual({
       workspaceId: "ws_123",
       projectId: "proj_my_app",
-      defaultAppId: "app_new",
     });
     await expect(readFile(path.join(cwd, ".gitignore"), "utf8")).resolves.toBe(".prisma/\n");
   });
@@ -562,7 +564,6 @@ describe("app controller", () => {
     await writeLocalPin(cwd, {
       workspaceId: "ws_123",
       projectId: "proj_missing",
-      defaultAppId: "app_1",
     });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
@@ -589,10 +590,24 @@ describe("app controller", () => {
     expect(deployApp).not.toHaveBeenCalled();
   });
 
-  it("returns LOCAL_STATE_STALE when the pinned app is gone", async () => {
+  it("ignores a legacy pinned app id and resolves the app inside the current branch", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
     const listApps = vi.fn().mockResolvedValue([]);
-    const deployApp = vi.fn();
+    const deployApp = vi.fn().mockImplementation(async (options: { appName?: string }) => ({
+      projectId: "proj_123",
+      app: {
+        id: "app_branch",
+        name: options.appName ?? "branch-app",
+        region: "eu-central-1",
+        liveDeploymentId: "dep_123",
+        liveUrl: "https://branch-app.prisma.app",
+      },
+      deployment: {
+        id: "dep_123",
+        status: "running",
+        url: "https://branch-app.prisma.app",
+      },
+    }));
 
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
@@ -627,13 +642,19 @@ describe("app controller", () => {
 
     await expect(runAppDeploy(context, undefined, {
       framework: "hono",
-    })).rejects.toMatchObject({
-      code: "LOCAL_STATE_STALE",
-      meta: {
-        pinPath: ".prisma/local.json",
+    })).resolves.toMatchObject({
+      result: {
+        app: {
+          id: "app_branch",
+          name: path.basename(cwd),
+        },
       },
     });
-    expect(deployApp).not.toHaveBeenCalled();
+    expect(deployApp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appName: path.basename(cwd),
+      }),
+    );
   });
 
   it("returns LOCAL_STATE_STALE when the local pin cannot be parsed", async () => {
@@ -1012,7 +1033,6 @@ describe("app controller", () => {
     await expect(readLocalPin(cwd)).resolves.toEqual({
       workspaceId: "ws_123",
       projectId: "proj_new",
-      defaultAppId: "app_new",
     });
     await expect(readFile(path.join(cwd, ".gitignore"), "utf8")).resolves.toBe(".prisma/\n");
   });
@@ -1099,7 +1119,6 @@ describe("app controller", () => {
     await expect(readLocalPin(cwd)).resolves.toEqual({
       workspaceId: "ws_123",
       projectId: "proj_new",
-      defaultAppId: "app_new",
     });
     stderr.buffer = "";
     client.GET.mockImplementation((pathName: string) => {

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -79,6 +79,25 @@ async function writePackageJson(
 async function writeGitBranch(cwd: string, branchName: string): Promise<void> {
   await mkdir(path.join(cwd, ".git"), { recursive: true });
   await writeFile(path.join(cwd, ".git", "HEAD"), `ref: refs/heads/${branchName}\n`);
+}
+
+async function readLocalPin(cwd: string): Promise<unknown> {
+  return JSON.parse(await readFile(path.join(cwd, ".prisma/local.json"), "utf8"));
+}
+
+async function writeLocalPin(
+  cwd: string,
+  pin: {
+    workspaceId: string;
+    projectId: string;
+    defaultAppId?: string;
+  } | string,
+): Promise<void> {
+  await mkdir(path.join(cwd, ".prisma"), { recursive: true });
+  await writeFile(
+    path.join(cwd, ".prisma/local.json"),
+    typeof pin === "string" ? pin : `${JSON.stringify(pin, null, 2)}\n`,
+  );
 }
 
 describe("app controller", () => {
@@ -349,12 +368,22 @@ describe("app controller", () => {
         id: "app_new",
         name: "my-app",
       },
+      localPin: {
+        path: ".prisma/local.json",
+        written: true,
+      },
     });
     expect(stderr.buffer).toContain(`Set up ./${path.basename(cwd)}`);
     expect(stderr.buffer).toContain("Project    my-app");
     expect(stderr.buffer).toContain("Branch     feat-j1");
     expect(stderr.buffer).toContain("Framework  Next.js");
     expect(stderr.buffer).toContain("Runtime    HTTP 3000");
+    await expect(readLocalPin(cwd)).resolves.toEqual({
+      workspaceId: "ws_123",
+      projectId: "proj_my_app",
+      defaultAppId: "app_new",
+    });
+    await expect(readFile(path.join(cwd, ".gitignore"), "utf8")).resolves.toBe(".prisma/\n");
   });
 
   it("lets --framework win over legacy --build-type for deploy", async () => {
@@ -417,6 +446,78 @@ describe("app controller", () => {
     );
   });
 
+  it("lets PRISMA_PROJECT_ID skip the local pin and resolve the project", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+    const listApps = vi.fn().mockResolvedValue([]);
+    const deployApp = vi.fn().mockImplementation(async (options: { appName?: string }) => ({
+      projectId: "proj_123",
+      app: {
+        id: "app_env",
+        name: options.appName ?? "env-app",
+        region: "eu-central-1",
+        liveDeploymentId: "dep_123",
+        liveUrl: "https://env-app.prisma.app",
+      },
+      deployment: {
+        id: "dep_123",
+        status: "running",
+        url: "https://env-app.prisma.app",
+      },
+    }));
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/preview-provider", () => ({
+      createPreviewAppProvider: vi.fn(() => ({
+        listApps,
+        deployApp,
+        listDeployments: vi.fn(),
+        showDeployment: vi.fn(),
+      })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runAppDeploy } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    await writeLocalPin(cwd, {
+      workspaceId: "ws_123",
+      projectId: "proj_stale",
+      defaultAppId: "app_stale",
+    });
+    const stateDir = path.join(cwd, ".state");
+    const { context, stderr } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      isTTY: false,
+      env: {
+        ...process.env,
+        PRISMA_PROJECT_ID: "proj_123",
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    const result = await runAppDeploy(context, undefined, {
+      framework: "hono",
+    });
+
+    expect(deployApp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "proj_123",
+        appName: path.basename(cwd),
+      }),
+    );
+    expect(result.result.project.id).toBe("proj_123");
+    expect(result.result.resolution.projectSource).toBe("env");
+    expect(result.result.localPin).toBeUndefined();
+    await expect(readLocalPin(cwd)).resolves.toEqual({
+      workspaceId: "ws_123",
+      projectId: "proj_stale",
+      defaultAppId: "app_stale",
+    });
+    expect(stderr.buffer).toContain("from PRISMA_PROJECT_ID");
+  });
+
   it("returns FRAMEWORK_NOT_DETECTED before deploy when framework inference fails", async () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppDeploy } = await import("../src/controllers/app");
@@ -435,6 +536,129 @@ describe("app controller", () => {
       code: "FRAMEWORK_NOT_DETECTED",
       domain: "app",
       exitCode: 2,
+    });
+  });
+
+  it("returns LOCAL_STATE_STALE when the pinned project is gone", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+    const listApps = vi.fn();
+    const deployApp = vi.fn();
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/preview-provider", () => ({
+      createPreviewAppProvider: vi.fn(() => ({
+        listApps,
+        deployApp,
+        listDeployments: vi.fn(),
+        showDeployment: vi.fn(),
+      })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runAppDeploy } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    await writeLocalPin(cwd, {
+      workspaceId: "ws_123",
+      projectId: "proj_missing",
+      defaultAppId: "app_1",
+    });
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      isTTY: false,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await expect(runAppDeploy(context, undefined, {
+      framework: "hono",
+    })).rejects.toMatchObject({
+      code: "LOCAL_STATE_STALE",
+      domain: "project",
+      meta: {
+        pinPath: ".prisma/local.json",
+      },
+      fix: "Delete .prisma/local.json and re-run to re-bootstrap.",
+    });
+    expect(listApps).not.toHaveBeenCalled();
+    expect(deployApp).not.toHaveBeenCalled();
+  });
+
+  it("returns LOCAL_STATE_STALE when the pinned app is gone", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+    const listApps = vi.fn().mockResolvedValue([]);
+    const deployApp = vi.fn();
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/preview-provider", () => ({
+      createPreviewAppProvider: vi.fn(() => ({
+        listApps,
+        deployApp,
+        listDeployments: vi.fn(),
+        showDeployment: vi.fn(),
+      })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runAppDeploy } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    await writeLocalPin(cwd, {
+      workspaceId: "ws_123",
+      projectId: "proj_123",
+      defaultAppId: "app_missing",
+    });
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      isTTY: false,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await expect(runAppDeploy(context, undefined, {
+      framework: "hono",
+    })).rejects.toMatchObject({
+      code: "LOCAL_STATE_STALE",
+      meta: {
+        pinPath: ".prisma/local.json",
+      },
+    });
+    expect(deployApp).not.toHaveBeenCalled();
+  });
+
+  it("returns LOCAL_STATE_STALE when the local pin cannot be parsed", async () => {
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runAppDeploy } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    await writeLocalPin(cwd, "{ nope");
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      isTTY: false,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await expect(runAppDeploy(context, undefined, {
+      framework: "hono",
+    })).rejects.toMatchObject({
+      code: "LOCAL_STATE_STALE",
+      meta: {
+        pinPath: ".prisma/local.json",
+      },
     });
   });
 
@@ -785,6 +1009,12 @@ describe("app controller", () => {
       name: "hello-world",
     });
     expect(result.result.project.id).toBe("proj_new");
+    await expect(readLocalPin(cwd)).resolves.toEqual({
+      workspaceId: "ws_123",
+      projectId: "proj_new",
+      defaultAppId: "app_new",
+    });
+    await expect(readFile(path.join(cwd, ".gitignore"), "utf8")).resolves.toBe(".prisma/\n");
   });
 
   it("reuses the created project on second deploy instead of creating another one", async () => {
@@ -848,7 +1078,7 @@ describe("app controller", () => {
     const { runAppDeploy } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");
-    const { context } = await createTestCommandContext({
+    const { context, stderr } = await createTestCommandContext({
       cwd,
       stateDir,
       isTTY: false,
@@ -859,9 +1089,19 @@ describe("app controller", () => {
       },
     });
 
-    await runAppDeploy(context, "hello-world", {
+    const firstResult = await runAppDeploy(context, "hello-world", {
       framework: "hono",
     });
+    expect(firstResult.result.localPin).toEqual({
+      path: ".prisma/local.json",
+      written: true,
+    });
+    await expect(readLocalPin(cwd)).resolves.toEqual({
+      workspaceId: "ws_123",
+      projectId: "proj_new",
+      defaultAppId: "app_new",
+    });
+    stderr.buffer = "";
     client.GET.mockImplementation((pathName: string) => {
       if (pathName === "/v1/projects") {
         return {
@@ -883,11 +1123,15 @@ describe("app controller", () => {
 
       throw new Error(`Unexpected path ${pathName}`);
     });
-    await runAppDeploy(context, "hello-world", {
+    const secondResult = await runAppDeploy(context, "hello-world", {
       framework: "hono",
     });
 
     expect(createProject).toHaveBeenCalledTimes(1);
+    expect(secondResult.result.localPin).toBeUndefined();
+    expect(stderr.buffer).toContain(`Deploying ./${path.basename(cwd)}`);
+    expect(stderr.buffer).not.toContain("Set up");
+    await expect(readFile(path.join(cwd, ".gitignore"), "utf8")).resolves.toBe(".prisma/\n");
     expect(deployApp).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
@@ -1062,7 +1306,7 @@ describe("app controller", () => {
     });
   });
 
-  it("reuses the saved app selection on a second deploy", async () => {
+  it("does not use saved app selection as the deploy target source", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
     const listApps = vi.fn().mockResolvedValue([
       { id: "app_1", name: "hello-world", region: "eu-west-3", liveDeploymentId: "dep_live" },
@@ -1119,7 +1363,8 @@ describe("app controller", () => {
 
     expect(deployApp).toHaveBeenCalledWith(
       expect.objectContaining({
-        appId: "app_1",
+        appId: undefined,
+        appName: path.basename(cwd),
       }),
     );
   });

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -87,12 +87,7 @@ async function readLocalPin(cwd: string): Promise<unknown> {
 
 async function writeLocalPin(
   cwd: string,
-  pin: {
-    workspaceId: string;
-    projectId: string;
-    // Legacy pins may still contain an app id; deploy resolution ignores it.
-    defaultAppId?: string;
-  } | string,
+  pin: unknown | string,
 ): Promise<void> {
   await mkdir(path.join(cwd, ".prisma"), { recursive: true });
   await writeFile(
@@ -485,7 +480,6 @@ describe("app controller", () => {
     await writeLocalPin(cwd, {
       workspaceId: "ws_123",
       projectId: "proj_stale",
-      defaultAppId: "app_stale",
     });
     const stateDir = path.join(cwd, ".state");
     const { context, stderr } = await createTestCommandContext({
@@ -515,7 +509,6 @@ describe("app controller", () => {
     await expect(readLocalPin(cwd)).resolves.toEqual({
       workspaceId: "ws_123",
       projectId: "proj_stale",
-      defaultAppId: "app_stale",
     });
     expect(stderr.buffer).toContain("from PRISMA_PROJECT_ID");
   });
@@ -590,24 +583,10 @@ describe("app controller", () => {
     expect(deployApp).not.toHaveBeenCalled();
   });
 
-  it("ignores a legacy pinned app id and resolves the app inside the current branch", async () => {
+  it("returns LOCAL_STATE_STALE when the local pin has unsupported keys", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
-    const listApps = vi.fn().mockResolvedValue([]);
-    const deployApp = vi.fn().mockImplementation(async (options: { appName?: string }) => ({
-      projectId: "proj_123",
-      app: {
-        id: "app_branch",
-        name: options.appName ?? "branch-app",
-        region: "eu-central-1",
-        liveDeploymentId: "dep_123",
-        liveUrl: "https://branch-app.prisma.app",
-      },
-      deployment: {
-        id: "dep_123",
-        status: "running",
-        url: "https://branch-app.prisma.app",
-      },
-    }));
+    const listApps = vi.fn();
+    const deployApp = vi.fn();
 
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
@@ -627,7 +606,7 @@ describe("app controller", () => {
     await writeLocalPin(cwd, {
       workspaceId: "ws_123",
       projectId: "proj_123",
-      defaultAppId: "app_missing",
+      unsupportedKey: "not-supported",
     });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
@@ -642,19 +621,14 @@ describe("app controller", () => {
 
     await expect(runAppDeploy(context, undefined, {
       framework: "hono",
-    })).resolves.toMatchObject({
-      result: {
-        app: {
-          id: "app_branch",
-          name: path.basename(cwd),
-        },
+    })).rejects.toMatchObject({
+      code: "LOCAL_STATE_STALE",
+      meta: {
+        pinPath: ".prisma/local.json",
       },
     });
-    expect(deployApp).toHaveBeenCalledWith(
-      expect.objectContaining({
-        appName: path.basename(cwd),
-      }),
-    );
+    expect(listApps).not.toHaveBeenCalled();
+    expect(deployApp).not.toHaveBeenCalled();
   });
 
   it("returns LOCAL_STATE_STALE when the local pin cannot be parsed", async () => {

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -1,3 +1,4 @@
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -64,6 +65,22 @@ function createProjectClient(projectId = "proj_123") {
   };
 }
 
+async function writePackageJson(
+  cwd: string,
+  packageJson: {
+    name?: string;
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+  },
+): Promise<void> {
+  await writeFile(path.join(cwd, "package.json"), `${JSON.stringify(packageJson, null, 2)}\n`);
+}
+
+async function writeGitBranch(cwd: string, branchName: string): Promise<void> {
+  await mkdir(path.join(cwd, ".git"), { recursive: true });
+  await writeFile(path.join(cwd, ".git", "HEAD"), `ref: refs/heads/${branchName}\n`);
+}
+
 describe("app controller", () => {
   it("deploy selects the correct existing app when --app is provided", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
@@ -111,7 +128,10 @@ describe("app controller", () => {
       },
     });
 
-    const result = await runAppDeploy(context, "hello-world");
+    const result = await runAppDeploy(context, "hello-world", {
+      projectRef: "proj_123",
+      framework: "hono",
+    });
 
     expect(deployApp).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -129,11 +149,11 @@ describe("app controller", () => {
         name: "Acme Dashboard",
       },
       branch: {
-        name: "preview",
-        kind: "preview",
+        name: "main",
+        kind: "production",
       },
       resolution: {
-        projectSource: "remembered-local",
+        projectSource: "explicit",
       },
       app: {
         id: "app_1",
@@ -203,6 +223,7 @@ describe("app controller", () => {
     });
 
     await runAppDeploy(context, "hello-world", {
+      projectRef: "proj_123",
       entrypoint: "server.ts",
       buildType: "bun",
       httpPort: "8080",
@@ -221,6 +242,251 @@ describe("app controller", () => {
         },
       }),
     );
+  });
+
+  it("infers project, branch, app, framework, and runtime for a first deploy", async () => {
+    const client = {
+      token: "token",
+      GET: vi.fn().mockImplementation((pathName: string) => {
+        if (pathName === "/v1/projects") {
+          return {
+            data: {
+              data: [
+                {
+                  id: "proj_my_app",
+                  name: "my-app",
+                  slug: "my-app",
+                  workspace: {
+                    id: "ws_123",
+                    name: "Acme Inc",
+                  },
+                },
+              ],
+            },
+          };
+        }
+
+        throw new Error(`Unexpected path ${pathName}`);
+      }),
+    };
+    const requireComputeAuth = vi.fn().mockResolvedValue(client);
+    const listApps = vi.fn().mockResolvedValue([]);
+    const deployApp = vi.fn().mockImplementation(async (options: { appName?: string }) => ({
+      projectId: "proj_my_app",
+      app: {
+        id: "app_new",
+        name: options.appName ?? "my-app",
+        region: "eu-central-1",
+        liveDeploymentId: "dep_123",
+      },
+      deployment: {
+        id: "dep_123",
+        status: "running",
+        url: "https://my-app.prisma.app",
+      },
+    }));
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/preview-provider", () => ({
+      createPreviewAppProvider: vi.fn(() => ({
+        createProject: vi.fn(),
+        listApps,
+        deployApp,
+        listDeployments: vi.fn(),
+        showDeployment: vi.fn(),
+      })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runAppDeploy } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    await writePackageJson(cwd, {
+      name: "my-app",
+      dependencies: {
+        next: "15.0.0",
+      },
+    });
+    await writeGitBranch(cwd, "feat-j1");
+    const stateDir = path.join(cwd, ".state");
+    const { context, stderr } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      isTTY: false,
+      env: {
+        ...process.env,
+        PRISMA_CLI_TEST_REMEMBER_PROJECT_ID: "",
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    const result = await runAppDeploy(context, undefined);
+
+    expect(deployApp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "proj_my_app",
+        appName: "my-app",
+        buildType: "nextjs",
+        portMapping: { http: 3000 },
+      }),
+    );
+    expect(result.result).toMatchObject({
+      project: {
+        id: "proj_my_app",
+        name: "my-app",
+      },
+      branch: {
+        name: "feat-j1",
+        kind: "preview",
+      },
+      resolution: {
+        projectSource: "package-name",
+        targetName: "my-app",
+        targetNameSource: "package-name",
+      },
+      app: {
+        id: "app_new",
+        name: "my-app",
+      },
+    });
+    expect(stderr.buffer).toContain(`Set up ./${path.basename(cwd)}`);
+    expect(stderr.buffer).toContain("Project    my-app");
+    expect(stderr.buffer).toContain("Branch     feat-j1");
+    expect(stderr.buffer).toContain("Framework  Next.js");
+    expect(stderr.buffer).toContain("Runtime    HTTP 3000");
+  });
+
+  it("lets --framework win over legacy --build-type for deploy", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+    const listApps = vi.fn().mockResolvedValue([
+      { id: "app_1", name: "hello-world", region: "eu-central-1", liveDeploymentId: null, liveUrl: null },
+    ]);
+    const deployApp = vi.fn().mockResolvedValue({
+      projectId: "proj_123",
+      app: {
+        id: "app_1",
+        name: "hello-world",
+        region: "eu-central-1",
+        liveDeploymentId: "dep_123",
+        liveUrl: "https://hello-world.prisma.app",
+      },
+      deployment: {
+        id: "dep_123",
+        status: "running",
+        url: "https://hello-world.prisma.app",
+      },
+    });
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/preview-provider", () => ({
+      createPreviewAppProvider: vi.fn(() => ({
+        listApps,
+        deployApp,
+        listDeployments: vi.fn(),
+        showDeployment: vi.fn(),
+      })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runAppDeploy } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await runAppDeploy(context, "hello-world", {
+      projectRef: "proj_123",
+      framework: "hono",
+      buildType: "nextjs",
+    });
+
+    expect(deployApp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        buildType: "bun",
+        portMapping: { http: 3000 },
+      }),
+    );
+  });
+
+  it("returns FRAMEWORK_NOT_DETECTED before deploy when framework inference fails", async () => {
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runAppDeploy } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await expect(runAppDeploy(context, "hello-world")).rejects.toMatchObject({
+      code: "FRAMEWORK_NOT_DETECTED",
+      domain: "app",
+      exitCode: 2,
+    });
+  });
+
+  it("returns APP_AMBIGUOUS for duplicate app names in non-interactive mode", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+    const listApps = vi.fn().mockResolvedValue([
+      { id: "app_1", name: "hello-world", region: "eu-central-1", liveDeploymentId: null, liveUrl: null },
+      { id: "app_2", name: "hello-world", region: "eu-central-1", liveDeploymentId: null, liveUrl: null },
+    ]);
+    const deployApp = vi.fn();
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/preview-provider", () => ({
+      createPreviewAppProvider: vi.fn(() => ({
+        listApps,
+        deployApp,
+        listDeployments: vi.fn(),
+        showDeployment: vi.fn(),
+      })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runAppDeploy } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      isTTY: false,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await expect(runAppDeploy(context, "hello-world", {
+      projectRef: "proj_123",
+      framework: "hono",
+    })).rejects.toMatchObject({
+      code: "APP_AMBIGUOUS",
+      domain: "app",
+      exitCode: 2,
+      meta: {
+        candidates: [
+          { id: "app_1", name: "hello-world" },
+          { id: "app_2", name: "hello-world" },
+        ],
+      },
+    });
+    expect(deployApp).not.toHaveBeenCalled();
   });
 
   it("rejects --entry together with --build-type nextjs for deploy", async () => {
@@ -273,11 +539,11 @@ describe("app controller", () => {
   it("interactive first deploy can create a new app when none is selected", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
     const listApps = vi.fn().mockResolvedValue([]);
-    const deployApp = vi.fn().mockResolvedValue({
+    const deployApp = vi.fn().mockImplementation(async (options: { appName?: string }) => ({
       projectId: "proj_123",
       app: {
         id: "app_new",
-        name: "hello-world",
+        name: options.appName ?? "hello-world",
         region: "eu-west-3",
         liveDeploymentId: "dep_123",
       },
@@ -286,7 +552,7 @@ describe("app controller", () => {
         status: "running",
         url: "https://hello-world.prisma.app",
       },
-    });
+    }));
 
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
@@ -314,25 +580,42 @@ describe("app controller", () => {
       },
     });
 
-    const result = await runAppDeploy(context, undefined);
+    const result = await runAppDeploy(context, undefined, {
+      projectRef: "proj_123",
+      framework: "hono",
+    });
 
     expect(deployApp).toHaveBeenCalledWith(
       expect.objectContaining({
         projectId: "proj_123",
         appId: undefined,
-        appName: undefined,
-        interaction: expect.any(Object),
+        appName: path.basename(cwd),
+        interaction: undefined,
       }),
     );
     expect(result.result.app).toEqual({
       id: "app_new",
-      name: "hello-world",
+      name: path.basename(cwd),
     });
   });
 
-  it("returns USAGE_ERROR for deploy without app selection in non-interactive mode", async () => {
+  it("auto-creates the inferred app without prompting in non-interactive mode", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
     const listApps = vi.fn().mockResolvedValue([]);
+    const deployApp = vi.fn().mockImplementation(async (options: { appName?: string }) => ({
+      projectId: "proj_123",
+      app: {
+        id: "app_new",
+        name: options.appName ?? "created-app",
+        region: "eu-central-1",
+        liveDeploymentId: "dep_123",
+      },
+      deployment: {
+        id: "dep_123",
+        status: "running",
+        url: "https://created-app.prisma.app",
+      },
+    }));
 
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
@@ -340,7 +623,7 @@ describe("app controller", () => {
     vi.doMock("../src/lib/app/preview-provider", () => ({
       createPreviewAppProvider: vi.fn(() => ({
         listApps,
-        deployApp: vi.fn(),
+        deployApp,
         listDeployments: vi.fn(),
         showDeployment: vi.fn(),
       })),
@@ -360,11 +643,17 @@ describe("app controller", () => {
       },
     });
 
-    await expect(runAppDeploy(context, undefined)).rejects.toMatchObject({
-      code: "USAGE_ERROR",
-      domain: "app",
-      summary: "App deploy requires an app selection in non-interactive mode",
+    await runAppDeploy(context, undefined, {
+      projectRef: "proj_123",
+      framework: "hono",
     });
+
+    expect(deployApp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appName: path.basename(cwd),
+        interaction: undefined,
+      }),
+    );
   });
 
   it("creates a named new app with the default Frankfurt region in non-interactive mode", async () => {
@@ -411,7 +700,10 @@ describe("app controller", () => {
       },
     });
 
-    await runAppDeploy(context, "hello-world");
+    await runAppDeploy(context, "hello-world", {
+      projectRef: "proj_123",
+      framework: "hono",
+    });
 
     expect(deployApp).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -426,10 +718,10 @@ describe("app controller", () => {
 
   it("creates a project before first deploy when none is resolved", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
-    const createProject = vi.fn().mockResolvedValue({
+    const createProject = vi.fn(async (options: { name: string }) => ({
       id: "proj_new",
-      name: "next-smoke",
-    });
+      name: options.name,
+    }));
     const listApps = vi.fn().mockResolvedValue([]);
     const deployApp = vi.fn().mockResolvedValue({
       projectId: "proj_new",
@@ -474,7 +766,9 @@ describe("app controller", () => {
       },
     });
 
-    const result = await runAppDeploy(context, "hello-world");
+    const result = await runAppDeploy(context, "hello-world", {
+      framework: "hono",
+    });
 
     expect(createProject).toHaveBeenCalledWith({
       name: path.basename(cwd),
@@ -565,7 +859,9 @@ describe("app controller", () => {
       },
     });
 
-    await runAppDeploy(context, "hello-world");
+    await runAppDeploy(context, "hello-world", {
+      framework: "hono",
+    });
     client.GET.mockImplementation((pathName: string) => {
       if (pathName === "/v1/projects") {
         return {
@@ -573,8 +869,8 @@ describe("app controller", () => {
             data: [
               {
                 id: "proj_new",
-                name: "next-smoke",
-                slug: "next-smoke",
+                name: path.basename(cwd),
+                slug: path.basename(cwd),
                 workspace: {
                   id: "ws_123",
                   name: "Acme Inc",
@@ -587,7 +883,9 @@ describe("app controller", () => {
 
       throw new Error(`Unexpected path ${pathName}`);
     });
-    await runAppDeploy(context, "hello-world");
+    await runAppDeploy(context, "hello-world", {
+      framework: "hono",
+    });
 
     expect(createProject).toHaveBeenCalledTimes(1);
     expect(deployApp).toHaveBeenNthCalledWith(
@@ -648,7 +946,9 @@ describe("app controller", () => {
       },
     });
 
-    await expect(runAppDeploy(context, "hello-world")).resolves.toMatchObject({
+    await expect(runAppDeploy(context, "hello-world", {
+      framework: "hono",
+    })).resolves.toMatchObject({
       result: {
         project: {
           id: "proj_new",
@@ -702,7 +1002,9 @@ describe("app controller", () => {
       },
     });
 
-    await expect(runAppDeploy(context, "hello-world")).rejects.toMatchObject({
+    await expect(runAppDeploy(context, "hello-world", {
+      framework: "hono",
+    })).rejects.toMatchObject({
       code: "AUTH_FORBIDDEN",
       domain: "auth",
       summary: "Could not create a new project for this deploy",
@@ -748,7 +1050,9 @@ describe("app controller", () => {
       },
     });
 
-    await expect(runAppDeploy(context, "hello-world")).rejects.toMatchObject({
+    await expect(runAppDeploy(context, "hello-world", {
+      framework: "hono",
+    })).rejects.toMatchObject({
       code: "DEPLOY_FAILED",
       domain: "app",
       summary: "Could not create a new project for this deploy",
@@ -808,7 +1112,10 @@ describe("app controller", () => {
       name: "hello-world",
     });
 
-    await runAppDeploy(context, undefined);
+    await runAppDeploy(context, undefined, {
+      projectRef: "proj_123",
+      framework: "hono",
+    });
 
     expect(deployApp).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -887,7 +1194,6 @@ describe("app controller", () => {
     vi.doMock("../src/lib/app/preview-provider", () => ({
       createPreviewAppProvider: vi.fn(() => ({
         listApps,
-        deployApp: vi.fn(),
         listDeployments: vi.fn(),
         showDeployment: vi.fn(),
       })),
@@ -2091,6 +2397,20 @@ describe("app controller", () => {
   it("does not reuse the wrong saved app when the resolved project changes", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient("proj_456"));
     const listApps = vi.fn().mockResolvedValue([]);
+    const deployApp = vi.fn().mockImplementation(async (options: { appName?: string }) => ({
+      projectId: "proj_456",
+      app: {
+        id: "app_new",
+        name: options.appName ?? "created-app",
+        region: "eu-central-1",
+        liveDeploymentId: "dep_123",
+      },
+      deployment: {
+        id: "dep_123",
+        status: "running",
+        url: "https://created-app.prisma.app",
+      },
+    }));
 
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
@@ -2098,7 +2418,7 @@ describe("app controller", () => {
     vi.doMock("../src/lib/app/preview-provider", () => ({
       createPreviewAppProvider: vi.fn(() => ({
         listApps,
-        deployApp: vi.fn(),
+        deployApp,
         listDeployments: vi.fn(),
         showDeployment: vi.fn(),
       })),
@@ -2125,11 +2445,17 @@ describe("app controller", () => {
       name: "hello-world",
     });
 
-    await expect(runAppDeploy(context, undefined)).rejects.toMatchObject({
-      code: "USAGE_ERROR",
-      domain: "app",
-      summary: "App deploy requires an app selection in non-interactive mode",
+    await runAppDeploy(context, undefined, {
+      projectRef: "proj_456",
+      framework: "hono",
     });
+
+    expect(deployApp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "proj_456",
+        appName: path.basename(cwd),
+      }),
+    );
   });
 
   it("logs streams the live deployment for the selected app", async () => {

--- a/packages/cli/tests/app-env-vars.test.ts
+++ b/packages/cli/tests/app-env-vars.test.ts
@@ -183,6 +183,8 @@ describe("app env vars", () => {
       context,
       "hello-world",
       {
+        projectRef: "proj_123",
+        framework: "hono",
         envAssignments: ["DATABASE_URL=postgresql://example", "FEATURE_FLAG=enabled", "EMPTY="],
       },
     );

--- a/packages/cli/tests/app-provider.test.ts
+++ b/packages/cli/tests/app-provider.test.ts
@@ -63,4 +63,124 @@ describe("preview app provider", () => {
       }),
     );
   });
+
+  it("creates a branch-scoped service before deploying a new branch app", async () => {
+    const deploy = vi.fn().mockResolvedValue({
+      isErr: () => false,
+      isOk: () => true,
+      value: {
+        projectId: "proj_123",
+        serviceId: "svc_branch",
+        serviceName: "hello-world",
+        region: "eu-central-1",
+        versionId: "dep_123",
+        versionEndpointDomain: "cv-123.fra.prisma.build",
+        serviceEndpointDomain: "hello-world.fra.prisma.build",
+      },
+    });
+    const PreviewBuildStrategy = vi.fn().mockImplementation((options: object) => ({ options }));
+    const client = {
+      GET: vi.fn().mockResolvedValue({
+        data: {
+          data: [],
+          pagination: { hasMore: false, nextCursor: null },
+        },
+        response: { status: 200 },
+      }),
+      POST: vi.fn().mockImplementation((pathName: string) => {
+        if (pathName === "/v1/projects/{projectId}/branches") {
+          return {
+            data: {
+              data: {
+                id: "br_billing",
+                gitName: "feat/billing",
+                isDefault: false,
+              },
+            },
+            response: { status: 201 },
+          };
+        }
+
+        if (pathName === "/v1/compute-services") {
+          return {
+            data: {
+              data: {
+                id: "svc_branch",
+                name: "hello-world",
+                region: { id: "eu-central-1", name: "Europe (Frankfurt)" },
+                projectId: "proj_123",
+                branchId: "br_billing",
+                latestVersionId: null,
+                serviceEndpointDomain: "hello-world.fra.prisma.build",
+              },
+            },
+            response: { status: 201 },
+          };
+        }
+
+        throw new Error(`Unexpected path ${pathName}`);
+      }),
+    };
+
+    vi.doMock("../src/lib/app/preview-build", () => ({
+      PreviewBuildStrategy,
+    }));
+    vi.doMock("@prisma/compute-sdk", () => ({
+      ApiError: { is: () => false },
+      ComputeClient: class {
+        deploy = deploy;
+      },
+    }));
+
+    const { createPreviewAppProvider } = await import("../src/lib/app/preview-provider");
+
+    const provider = createPreviewAppProvider(client as never);
+    const cwd = path.resolve("/tmp/next-smoke");
+
+    await provider.deployApp({
+      cwd,
+      projectId: "proj_123",
+      branchName: "feat/billing",
+      appName: "hello-world",
+      buildType: "nextjs",
+      portMapping: { http: 3000 },
+    });
+
+    expect(client.GET).toHaveBeenCalledWith(
+      "/v1/projects/{projectId}/branches",
+      expect.objectContaining({
+        params: {
+          path: { projectId: "proj_123" },
+          query: { gitName: "feat/billing" },
+        },
+      }),
+    );
+    expect(client.POST).toHaveBeenCalledWith(
+      "/v1/projects/{projectId}/branches",
+      expect.objectContaining({
+        body: {
+          gitName: "feat/billing",
+          isDefault: false,
+        },
+      }),
+    );
+    expect(client.POST).toHaveBeenCalledWith(
+      "/v1/compute-services",
+      expect.objectContaining({
+        body: {
+          projectId: "proj_123",
+          branchId: "br_billing",
+          displayName: "hello-world",
+        },
+      }),
+    );
+    expect(deploy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "proj_123",
+        serviceId: "svc_branch",
+        serviceName: "hello-world",
+        portMapping: { http: 3000 },
+      }),
+    );
+  });
 });

--- a/packages/cli/tests/app-provider.test.ts
+++ b/packages/cli/tests/app-provider.test.ts
@@ -183,4 +183,128 @@ describe("preview app provider", () => {
       }),
     );
   });
+
+  it("uses an existing branch-scoped service when app creation races", async () => {
+    const deploy = vi.fn().mockResolvedValue({
+      isErr: () => false,
+      isOk: () => true,
+      value: {
+        projectId: "proj_123",
+        serviceId: "svc_branch",
+        serviceName: "hello-world",
+        region: "eu-central-1",
+        versionId: "dep_123",
+        versionEndpointDomain: "cv-123.fra.prisma.build",
+        serviceEndpointDomain: "hello-world.fra.prisma.build",
+      },
+    });
+    const PreviewBuildStrategy = vi.fn().mockImplementation((options: object) => ({ options }));
+    const client = {
+      GET: vi.fn().mockImplementation((pathName: string) => {
+        if (pathName === "/v1/projects/{projectId}/branches") {
+          return {
+            data: {
+              data: [{
+                id: "br_billing",
+                gitName: "feat/billing",
+                isDefault: false,
+              }],
+              pagination: { hasMore: false, nextCursor: null },
+            },
+            response: { status: 200 },
+          };
+        }
+
+        if (pathName === "/v1/compute-services") {
+          return {
+            data: {
+              data: [{
+                id: "svc_branch",
+                name: "hello-world",
+                region: { id: "eu-central-1", name: "Europe (Frankfurt)" },
+                projectId: "proj_123",
+                branchId: "br_billing",
+                latestVersionId: null,
+                serviceEndpointDomain: "hello-world.fra.prisma.build",
+              }],
+              pagination: { hasMore: false, nextCursor: null },
+            },
+            response: { status: 200 },
+          };
+        }
+
+        throw new Error(`Unexpected path ${pathName}`);
+      }),
+      POST: vi.fn().mockImplementation((pathName: string) => {
+        if (pathName === "/v1/compute-services") {
+          return {
+            error: {
+              error: {
+                code: "CONFLICT",
+                message: "Compute service already exists.",
+              },
+            },
+            response: { status: 409 },
+          };
+        }
+
+        throw new Error(`Unexpected path ${pathName}`);
+      }),
+    };
+
+    vi.doMock("../src/lib/app/preview-build", () => ({
+      PreviewBuildStrategy,
+    }));
+    vi.doMock("@prisma/compute-sdk", () => ({
+      ApiError: { is: () => false },
+      ComputeClient: class {
+        deploy = deploy;
+      },
+    }));
+
+    const { createPreviewAppProvider } = await import("../src/lib/app/preview-provider");
+
+    const provider = createPreviewAppProvider(client as never);
+    const cwd = path.resolve("/tmp/next-smoke");
+
+    await provider.deployApp({
+      cwd,
+      projectId: "proj_123",
+      branchName: "feat/billing",
+      appName: "hello-world",
+      buildType: "nextjs",
+      portMapping: { http: 3000 },
+    });
+
+    expect(client.POST).toHaveBeenCalledWith(
+      "/v1/compute-services",
+      expect.objectContaining({
+        body: {
+          projectId: "proj_123",
+          branchId: "br_billing",
+          displayName: "hello-world",
+        },
+      }),
+    );
+    expect(client.GET).toHaveBeenCalledWith(
+      "/v1/compute-services",
+      expect.objectContaining({
+        params: {
+          query: {
+            projectId: "proj_123",
+            branchGitName: "feat/billing",
+            cursor: undefined,
+          },
+        },
+      }),
+    );
+    expect(deploy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "proj_123",
+        serviceId: "svc_branch",
+        serviceName: "hello-world",
+        portMapping: { http: 3000 },
+      }),
+    );
+  });
 });

--- a/packages/cli/tests/app.test.ts
+++ b/packages/cli/tests/app.test.ts
@@ -108,7 +108,7 @@ describe("app commands", () => {
     expect(appHelp.exitCode).toBe(0);
     expect(appHelp.stderr).toContain("Manage apps and deployments for a project");
     expect(appHelp.stderr).toContain("$ prisma-cli app deploy");
-    expect(appHelp.stderr).toContain("$ prisma-cli app deploy --app hello-world --build-type nextjs --http-port 3000");
+    expect(appHelp.stderr).toContain("$ prisma-cli app deploy --app my-app --framework nextjs --http-port 3000");
 
     expect(buildHelp.exitCode).toBe(0);
     expect(buildHelp.stderr).toContain("Build the app locally into a deployable artifact");
@@ -121,9 +121,10 @@ describe("app commands", () => {
     expect(deployHelp.exitCode).toBe(0);
     expect(deployHelp.stderr).toContain("Creates a new deployment for the app");
     expect(deployHelp.stderr).toContain("$ prisma-cli app deploy");
-    expect(deployHelp.stderr).toContain("$ prisma-cli app deploy --app hello-world --build-type nextjs --http-port 3000");
+    expect(deployHelp.stderr).toContain("$ prisma-cli app deploy --app my-app --framework nextjs --http-port 3000");
     expect(deployHelp.stderr).toContain("--entry <path>");
-    expect(deployHelp.stderr).toContain("--build-type <type>");
+    expect(deployHelp.stderr).toContain("--framework <name>");
+    expect(deployHelp.stderr).not.toContain("--build-type <type>");
     expect(deployHelp.stderr).toContain("--http-port <port>");
     expect(deployHelp.stderr).toContain("--env <name=value>");
 

--- a/packages/cli/tests/project.test.ts
+++ b/packages/cli/tests/project.test.ts
@@ -123,6 +123,8 @@ describe("project commands", () => {
         },
         resolution: {
           projectSource: "package-name",
+          targetName: "billing-api",
+          targetNameSource: "package-name",
         },
       },
       warnings: [],


### PR DESCRIPTION
## Summary
- Add the J1 deploy setup flow: infer Project, Branch, App, Framework, and Runtime before deploy.
- Skip first-deploy app prompts when there is no real choice, and create the inferred app directly.
- Add `--framework` / `--branch`, keep `--build-type` as legacy passthrough, and default runtime HTTP port to `3000`.
- Update product docs and tests for the new deploy contract.
---
Adds the J1 local resolution pin model for app deploy.

- Writes `.prisma/local.json` after the first successful deploy.
- Reads and validates the pin on later deploys.
- Supports `PRISMA_PROJECT_ID` / `PRISMA_APP_ID` env overrides.
- Adds `LOCAL_STATE_STALE` when the local pin points at deleted/inaccessible platform state.
- Auto-ignores `.prisma/` for the per-user local pin.

## Linear
- [PRO-177](https://linear.app/prisma-company/issue/PRO-177/dont-prompt-when-theres-nothing-to-choose)
- [PRO-178](https://linear.app/prisma-company/issue/PRO-178/show-an-inference-visible-target-table-on-first-deploy)
- [PRO-179](https://linear.app/prisma-company/issue/PRO-179/detect-framework-ask-before-customizing)
- [PRO-180](https://linear.app/prisma-company/issue/PRO-180/default-app-name-from-packagejson-not-hello-world)

## Verification
- `pnpm --filter @prisma/cli build`
- `pnpm --filter @prisma/cli test`