### PR TITLE
Improve deploy status and retry UX

### DIFF
--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -507,7 +507,7 @@ Behavior:
 - asks `Customize settings? (y/N)` only while binding the directory for the first time, and only asks for Framework and HTTP port when the user opts in
 - subsequent deploys print a compact target header such as `Deploying ./j1 to j1 / main / j1`
 - deploy progress uses short stage copy (`Building locally...`, `Built <size>`, `Uploading...`, `Uploaded`, `Deploying...`, `Deployed`) and never prints `Status: running` or `Deployment is running at ...`
-- success human output prints `Live in <duration>`, the URL on its own line, and `Logs   prisma app logs`
+- success human output prints `Live in <duration>`, the URL on its own line, and `Logs   prisma-cli app logs`
 - accepts repeated `--env NAME=VALUE` flags
 - maps user-facing framework names to deploy build strategies
 - accepts `--build-type <auto|bun|nextjs|nuxt|astro|tanstack-start>` as a legacy passthrough, but `--framework` wins when both are passed

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -502,13 +502,17 @@ Behavior:
 - resolves or creates branch context from `--branch`, local Git branch, or `main`
 - resolves or creates app context inside the resolved branch from `--app`, `PRISMA_APP_ID`, `package.json#name`, or current directory name
 - does not prompt when there is no real choice; zero matching apps creates the inferred app
-- detects supported frameworks and shows the resolved framework/runtime settings before deploy
-- asks `Customize settings? (y/N)` only in interactive first-deploy flows, and only asks for Framework and HTTP port when the user opts in
+- detects supported frameworks and shows the resolved framework/runtime settings only while binding the directory for the first time
+- writes `.prisma/local.json` after Project binding succeeds and before build/deploy starts, so retries after a failed deploy do not repeat setup
+- asks `Customize settings? (y/N)` only while binding the directory for the first time, and only asks for Framework and HTTP port when the user opts in
+- subsequent deploys print a compact target header such as `Deploying ./j1 to j1 / main / j1`
+- deploy progress uses phase copy (`Building locally`, `Packaging artifact`, `Uploading`, `Starting deployment`, `Checking runtime health`) and never prints `Status: running` or `Deployment is running at ...`
+- success human output prints `Deployed to <url>` and `Runtime logs: prisma app logs`
 - accepts repeated `--env NAME=VALUE` flags
 - maps user-facing framework names to deploy build strategies
 - accepts `--build-type <auto|bun|nextjs|nuxt|astro|tanstack-start>` as a legacy passthrough, but `--framework` wins when both are passed
 - does not print secret values
-- returns app, deployment id, URL, and next steps
+- returns app, deployment id, URL, and next steps in `--json` output
 
 Examples:
 

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -506,8 +506,8 @@ Behavior:
 - writes `.prisma/local.json` after Project binding succeeds and before build/deploy starts, so retries after a failed deploy do not repeat setup
 - asks `Customize settings? (y/N)` only while binding the directory for the first time, and only asks for Framework and HTTP port when the user opts in
 - subsequent deploys print a compact target header such as `Deploying ./j1 to j1 / main / j1`
-- deploy progress uses phase copy (`Building locally`, `Packaging artifact`, `Uploading`, `Starting deployment`, `Checking runtime health`) and never prints `Status: running` or `Deployment is running at ...`
-- success human output prints `Deployed to <url>` and `Runtime logs: prisma app logs`
+- deploy progress uses short stage copy (`Building locally...`, `Built <size>`, `Uploading...`, `Uploaded`, `Deploying...`, `Deployed`) and never prints `Status: running` or `Deployment is running at ...`
+- success human output prints `Live in <duration>`, the URL on its own line, and `Logs   prisma app logs`
 - accepts repeated `--env NAME=VALUE` flags
 - maps user-facing framework names to deploy build strategies
 - accepts `--build-type <auto|bun|nextjs|nuxt|astro|tanstack-start>` as a legacy passthrough, but `--framework` wins when both are passed

--- a/docs/product/error-conventions.md
+++ b/docs/product/error-conventions.md
@@ -114,6 +114,10 @@ Deployment:  https://cv-... (unhealthy)
 Runtime logs: prisma app logs --deployment <id>
 ```
 
+If the failure happens after the local build but before the runtime is live, use
+`Deploy failed after the build completed.` as the headline and keep `Runtime:
+not started`.
+
 ## JSON Error Shape
 
 Commands run with `--json` should emit this envelope on failure:

--- a/docs/product/error-conventions.md
+++ b/docs/product/error-conventions.md
@@ -89,16 +89,29 @@ Human-readable errors should follow this shape:
 Example:
 
 ```text
-✘ Deployment failed during build [BUILD_FAILED]
-Branch: preview
-Why: Next.js build returned a non-zero exit code
-Fix: Inspect logs and redeploy after fixing the build
+Build failed locally.
 
-More: Re-run with --trace for deeper diagnostics
+Build:    failed
+Deploy:   not started
+Runtime:  not started
+URL:      not promoted
 
-Next steps:
-- prisma-cli app logs
-- fix the issue and rerun prisma-cli app deploy
+Why: next build exited with code 1
+Fix: Inspect the build output above, fix the error, and redeploy.
+```
+
+Runtime failures after build should distinguish local build success from deployed
+runtime failure and point to runtime logs:
+
+```text
+Runtime failed after the build completed.
+
+Build:       passed locally
+Deploy:      artifact uploaded, container started
+Runtime:     failed health check
+Deployment:  https://cv-... (unhealthy)
+
+Runtime logs: prisma app logs --deployment <id>
 ```
 
 ## JSON Error Shape

--- a/docs/product/error-conventions.md
+++ b/docs/product/error-conventions.md
@@ -91,32 +91,27 @@ Example:
 ```text
 Build failed locally.
 
-Build:    failed
-Deploy:   not started
-Runtime:  not started
-URL:      not promoted
+✗ Built       next build exited with code 1
 
-Why: next build exited with code 1
 Fix: Inspect the build output above, fix the error, and redeploy.
 ```
 
-Runtime failures after build should distinguish local build success from deployed
-runtime failure and point to runtime logs:
+If the deployment starts but the app is not ready yet, list the deployment URL
+and point to runtime logs without claiming a health-check result until the
+platform exposes one:
 
 ```text
-Runtime failed after the build completed.
+The deployment started, but the app is not ready yet.
 
-Build:       passed locally
-Deploy:      artifact uploaded, container started
-Runtime:     failed health check
-Deployment:  https://cv-... (unhealthy)
+This is usually a missing env var, a failed DB connection,
+or a crash on startup.
 
-Runtime logs: prisma app logs --deployment <id>
+See what happened
+prisma app logs --deployment <id>
+
+URL
+https://cv-...
 ```
-
-If the failure happens after the local build but before the runtime is live, use
-`Deploy failed after the build completed.` as the headline and keep `Runtime:
-not started`.
 
 ## JSON Error Shape
 

--- a/docs/product/error-conventions.md
+++ b/docs/product/error-conventions.md
@@ -107,7 +107,7 @@ This is usually a missing env var, a failed DB connection,
 or a crash on startup.
 
 See what happened
-prisma app logs --deployment <id>
+prisma-cli app logs --deployment <id>
 
 URL
 https://cv-...

--- a/docs/product/output-conventions.md
+++ b/docs/product/output-conventions.md
@@ -276,14 +276,24 @@ For `app deploy`, the setup block is a one-time local binding surface, not a
 per-run summary. Once `.prisma/local.json` has been written, retries and later
 deploys should feel like deploys, not setup. Do not repeat source annotations or
 ask `Customize settings?` again unless the user deletes the pin or passes a
-flag that explicitly changes targeting/configuration.
+flag that explicitly changes targeting/configuration. The first setup title
+should read `Setting up your local directory <path>`, followed by the resolved
+table and then the plain-language note `This directory is now linked to project
+<name>.`
 
 Deploy progress should describe phases without claiming runtime success before
 health is known. Do not print `Status: running` or `Deployment is running at ...`.
-Use phase copy such as `Building locally...`, `Packaging artifact...`,
-`Uploading...`, `Starting deployment...`, and `Checking runtime health...`.
-On success, print `Deployed to <url>` and `Runtime logs: prisma app logs`.
+Use short stage copy such as `Building locally...`, `Built <size>`,
+`Uploading...`, `Uploaded`, `Deploying...`, and `Deployed`.
+On success, print `Live in <duration>`, the URL on its own line, and
+`Logs   prisma app logs`.
 Human deploy output is stderr; `--json` is the machine-readable stdout path.
+
+Deploy setup and result rows should share one table style: labels start two
+spaces from the left margin, values align in one column, and optional origins
+align in a dim third column prefixed with `·`. Values should be the strongest
+part of the row; origins are secondary reassurance and must be dimmed only when
+color is enabled.
 
 ## Action and Data Commands
 

--- a/docs/product/output-conventions.md
+++ b/docs/product/output-conventions.md
@@ -286,7 +286,7 @@ health is known. Do not print `Status: running` or `Deployment is running at ...
 Use short stage copy such as `Building locally...`, `Built <size>`,
 `Uploading...`, `Uploaded`, `Deploying...`, and `Deployed`.
 On success, print `Live in <duration>`, the URL on its own line, and
-`Logs   prisma app logs`.
+`Logs   prisma-cli app logs`.
 Human deploy output is stderr; `--json` is the machine-readable stdout path.
 
 Deploy setup and result rows should share one table style: labels start two

--- a/docs/product/output-conventions.md
+++ b/docs/product/output-conventions.md
@@ -265,12 +265,25 @@ When a command acts on a project, branch, app, or deployment, the output should 
 Examples:
 
 - `app deploy` should state the resolved target that matters in the current slice
-- first `app deploy` should show Workspace, Project, Branch, App, Framework, and Runtime with source annotations before work begins
-- subsequent `app deploy` should show the resolved tuple without repeating first-run annotations
+- first local `app deploy` binding should show Workspace, Project, Branch, App, Framework, and Runtime with source annotations before work begins
+- subsequent `app deploy` calls should use a compact target header such as `Deploying ./j1 to j1 / main / j1`
 - `app logs` should state the deployment it resolved
 - `app list-deploys` should state which app or branch is being listed
 
 The CLI must not make users guess which target a command acted on.
+
+For `app deploy`, the setup block is a one-time local binding surface, not a
+per-run summary. Once `.prisma/local.json` has been written, retries and later
+deploys should feel like deploys, not setup. Do not repeat source annotations or
+ask `Customize settings?` again unless the user deletes the pin or passes a
+flag that explicitly changes targeting/configuration.
+
+Deploy progress should describe phases without claiming runtime success before
+health is known. Do not print `Status: running` or `Deployment is running at ...`.
+Use phase copy such as `Building locally...`, `Packaging artifact...`,
+`Uploading...`, `Starting deployment...`, and `Checking runtime health...`.
+On success, print `Deployed to <url>` and `Runtime logs: prisma app logs`.
+Human deploy output is stderr; `--json` is the machine-readable stdout path.
 
 ## Action and Data Commands
 

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -64,8 +64,10 @@ import {
 import { PREVIEW_DEFAULT_REGION } from "../lib/app/preview-interaction";
 import {
   createPreviewDeployProgress,
+  createPreviewDeployProgressState,
   createPreviewPromoteProgress,
   createPreviewUpdateEnvProgress,
+  type PreviewDeployProgressState,
 } from "../lib/app/preview-progress";
 import { createPreviewAppProvider, type PreviewAppRecord } from "../lib/app/preview-provider";
 import { requireAuthenticatedAuthState } from "./auth";
@@ -239,7 +241,6 @@ export async function runAppDeploy(
 
   await maybeRenderDeploySetupBlock(context, {
     firstDeploy: selectedApp.firstDeploy,
-    showSubsequentAnnotations: skipLocalPin,
     workspaceName: target.workspace.name,
     projectName: target.project.name,
     projectAnnotation: annotationForProjectResolution(target.resolution),
@@ -267,7 +268,18 @@ export async function runAppDeploy(
   const buildType = framework.buildType;
   assertSupportedEntrypoint(buildType, options?.entrypoint, "deploy");
   const portMapping = parseDeployPortMapping(String(runtime.port));
+  const shouldWriteLocalPin = firstDeploy && !skipLocalPin;
+  if (shouldWriteLocalPin) {
+    await writeLocalResolutionPin(context.runtime.cwd, {
+      workspaceId: target.workspace.id,
+      projectId: target.project.id,
+    });
+    await ensureLocalResolutionPinGitignore(context.runtime.cwd);
+    maybeRenderLocalPinBound(context);
+  }
 
+  const progressState = createPreviewDeployProgressState();
+  const deployStartedAt = Date.now();
   const deployResult = await provider.deployApp({
     cwd: context.runtime.cwd,
     projectId,
@@ -280,24 +292,17 @@ export async function runAppDeploy(
     portMapping,
     envVars,
     interaction: undefined,
-    progress: createPreviewDeployProgress(context.output.stderr, !context.flags.json && !context.flags.quiet),
+    progress: createPreviewDeployProgress(context.output.stderr, !context.flags.json && !context.flags.quiet, progressState),
   }).catch((error) => {
-    throw deployFailedError("App deploy failed", error, ["prisma-cli app list-deploys"]);
+    throw appDeployFailedError(error, progressState);
   });
+  const deployDurationMs = Date.now() - deployStartedAt;
 
   await context.stateStore.setSelectedApp(projectId, {
     id: deployResult.app.id,
     name: deployResult.app.name,
   });
   await context.stateStore.setKnownLiveDeployment(projectId, deployResult.app.id, deployResult.deployment.id);
-  const shouldWriteLocalPin = firstDeploy && !skipLocalPin;
-  if (shouldWriteLocalPin) {
-    await writeLocalResolutionPin(context.runtime.cwd, {
-      workspaceId: target.workspace.id,
-      projectId: target.project.id,
-    });
-    await ensureLocalResolutionPinGitignore(context.runtime.cwd);
-  }
 
   return {
     command: "app.deploy",
@@ -311,6 +316,7 @@ export async function runAppDeploy(
         name: deployResult.app.name,
       },
       deployment: deployResult.deployment,
+      durationMs: deployDurationMs,
       localPin: shouldWriteLocalPin
         ? {
             path: LOCAL_RESOLUTION_PIN_RELATIVE_PATH,
@@ -1772,12 +1778,13 @@ async function resolveDeployProjectContext(
     }, branch);
   }
 
-  if (options.localPin.kind === "present") {
-    if (options.localPin.pin.workspaceId !== workspace.id) {
+  const localPin = options.localPin;
+  if (localPin.kind === "present") {
+    if (localPin.pin.workspaceId !== workspace.id) {
       throw localResolutionPinStaleError();
     }
 
-    const project = projects.find((candidate) => candidate.id === options.localPin.pin.projectId);
+    const project = projects.find((candidate) => candidate.id === localPin.pin.projectId);
     if (!project) {
       throw localResolutionPinStaleError();
     }
@@ -2094,7 +2101,6 @@ async function maybeRenderDeploySetupBlock(
   context: CommandContext,
   details: {
     firstDeploy: boolean;
-    showSubsequentAnnotations?: boolean;
     workspaceName: string;
     projectName: string;
     projectAnnotation: string;
@@ -2110,7 +2116,13 @@ async function maybeRenderDeploySetupBlock(
     return;
   }
 
-  const title = `${details.firstDeploy ? "Set up" : "Deploying"} ${formatDeployDirectory(context.runtime.cwd)}`;
+  const directory = formatDeployDirectory(context.runtime.cwd);
+  if (!details.firstDeploy) {
+    context.output.stderr.write(`Deploying ${directory} to ${details.projectName} / ${details.branchName} / ${details.appName}\n\n`);
+    return;
+  }
+
+  const title = `Set up ${directory}`;
   const rows = details.firstDeploy
     ? [
         { label: "Workspace", value: details.workspaceName },
@@ -2120,17 +2132,18 @@ async function maybeRenderDeploySetupBlock(
         { label: "Framework", value: details.framework.displayName, annotation: details.framework.annotation },
         { label: "Runtime", value: `HTTP ${details.runtime.port}`, annotation: details.runtime.annotation },
       ]
-    : [
-        { label: "Workspace", value: details.workspaceName },
-        { label: "Project", value: details.projectName, annotation: details.showSubsequentAnnotations ? details.projectAnnotation : undefined },
-        { label: "Branch", value: details.branchName, annotation: details.showSubsequentAnnotations ? details.branchAnnotation : undefined },
-        { label: "App", value: details.appName, annotation: details.showSubsequentAnnotations ? details.appAnnotation : undefined },
-      ];
-  const lines = details.firstDeploy
-    ? [title, "", ...renderDeploySetupRows(context, rows), ""]
-    : [title, ...renderDeploySetupRows(context, rows), ""];
+    : [];
+  const lines = [title, "", ...renderDeploySetupRows(context, rows), ""];
 
   context.output.stderr.write(`${lines.join("\n")}\n`);
+}
+
+function maybeRenderLocalPinBound(context: CommandContext): void {
+  if (context.flags.json || context.flags.quiet) {
+    return;
+  }
+
+  context.output.stderr.write(`Bound this directory in ${LOCAL_RESOLUTION_PIN_RELATIVE_PATH}. Subsequent commands target the same Project.\n`);
 }
 
 async function maybeCustomizeDeploySettings(
@@ -2430,6 +2443,84 @@ function deployFailedError(summary: string, error: unknown, nextSteps: string[])
     debug: formatDebugDetails(error),
     exitCode: 1,
     nextSteps,
+  });
+}
+
+function appDeployFailedError(error: unknown, progress: PreviewDeployProgressState): CliError {
+  const why = error instanceof Error ? error.message : String(error);
+  const debug = formatDebugDetails(error);
+
+  if (progress.buildStarted && !progress.buildCompleted) {
+    return new CliError({
+      code: "BUILD_FAILED",
+      domain: "app",
+      summary: "Build failed locally.",
+      why,
+      fix: "Inspect the build output above, fix the error, and redeploy.",
+      debug,
+      meta: { phase: "build" },
+      humanLines: [
+        "Build failed locally.",
+        "",
+        "Build:    failed",
+        "Deploy:   not started",
+        "Runtime:  not started",
+        "URL:      not promoted",
+        "",
+        `Why: ${why}`,
+        "Fix: Inspect the build output above, fix the error, and redeploy.",
+      ],
+      exitCode: 1,
+      nextSteps: [],
+    });
+  }
+
+  if (!progress.buildStarted) {
+    return deployFailedError("App deploy failed", error, ["prisma-cli app deploy"]);
+  }
+
+  const deployState = progress.containerLive || progress.startRequested
+    ? "artifact uploaded, container started"
+    : progress.uploadCompleted
+      ? "artifact uploaded, container not started"
+      : progress.archiveReady
+        ? "artifact packaged, upload incomplete"
+        : "not started";
+  const runtimeState = progress.containerLive ? "failed health check" : "not started";
+  const deploymentLine = progress.deploymentUrl
+    ? `Deployment:  ${progress.deploymentUrl} (unhealthy)`
+    : "Deployment:  unavailable";
+  const recoveryLine = progress.versionId
+    ? `Runtime logs: prisma app logs --deployment ${progress.versionId}`
+    : "Fix: Retry the command, or rerun with --trace for more detailed diagnostics.";
+
+  return new CliError({
+    code: "DEPLOY_FAILED",
+    domain: "app",
+    summary: "Runtime failed after the build completed.",
+    why,
+    fix: progress.versionId
+      ? `Inspect runtime logs with prisma app logs --deployment ${progress.versionId}.`
+      : "Retry the command, or rerun with --trace for more detailed diagnostics.",
+    debug,
+    meta: {
+      phase: progress.containerLive ? "runtime_health" : "deploy",
+      deploymentId: progress.versionId,
+      deploymentUrl: progress.deploymentUrl,
+    },
+    humanLines: [
+      "Runtime failed after the build completed.",
+      "",
+      "Build:       passed locally",
+      `Deploy:      ${deployState}`,
+      `Runtime:     ${runtimeState}`,
+      deploymentLine,
+      "",
+      `Why: ${why}`,
+      recoveryLine,
+    ],
+    exitCode: 1,
+    nextSteps: [],
   });
 }
 

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -2487,6 +2487,9 @@ function appDeployFailedError(error: unknown, progress: PreviewDeployProgressSta
         ? "artifact packaged, upload incomplete"
         : "not started";
   const runtimeState = progress.containerLive ? "failed health check" : "not started";
+  const phaseHeadline = progress.containerLive
+    ? "Runtime failed after the build completed."
+    : "Deploy failed after the build completed.";
   const deploymentLine = progress.deploymentUrl
     ? `Deployment:  ${progress.deploymentUrl} (unhealthy)`
     : "Deployment:  unavailable";
@@ -2497,7 +2500,7 @@ function appDeployFailedError(error: unknown, progress: PreviewDeployProgressSta
   return new CliError({
     code: "DEPLOY_FAILED",
     domain: "app",
-    summary: "Runtime failed after the build completed.",
+    summary: phaseHeadline,
     why,
     fix: progress.versionId
       ? `Inspect runtime logs with prisma app logs --deployment ${progress.versionId}.`
@@ -2509,7 +2512,7 @@ function appDeployFailedError(error: unknown, progress: PreviewDeployProgressSta
       deploymentUrl: progress.deploymentUrl,
     },
     humanLines: [
-      "Runtime failed after the build completed.",
+      phaseHeadline,
       "",
       "Build:       passed locally",
       `Deploy:      ${deployState}`,

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -33,6 +33,7 @@ import { requireComputeAuth } from "../lib/auth/guard";
 import { readAuthState } from "../lib/auth/auth-ops";
 import { getApiBaseUrl, SERVICE_TOKEN_ENV_VAR } from "../lib/auth/client";
 import { parseEnvAssignments } from "../lib/app/env-vars";
+import { renderDeployOutputRows } from "../lib/app/deploy-output";
 import {
   DEFAULT_LOCAL_DEV_PORT,
   resolveLocalBuildType,
@@ -275,7 +276,7 @@ export async function runAppDeploy(
       projectId: target.project.id,
     });
     await ensureLocalResolutionPinGitignore(context.runtime.cwd);
-    maybeRenderLocalPinBound(context);
+    maybeRenderLocalPinBound(context, target.project.name);
   }
 
   const progressState = createPreviewDeployProgressState();
@@ -292,7 +293,7 @@ export async function runAppDeploy(
     portMapping,
     envVars,
     interaction: undefined,
-    progress: createPreviewDeployProgress(context.output.stderr, !context.flags.json && !context.flags.quiet, progressState),
+    progress: createPreviewDeployProgress(context.output.stderr, context.ui, !context.flags.json && !context.flags.quiet, progressState),
   }).catch((error) => {
     throw appDeployFailedError(error, progressState);
   });
@@ -2122,28 +2123,28 @@ async function maybeRenderDeploySetupBlock(
     return;
   }
 
-  const title = `Set up ${directory}`;
+  const title = `Setting up your local directory ${formatLocalDirectory(context.runtime.cwd, context.runtime.env)}`;
   const rows = details.firstDeploy
     ? [
         { label: "Workspace", value: details.workspaceName },
-        { label: "Project", value: details.projectName, annotation: details.projectAnnotation },
-        { label: "Branch", value: details.branchName, annotation: details.branchAnnotation },
-        { label: "App", value: details.appName, annotation: details.appAnnotation },
-        { label: "Framework", value: details.framework.displayName, annotation: details.framework.annotation },
-        { label: "Runtime", value: `HTTP ${details.runtime.port}`, annotation: details.runtime.annotation },
+        { label: "Project", value: details.projectName, origin: details.projectAnnotation },
+        { label: "Branch", value: details.branchName, origin: details.branchAnnotation },
+        { label: "App", value: details.appName, origin: details.appAnnotation },
+        { label: "Framework", value: details.framework.displayName, origin: details.framework.annotation },
+        { label: "Runtime", value: `HTTP ${details.runtime.port}`, origin: details.runtime.annotation },
       ]
     : [];
-  const lines = [title, "", ...renderDeploySetupRows(context, rows), ""];
+  const lines = [title, "", ...renderDeployOutputRows(context.ui, rows), ""];
 
   context.output.stderr.write(`${lines.join("\n")}\n`);
 }
 
-function maybeRenderLocalPinBound(context: CommandContext): void {
+function maybeRenderLocalPinBound(context: CommandContext, projectName: string): void {
   if (context.flags.json || context.flags.quiet) {
     return;
   }
 
-  context.output.stderr.write(`Bound this directory in ${LOCAL_RESOLUTION_PIN_RELATIVE_PATH}. Subsequent commands target the same Project.\n`);
+  context.output.stderr.write(`This directory is now linked to project ${projectName}.\n\n`);
 }
 
 async function maybeCustomizeDeploySettings(
@@ -2216,28 +2217,17 @@ async function maybeCustomizeDeploySettings(
   ].filter((row): row is { label: string; value: string; annotation: string } => Boolean(row));
 
   if (changedRows.length > 0 && !context.flags.quiet && !context.flags.json) {
-    context.output.stderr.write(`${renderDeploySetupRows(context, changedRows).join("\n")}\n\n`);
+    context.output.stderr.write(`${renderDeployOutputRows(context.ui, changedRows.map((row) => ({
+      label: row.label,
+      value: row.value,
+      origin: row.annotation,
+    }))).join("\n")}\n\n`);
   }
 
   return {
     framework,
     runtime,
   };
-}
-
-function renderDeploySetupRows(
-  context: CommandContext,
-  rows: Array<{ label: string; value: string; annotation?: string }>,
-): string[] {
-  const labelWidth = Math.max(...rows.map((row) => row.label.length));
-  const valueWidth = Math.max(...rows.map((row) => row.value.length));
-
-  return rows.map((row) => {
-    const label = row.label.padEnd(labelWidth);
-    const value = row.value.padEnd(valueWidth);
-    const annotation = row.annotation ? `  ${context.ui.dim(row.annotation)}` : "";
-    return `  ${label}  ${value}${annotation}`.trimEnd();
-  });
 }
 
 function annotationForProjectResolution(resolution: ProjectResolution): string {
@@ -2290,6 +2280,18 @@ function validateDeployHttpPortText(value: string | undefined): string | undefin
 function formatDeployDirectory(cwd: string): string {
   const basename = path.basename(cwd);
   return basename ? `./${basename}` : ".";
+}
+
+function formatLocalDirectory(cwd: string, env: NodeJS.ProcessEnv): string {
+  const resolved = path.resolve(cwd);
+  const home = env.HOME ? path.resolve(env.HOME) : null;
+
+  if (home && (resolved === home || resolved.startsWith(`${home}${path.sep}`))) {
+    const relative = path.relative(home, resolved);
+    return relative ? `~/${relative}` : "~";
+  }
+
+  return resolved;
 }
 
 async function readCurrentWorkspaceId(context: CommandContext): Promise<string | null> {
@@ -2462,12 +2464,8 @@ function appDeployFailedError(error: unknown, progress: PreviewDeployProgressSta
       humanLines: [
         "Build failed locally.",
         "",
-        "Build:    failed",
-        "Deploy:   not started",
-        "Runtime:  not started",
-        "URL:      not promoted",
+        `✗ Built       ${why}`,
         "",
-        `Why: ${why}`,
         "Fix: Inspect the build output above, fix the error, and redeploy.",
       ],
       exitCode: 1,
@@ -2479,49 +2477,53 @@ function appDeployFailedError(error: unknown, progress: PreviewDeployProgressSta
     return deployFailedError("App deploy failed", error, ["prisma-cli app deploy"]);
   }
 
-  const deployState = progress.containerLive || progress.startRequested
-    ? "artifact uploaded, container started"
-    : progress.uploadCompleted
-      ? "artifact uploaded, container not started"
-      : progress.archiveReady
-        ? "artifact packaged, upload incomplete"
-        : "not started";
-  const runtimeState = progress.containerLive ? "failed health check" : "not started";
   const phaseHeadline = progress.containerLive
-    ? "Runtime failed after the build completed."
+    ? "The deployment started, but the app is not ready yet."
     : "Deploy failed after the build completed.";
-  const deploymentLine = progress.deploymentUrl
-    ? `Deployment:  ${progress.deploymentUrl} (unhealthy)`
-    : "Deployment:  unavailable";
-  const recoveryLine = progress.versionId
-    ? `Runtime logs: prisma app logs --deployment ${progress.versionId}`
-    : "Fix: Retry the command, or rerun with --trace for more detailed diagnostics.";
+  const recoveryLines = progress.versionId
+    ? ["See what happened", `prisma app logs --deployment ${progress.versionId}`]
+    : ["Fix", "Retry the command, or rerun with --trace for more detailed diagnostics."];
+  const urlLines = progress.deploymentUrl
+    ? ["", "URL", progress.deploymentUrl]
+    : [];
+  const humanLines = progress.containerLive
+    ? [
+        phaseHeadline,
+        "",
+        "This is usually a missing env var, a failed DB connection,",
+        "or a crash on startup.",
+        "",
+        ...recoveryLines,
+        ...urlLines,
+      ]
+    : [
+        phaseHeadline,
+        "",
+        progress.uploadCompleted
+          ? "The artifact uploaded, but the deployment did not start."
+          : progress.archiveReady
+            ? "The app built locally, but the artifact did not finish uploading."
+            : "The app built locally, but the deployment did not start.",
+        "",
+        ...recoveryLines,
+      ];
+  const fix = progress.versionId
+    ? `Inspect logs with prisma app logs --deployment ${progress.versionId}.`
+    : "Retry the command, or rerun with --trace for more detailed diagnostics.";
 
   return new CliError({
     code: "DEPLOY_FAILED",
     domain: "app",
     summary: phaseHeadline,
     why,
-    fix: progress.versionId
-      ? `Inspect runtime logs with prisma app logs --deployment ${progress.versionId}.`
-      : "Retry the command, or rerun with --trace for more detailed diagnostics.",
+    fix,
     debug,
     meta: {
-      phase: progress.containerLive ? "runtime_health" : "deploy",
+      phase: progress.containerLive ? "runtime_ready" : "deploy",
       deploymentId: progress.versionId,
       deploymentUrl: progress.deploymentUrl,
     },
-    humanLines: [
-      phaseHeadline,
-      "",
-      "Build:       passed locally",
-      `Deploy:      ${deployState}`,
-      `Runtime:     ${runtimeState}`,
-      deploymentLine,
-      "",
-      `Why: ${why}`,
-      recoveryLine,
-    ],
+    humanLines,
     exitCode: 1,
     nextSteps: [],
   });

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -2481,7 +2481,7 @@ function appDeployFailedError(error: unknown, progress: PreviewDeployProgressSta
     ? "The deployment started, but the app is not ready yet."
     : "Deploy failed after the build completed.";
   const recoveryLines = progress.versionId
-    ? ["See what happened", `prisma app logs --deployment ${progress.versionId}`]
+    ? ["See what happened", `prisma-cli app logs --deployment ${progress.versionId}`]
     : ["Fix", "Retry the command, or rerun with --trace for more detailed diagnostics."];
   const urlLines = progress.deploymentUrl
     ? ["", "URL", progress.deploymentUrl]
@@ -2508,7 +2508,7 @@ function appDeployFailedError(error: unknown, progress: PreviewDeployProgressSta
         ...recoveryLines,
       ];
   const fix = progress.versionId
-    ? `Inspect logs with prisma app logs --deployment ${progress.versionId}.`
+    ? `Inspect logs with prisma-cli app logs --deployment ${progress.versionId}.`
     : "Retry the command, or rerun with --trace for more detailed diagnostics.";
 
   return new CliError({

--- a/packages/cli/src/lib/app/deploy-output.ts
+++ b/packages/cli/src/lib/app/deploy-output.ts
@@ -1,0 +1,30 @@
+import { padDisplay, type ShellUi } from "../../shell/ui";
+
+export interface DeployOutputRow {
+  label: string;
+  value?: string;
+  origin?: string;
+}
+
+const DEPLOY_OUTPUT_MIN_LABEL_WIDTH = "Framework".length;
+const DEPLOY_OUTPUT_MIN_VALUE_WIDTH = "HTTP 3000".length;
+
+export function renderDeployOutputRows(ui: ShellUi, rows: DeployOutputRow[]): string[] {
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const labelWidth = Math.max(DEPLOY_OUTPUT_MIN_LABEL_WIDTH, ...rows.map((row) => row.label.length));
+  const valueWidth = Math.max(DEPLOY_OUTPUT_MIN_VALUE_WIDTH, ...rows.map((row) => row.value?.length ?? 0));
+
+  return rows.map((row) => {
+    if (!row.value) {
+      return `  ${row.label}`;
+    }
+
+    const label = padDisplay(row.label, labelWidth);
+    const value = padDisplay(ui.strong(row.value), valueWidth);
+    const origin = row.origin ? `  ${ui.dim(`· ${row.origin}`)}` : "";
+    return `  ${label}  ${value}${origin}`.trimEnd();
+  });
+}

--- a/packages/cli/src/lib/app/preview-progress.ts
+++ b/packages/cli/src/lib/app/preview-progress.ts
@@ -1,6 +1,9 @@
 import type { DeployProgress, PromoteProgress, UpdateEnvProgress } from "@prisma/compute-sdk";
 import type { Writable } from "node:stream";
 
+import { renderDeployOutputRows } from "./deploy-output";
+import type { ShellUi } from "../../shell/ui";
+
 export interface PreviewDeployProgressState {
   buildStarted: boolean;
   buildCompleted: boolean;
@@ -29,6 +32,7 @@ export function createPreviewDeployProgressState(): PreviewDeployProgressState {
 
 export function createPreviewDeployProgress(
   output: Writable,
+  ui: ShellUi,
   enabled: boolean,
   state: PreviewDeployProgressState = createPreviewDeployProgressState(),
 ): DeployProgress | undefined {
@@ -40,6 +44,12 @@ export function createPreviewDeployProgress(
     output.write(`${line}\n`);
   };
 
+  const writeRows = (rows: Parameters<typeof renderDeployOutputRows>[1]) => {
+    for (const line of renderDeployOutputRows(ui, rows)) {
+      write(line);
+    }
+  };
+
   return {
     onBuildStart() {
       state.buildStarted = true;
@@ -47,14 +57,10 @@ export function createPreviewDeployProgress(
     },
     onBuildComplete() {
       state.buildCompleted = true;
-      write("Building locally. Done.");
-    },
-    onArchiveCreating() {
-      write("Packaging artifact...");
     },
     onArchiveReady(byteLength) {
       state.archiveReady = true;
-      write(`Packaging artifact. ${formatArtifactSize(byteLength)}.`);
+      writeRows([{ label: "Built", value: formatArtifactSize(byteLength) }]);
     },
     onUploadStart() {
       write("Uploading...");
@@ -64,18 +70,16 @@ export function createPreviewDeployProgress(
     },
     onUploadComplete() {
       state.uploadCompleted = true;
-      write("Uploading. Done.");
+      writeRows([{ label: "Uploaded" }]);
     },
     onStartRequested() {
       state.startRequested = true;
-      write("Starting deployment...");
+      write("Deploying...");
     },
     onRunning(url) {
       state.containerLive = true;
       state.deploymentUrl = url;
-      write("Starting deployment. Container live.");
-      // TODO: replace this SDK "running" boundary with the platform health-passed signal.
-      write("Checking runtime health...");
+      writeRows([{ label: "Deployed" }]);
     },
     onPromoted(url) {
       state.promotedUrl = url;

--- a/packages/cli/src/lib/app/preview-progress.ts
+++ b/packages/cli/src/lib/app/preview-progress.ts
@@ -1,93 +1,90 @@
 import type { DeployProgress, PromoteProgress, UpdateEnvProgress } from "@prisma/compute-sdk";
 import type { Writable } from "node:stream";
 
+export interface PreviewDeployProgressState {
+  buildStarted: boolean;
+  buildCompleted: boolean;
+  archiveReady: boolean;
+  uploadCompleted: boolean;
+  versionId: string | null;
+  startRequested: boolean;
+  containerLive: boolean;
+  deploymentUrl: string | null;
+  promotedUrl: string | null;
+}
+
+export function createPreviewDeployProgressState(): PreviewDeployProgressState {
+  return {
+    buildStarted: false,
+    buildCompleted: false,
+    archiveReady: false,
+    uploadCompleted: false,
+    versionId: null,
+    startRequested: false,
+    containerLive: false,
+    deploymentUrl: null,
+    promotedUrl: null,
+  };
+}
+
 export function createPreviewDeployProgress(
   output: Writable,
   enabled: boolean,
+  state: PreviewDeployProgressState = createPreviewDeployProgressState(),
 ): DeployProgress | undefined {
-  if (!enabled) {
-    return undefined;
-  }
-
   const write = (line: string) => {
+    if (!enabled) {
+      return;
+    }
+
     output.write(`${line}\n`);
   };
 
   return {
     onBuildStart() {
-      write("Building application...");
+      state.buildStarted = true;
+      write("Building locally...");
     },
     onBuildComplete() {
-      write("Build complete.");
+      state.buildCompleted = true;
+      write("Building locally. Done.");
     },
     onArchiveCreating() {
-      write("Creating deployment artifact...");
+      write("Packaging artifact...");
     },
     onArchiveReady(byteLength) {
-      write(`Artifact ready (${(byteLength / 1024).toFixed(1)} KB).`);
+      state.archiveReady = true;
+      write(`Packaging artifact. ${formatArtifactSize(byteLength)}.`);
+    },
+    onUploadStart() {
+      write("Uploading...");
     },
     onVersionCreated(versionId) {
-      write(`Deployment ${versionId} created.`);
+      state.versionId = versionId;
     },
     onUploadComplete() {
-      write("Upload complete.");
+      state.uploadCompleted = true;
+      write("Uploading. Done.");
     },
     onStartRequested() {
+      state.startRequested = true;
       write("Starting deployment...");
     },
-    onStatusChange(status) {
-      write(`Status: ${status}`);
-    },
     onRunning(url) {
-      if (url) {
-        write(`Deployment is running at ${url}.`);
-        return;
-      }
-
-      write("Deployment is running.");
-    },
-    onPromoteStart() {
-      write("Promoting deployment...");
+      state.containerLive = true;
+      state.deploymentUrl = url;
+      write("Starting deployment. Container live.");
+      // TODO: replace this SDK "running" boundary with the platform health-passed signal.
+      write("Checking runtime health...");
     },
     onPromoted(url) {
-      if (url) {
-        write(`Promoted to ${url}.`);
-        return;
-      }
-
-      write("Promotion complete.");
-    },
-    onPromoteFailed(error) {
-      write(`Promotion failed${error?.message ? `: ${error.message}` : "."}`);
-    },
-    onOldVersionStopping(versionId) {
-      write(`Stopping previous deployment ${versionId}...`);
-    },
-    onOldVersionStopped(versionId) {
-      write(`Previous deployment ${versionId} stopped.`);
-    },
-    onOldVersionStopFailed(versionId) {
-      write(`Failed to stop previous deployment ${versionId} (non-fatal).`);
-    },
-    onOldVersionDeleting(versionId) {
-      write(`Deleting previous deployment ${versionId}...`);
-    },
-    onOldVersionDeleted(versionId) {
-      write(`Previous deployment ${versionId} deleted.`);
-    },
-    onOldVersionDeleteFailed(versionId) {
-      write(`Failed to delete previous deployment ${versionId} (non-fatal).`);
-    },
-    onCleanupDanglingVersion(versionId) {
-      write(`Cleaning up deployment ${versionId}...`);
-    },
-    onCleanupDanglingVersionComplete(versionId) {
-      write(`Deployment ${versionId} cleaned up.`);
-    },
-    onCleanupDanglingVersionFailed(versionId) {
-      write(`Failed to clean up deployment ${versionId}.`);
+      state.promotedUrl = url;
     },
   };
+}
+
+function formatArtifactSize(byteLength: number): string {
+  return `${(byteLength / 1024 / 1024).toFixed(1)} MB`;
 }
 
 export function createPreviewPromoteProgress(

--- a/packages/cli/src/presenters/app.ts
+++ b/packages/cli/src/presenters/app.ts
@@ -44,31 +44,30 @@ export function renderAppDeploy(
   descriptor: CommandDescriptor,
   result: AppDeployResult,
 ): string[] {
-  const lines = renderShow(
-    {
-      title: "Deploying the selected app.",
-      descriptor,
-      fields: [
-        { key: "workspace", value: result.workspace.name },
-        { key: "project", value: result.project.name },
-        { key: "branch", value: result.branch.name },
-        { key: "app", value: result.app.name },
-        { key: "deployment", value: result.deployment.id },
-        { key: "status", value: result.deployment.status, tone: toneForStatus(result.deployment.status) },
-        ...(result.deployment.url ? [{ key: "url", value: result.deployment.url, tone: "link" as const }] : []),
-      ],
-    },
-    context.ui,
-  );
-  if (result.localPin?.written) {
-    lines.push(`Bound this directory in ${result.localPin.path}. Subsequent commands target the same Project.`);
-  }
+  void context;
+  void descriptor;
+
+  const lines = [
+    result.deployment.url
+      ? `Deployed to ${result.deployment.url} in ${formatDuration(result.durationMs)}.`
+      : `Deployed in ${formatDuration(result.durationMs)}.`,
+    "",
+    "Runtime logs: prisma app logs",
+  ];
   return lines;
 }
 
 export function serializeAppDeploy(result: AppDeployResult) {
   const { localPin: _localPin, ...serialized } = result;
   return serialized;
+}
+
+function formatDuration(durationMs: number): string {
+  if (durationMs < 1000) {
+    return `${durationMs}ms`;
+  }
+
+  return `${(durationMs / 1000).toFixed(1)}s`;
 }
 
 export function renderAppUpdateEnv(

--- a/packages/cli/src/presenters/app.ts
+++ b/packages/cli/src/presenters/app.ts
@@ -52,7 +52,7 @@ export function renderAppDeploy(
     ...(result.deployment.url ? [context.ui.link(result.deployment.url)] : []),
     "",
     ...renderDeployOutputRows(context.ui, [
-      { label: "Logs", value: "prisma app logs" },
+      { label: "Logs", value: "prisma-cli app logs" },
     ]),
   ];
   return lines;

--- a/packages/cli/src/presenters/app.ts
+++ b/packages/cli/src/presenters/app.ts
@@ -15,6 +15,7 @@ import type {
   AppUpdateEnvResult,
 } from "../types/app";
 import { renderList, renderShow, serializeList } from "../output/patterns";
+import { renderDeployOutputRows } from "../lib/app/deploy-output";
 
 export function renderAppBuild(
   context: CommandContext,
@@ -44,15 +45,15 @@ export function renderAppDeploy(
   descriptor: CommandDescriptor,
   result: AppDeployResult,
 ): string[] {
-  void context;
   void descriptor;
 
   const lines = [
-    result.deployment.url
-      ? `Deployed to ${result.deployment.url} in ${formatDuration(result.durationMs)}.`
-      : `Deployed in ${formatDuration(result.durationMs)}.`,
+    `Live in ${formatDuration(result.durationMs)}`,
+    ...(result.deployment.url ? [context.ui.link(result.deployment.url)] : []),
     "",
-    "Runtime logs: prisma app logs",
+    ...renderDeployOutputRows(context.ui, [
+      { label: "Logs", value: "prisma app logs" },
+    ]),
   ];
   return lines;
 }

--- a/packages/cli/src/shell/errors.ts
+++ b/packages/cli/src/shell/errors.ts
@@ -46,7 +46,9 @@ export class CliError extends Error {
     this.docsUrl = options.docsUrl ?? null;
     this.exitCode = options.exitCode ?? 1;
     this.nextSteps = options.nextSteps ?? [];
-    this.humanLines = options.humanLines ?? null;
+    this.humanLines = options.humanLines && options.humanLines.length > 0
+      ? [...options.humanLines]
+      : null;
   }
 }
 

--- a/packages/cli/src/shell/errors.ts
+++ b/packages/cli/src/shell/errors.ts
@@ -13,6 +13,7 @@ export interface CliErrorOptions {
   docsUrl?: string | null;
   exitCode?: number;
   nextSteps?: string[];
+  humanLines?: string[];
 }
 
 export class CliError extends Error {
@@ -28,6 +29,7 @@ export class CliError extends Error {
   readonly docsUrl: string | null;
   readonly exitCode: number;
   readonly nextSteps: string[];
+  readonly humanLines: string[] | null;
 
   constructor(options: CliErrorOptions) {
     super(options.summary);
@@ -44,6 +46,7 @@ export class CliError extends Error {
     this.docsUrl = options.docsUrl ?? null;
     this.exitCode = options.exitCode ?? 1;
     this.nextSteps = options.nextSteps ?? [];
+    this.humanLines = options.humanLines ?? null;
   }
 }
 

--- a/packages/cli/src/shell/output.ts
+++ b/packages/cli/src/shell/output.ts
@@ -68,6 +68,18 @@ export function writeHumanError(
   error: CliError,
   options: { trace: boolean },
 ): void {
+  if (error.humanLines) {
+    const lines = [...error.humanLines];
+    if (options.trace && error.debug) {
+      lines.push("");
+      lines.push("Trace:");
+      lines.push(...error.debug.trimEnd().split("\n"));
+    }
+    lines.push(...renderNextSteps(error.nextSteps));
+    writeHumanLines(output, lines);
+    return;
+  }
+
   const lines = [renderSummaryLine(ui, "error", `${error.summary} [${error.code}]`)];
 
   if (error.where) {

--- a/packages/cli/src/shell/output.ts
+++ b/packages/cli/src/shell/output.ts
@@ -68,7 +68,7 @@ export function writeHumanError(
   error: CliError,
   options: { trace: boolean },
 ): void {
-  if (error.humanLines) {
+  if (error.humanLines && error.humanLines.length > 0) {
     const lines = [...error.humanLines];
     if (options.trace && error.debug) {
       lines.push("");

--- a/packages/cli/src/types/app.ts
+++ b/packages/cli/src/types/app.ts
@@ -29,6 +29,7 @@ export interface AppDeployResult {
     status: string;
     url: string | null;
   };
+  durationMs: number;
   localPin?: {
     path: string;
     written: boolean;

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -510,7 +510,7 @@ describe("app controller", () => {
         "This is usually a missing env var, a failed DB connection,",
         "or a crash on startup.",
         "See what happened",
-        "prisma app logs --deployment dep_failed",
+        "prisma-cli app logs --deployment dep_failed",
         "URL",
         "https://cv-example.fra.prisma.build",
       ]),

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -371,7 +371,7 @@ describe("app controller", () => {
         written: true,
       },
     });
-    expect(stderr.buffer).toContain(`Set up ./${path.basename(cwd)}`);
+    expect(stderr.buffer).toContain(`Setting up your local directory ${cwd}`);
     expect(stderr.buffer).toContain("Project    my-app");
     expect(stderr.buffer).toContain("Branch     feat-j1");
     expect(stderr.buffer).toContain("Framework  Next.js");
@@ -426,12 +426,8 @@ describe("app controller", () => {
       humanLines: [
         "Build failed locally.",
         "",
-        "Build:    failed",
-        "Deploy:   not started",
-        "Runtime:  not started",
-        "URL:      not promoted",
+        "✗ Built       next build exited with code 1",
         "",
-        "Why: next build exited with code 1",
         "Fix: Inspect the build output above, fix the error, and redeploy.",
       ],
     });
@@ -439,7 +435,7 @@ describe("app controller", () => {
       workspaceId: "ws_123",
       projectId: "proj_123",
     });
-    expect(stderr.buffer).toContain("Bound this directory in .prisma/local.json. Subsequent commands target the same Project.");
+    expect(stderr.buffer).toContain("This directory is now linked to project Acme Dashboard.");
     expect(stderr.buffer).toContain("Building locally...");
   });
 
@@ -510,21 +506,23 @@ describe("app controller", () => {
     })).rejects.toMatchObject({
       code: "DEPLOY_FAILED",
       humanLines: expect.arrayContaining([
-        "Runtime failed after the build completed.",
-        "Build:       passed locally",
-        "Deploy:      artifact uploaded, container started",
-        "Runtime:     failed health check",
-        "Deployment:  https://cv-example.fra.prisma.build (unhealthy)",
-        "Runtime logs: prisma app logs --deployment dep_failed",
+        "The deployment started, but the app is not ready yet.",
+        "This is usually a missing env var, a failed DB connection,",
+        "or a crash on startup.",
+        "See what happened",
+        "prisma app logs --deployment dep_failed",
+        "URL",
+        "https://cv-example.fra.prisma.build",
       ]),
     });
     expect(stderr.buffer).toContain(`Deploying ./${path.basename(cwd)} to Acme Dashboard / main / ${path.basename(cwd)}`);
-    expect(stderr.buffer).toContain("Building locally. Done.");
-    expect(stderr.buffer).toContain("Packaging artifact. 10.6 MB.");
-    expect(stderr.buffer).toContain("Starting deployment. Container live.");
-    expect(stderr.buffer).toContain("Checking runtime health...");
+    expect(stderr.buffer).toContain("  Built      10.6 MB");
+    expect(stderr.buffer).toContain("  Uploaded");
+    expect(stderr.buffer).toContain("Deploying...");
+    expect(stderr.buffer).toContain("  Deployed");
     expect(stderr.buffer).not.toContain("Status: running");
     expect(stderr.buffer).not.toContain("Deployment is running at");
+    expect(stderr.buffer).not.toContain("Checking runtime health");
   });
 
   it("renders deploy-failure copy when failure happens before runtime starts", async () => {
@@ -588,9 +586,9 @@ describe("app controller", () => {
       summary: "Deploy failed after the build completed.",
       humanLines: expect.arrayContaining([
         "Deploy failed after the build completed.",
-        "Build:       passed locally",
-        "Deploy:      artifact packaged, upload incomplete",
-        "Runtime:     not started",
+        "The app built locally, but the artifact did not finish uploading.",
+        "Fix",
+        "Retry the command, or rerun with --trace for more detailed diagnostics.",
       ]),
     });
   });

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -383,6 +383,150 @@ describe("app controller", () => {
     await expect(readFile(path.join(cwd, ".gitignore"), "utf8")).resolves.toBe(".prisma/\n");
   });
 
+  it("writes the local binding before build failures and renders build-failure copy", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+    const listApps = vi.fn().mockResolvedValue([]);
+    const deployApp = vi.fn().mockImplementation(async (options: { progress?: { onBuildStart?: () => void } }) => {
+      options.progress?.onBuildStart?.();
+      throw new Error("next build exited with code 1");
+    });
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/preview-provider", () => ({
+      createPreviewAppProvider: vi.fn(() => ({
+        createProject: vi.fn(),
+        listApps,
+        deployApp,
+        listDeployments: vi.fn(),
+        showDeployment: vi.fn(),
+      })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runAppDeploy } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const { context, stderr } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      isTTY: false,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await expect(runAppDeploy(context, "hello-world", {
+      projectRef: "proj_123",
+      framework: "hono",
+    })).rejects.toMatchObject({
+      code: "BUILD_FAILED",
+      humanLines: [
+        "Build failed locally.",
+        "",
+        "Build:    failed",
+        "Deploy:   not started",
+        "Runtime:  not started",
+        "URL:      not promoted",
+        "",
+        "Why: next build exited with code 1",
+        "Fix: Inspect the build output above, fix the error, and redeploy.",
+      ],
+    });
+    await expect(readLocalPin(cwd)).resolves.toEqual({
+      workspaceId: "ws_123",
+      projectId: "proj_123",
+    });
+    expect(stderr.buffer).toContain("Bound this directory in .prisma/local.json. Subsequent commands target the same Project.");
+    expect(stderr.buffer).toContain("Building locally...");
+  });
+
+  it("renders runtime-failure copy with deployment logs after the container starts", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+    let appName = "";
+    const listApps = vi.fn().mockImplementation(async () => [
+      { id: "app_1", name: appName, region: "eu-central-1", liveDeploymentId: null, liveUrl: null },
+    ]);
+    const deployApp = vi.fn().mockImplementation(async (options: {
+      progress?: {
+        onBuildStart?: () => void;
+        onBuildComplete?: () => void;
+        onArchiveCreating?: () => void;
+        onArchiveReady?: (byteLength: number) => void;
+        onUploadStart?: () => void;
+        onVersionCreated?: (versionId: string) => void;
+        onUploadComplete?: () => void;
+        onStartRequested?: () => void;
+        onRunning?: (url?: string) => void;
+      };
+    }) => {
+      options.progress?.onBuildStart?.();
+      options.progress?.onBuildComplete?.();
+      options.progress?.onArchiveCreating?.();
+      options.progress?.onArchiveReady?.(11_114_905);
+      options.progress?.onUploadStart?.();
+      options.progress?.onVersionCreated?.("dep_failed");
+      options.progress?.onUploadComplete?.();
+      options.progress?.onStartRequested?.();
+      options.progress?.onRunning?.("https://cv-example.fra.prisma.build");
+      throw new Error("Internal Server Error");
+    });
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/preview-provider", () => ({
+      createPreviewAppProvider: vi.fn(() => ({
+        listApps,
+        deployApp,
+        listDeployments: vi.fn(),
+        showDeployment: vi.fn(),
+      })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runAppDeploy } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    appName = path.basename(cwd);
+    await writeLocalPin(cwd, {
+      workspaceId: "ws_123",
+      projectId: "proj_123",
+    });
+    const stateDir = path.join(cwd, ".state");
+    const { context, stderr } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      isTTY: false,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await expect(runAppDeploy(context, undefined, {
+      framework: "hono",
+    })).rejects.toMatchObject({
+      code: "DEPLOY_FAILED",
+      humanLines: expect.arrayContaining([
+        "Runtime failed after the build completed.",
+        "Build:       passed locally",
+        "Deploy:      artifact uploaded, container started",
+        "Runtime:     failed health check",
+        "Deployment:  https://cv-example.fra.prisma.build (unhealthy)",
+        "Runtime logs: prisma app logs --deployment dep_failed",
+      ]),
+    });
+    expect(stderr.buffer).toContain(`Deploying ./${path.basename(cwd)} to Acme Dashboard / main / ${path.basename(cwd)}`);
+    expect(stderr.buffer).toContain("Building locally. Done.");
+    expect(stderr.buffer).toContain("Packaging artifact. 10.6 MB.");
+    expect(stderr.buffer).toContain("Starting deployment. Container live.");
+    expect(stderr.buffer).toContain("Checking runtime health...");
+    expect(stderr.buffer).not.toContain("Status: running");
+    expect(stderr.buffer).not.toContain("Deployment is running at");
+  });
+
   it("lets --framework win over legacy --build-type for deploy", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
     const listApps = vi.fn().mockResolvedValue([
@@ -510,7 +654,8 @@ describe("app controller", () => {
       workspaceId: "ws_123",
       projectId: "proj_stale",
     });
-    expect(stderr.buffer).toContain("from PRISMA_PROJECT_ID");
+    expect(stderr.buffer).toContain(`Deploying ./${path.basename(cwd)} to Acme Dashboard / main / ${path.basename(cwd)}`);
+    expect(stderr.buffer).not.toContain("from PRISMA_PROJECT_ID");
   });
 
   it("returns FRAMEWORK_NOT_DETECTED before deploy when framework inference fails", async () => {

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -527,6 +527,74 @@ describe("app controller", () => {
     expect(stderr.buffer).not.toContain("Deployment is running at");
   });
 
+  it("renders deploy-failure copy when failure happens before runtime starts", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+    let appName = "";
+    const listApps = vi.fn().mockImplementation(async () => [
+      { id: "app_1", name: appName, region: "eu-central-1", liveDeploymentId: null, liveUrl: null },
+    ]);
+    const deployApp = vi.fn().mockImplementation(async (options: {
+      progress?: {
+        onBuildStart?: () => void;
+        onBuildComplete?: () => void;
+        onArchiveCreating?: () => void;
+        onArchiveReady?: (byteLength: number) => void;
+        onUploadStart?: () => void;
+      };
+    }) => {
+      options.progress?.onBuildStart?.();
+      options.progress?.onBuildComplete?.();
+      options.progress?.onArchiveCreating?.();
+      options.progress?.onArchiveReady?.(11_114_905);
+      options.progress?.onUploadStart?.();
+      throw new Error("Upload failed");
+    });
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/preview-provider", () => ({
+      createPreviewAppProvider: vi.fn(() => ({
+        listApps,
+        deployApp,
+        listDeployments: vi.fn(),
+        showDeployment: vi.fn(),
+      })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runAppDeploy } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    appName = path.basename(cwd);
+    await writeLocalPin(cwd, {
+      workspaceId: "ws_123",
+      projectId: "proj_123",
+    });
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      isTTY: false,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await expect(runAppDeploy(context, undefined, {
+      framework: "hono",
+    })).rejects.toMatchObject({
+      code: "DEPLOY_FAILED",
+      summary: "Deploy failed after the build completed.",
+      humanLines: expect.arrayContaining([
+        "Deploy failed after the build completed.",
+        "Build:       passed locally",
+        "Deploy:      artifact packaged, upload incomplete",
+        "Runtime:     not started",
+      ]),
+    });
+  });
+
   it("lets --framework win over legacy --build-type for deploy", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
     const listApps = vi.fn().mockResolvedValue([

--- a/packages/cli/tests/output.test.ts
+++ b/packages/cli/tests/output.test.ts
@@ -2,9 +2,36 @@ import { describe, expect, it } from "vitest";
 
 import { CliError } from "../src/shell/errors";
 import { writeHumanError } from "../src/shell/output";
+import { renderDeployOutputRows } from "../src/lib/app/deploy-output";
+import { plain } from "../src/shell/ui";
 import { createTempCwd, createTestCommandContext } from "./helpers";
 
 describe("shell output", () => {
+  it("aligns deploy output rows and dims origins when color is enabled", async () => {
+    const cwd = await createTempCwd();
+    const { context } = await createTestCommandContext({
+      cwd,
+      isTTY: true,
+      flags: { color: true },
+    });
+
+    const lines = renderDeployOutputRows(context.ui, [
+      { label: "Workspace", value: "Edith" },
+      { label: "Project", value: "j1", origin: "created from package.json" },
+      { label: "Runtime", value: "HTTP 3000", origin: "Next.js default" },
+      { label: "Uploaded" },
+    ]);
+
+    expect(plain(lines.join("\n"))).toBe([
+      "  Workspace  Edith",
+      "  Project    j1         · created from package.json",
+      "  Runtime    HTTP 3000  · Next.js default",
+      "  Uploaded",
+    ].join("\n"));
+    expect(lines[1]).toContain("\u001B[1m");
+    expect(lines[1]).toContain("\u001B[2m· created from package.json\u001B[22m");
+  });
+
   it("falls back to standard error formatting when humanLines is empty", async () => {
     const cwd = await createTempCwd();
     const { context, stderr } = await createTestCommandContext({ cwd });

--- a/packages/cli/tests/output.test.ts
+++ b/packages/cli/tests/output.test.ts
@@ -5,6 +5,58 @@ import { writeHumanError } from "../src/shell/output";
 import { createTempCwd, createTestCommandContext } from "./helpers";
 
 describe("shell output", () => {
+  it("falls back to standard error formatting when humanLines is empty", async () => {
+    const cwd = await createTempCwd();
+    const { context, stderr } = await createTestCommandContext({ cwd });
+
+    const error = new CliError({
+      code: "DEPLOY_FAILED",
+      domain: "app",
+      summary: "App deploy failed",
+      why: "Upload failed",
+      fix: "Retry the command.",
+      humanLines: [],
+    });
+
+    expect(error.humanLines).toBeNull();
+
+    writeHumanError(
+      context.output,
+      context.ui,
+      error,
+      { trace: false },
+    );
+
+    expect(stderr.buffer).toContain("App deploy failed [DEPLOY_FAILED]");
+    expect(stderr.buffer).toContain("Why: Upload failed");
+  });
+
+  it("clones custom human error lines before rendering", async () => {
+    const cwd = await createTempCwd();
+    const { context, stderr } = await createTestCommandContext({ cwd });
+    const humanLines = ["Custom failure."];
+
+    const error = new CliError({
+      code: "DEPLOY_FAILED",
+      domain: "app",
+      summary: "App deploy failed",
+      why: "Upload failed",
+      fix: "Retry the command.",
+      humanLines,
+    });
+    humanLines.push("Mutated after construction.");
+
+    writeHumanError(
+      context.output,
+      context.ui,
+      error,
+      { trace: false },
+    );
+
+    expect(stderr.buffer).toContain("Custom failure.");
+    expect(stderr.buffer).not.toContain("Mutated after construction.");
+  });
+
   it("renders debug details when --trace is enabled", async () => {
     const cwd = await createTempCwd();
     const { context, stderr } = await createTestCommandContext({


### PR DESCRIPTION
## Summary
- Make local deploy setup one-time by writing `.prisma/local.json` before build/deploy and using a compact retry header afterward.
- Replace misleading deploy progress with phase-based copy and a concise success block with `Runtime logs`.
- Add explicit build-failure and runtime-failure copy, plus controller coverage for both paths.

## Tests
- `pnpm --filter @prisma/cli exec vitest run tests/app-controller.test.ts tests/output.test.ts`
- `pnpm --filter @prisma/cli build`
- `pnpm --filter @prisma/cli test`