### PR TITLE
fix(build): nextjs standalone monorepo symlinks

### DIFF
--- a/packages/cli/src/lib/app/preview-build.ts
+++ b/packages/cli/src/lib/app/preview-build.ts
@@ -1,4 +1,4 @@
-import { chmod, copyFile, cp, lstat, mkdir, readdir, readlink, rm, stat } from "node:fs/promises";
+import { chmod, copyFile, cp, lstat, mkdir, readdir, readFile, readlink, rm, stat } from "node:fs/promises";
 import path from "node:path";
 
 import {
@@ -76,6 +76,10 @@ export async function executePreviewBuild(options: {
   const artifact = await strategy.execute();
 
   try {
+    if (buildType === "nextjs") {
+      await restageNextjsArtifact(artifact.directory, options.appPath);
+    }
+
     await normalizeArtifactSymlinks(artifact.directory, options.appPath);
     return {
       artifact,
@@ -168,11 +172,40 @@ export async function stageNextjsStandaloneArtifact(options: {
   const standaloneRoot = path.resolve(options.standaloneDir);
   const artifactRoot = path.resolve(options.artifactDir);
   const appRoot = path.resolve(options.appPath);
+  const sourceRoot = await resolveSourceRoot(appRoot);
 
   await copyPathMaterializingSymlinks(standaloneRoot, artifactRoot, {
     standaloneRoot,
     appRoot,
+    sourceRoot,
   });
+}
+
+async function restageNextjsArtifact(artifactDir: string, appPath: string): Promise<void> {
+  const standaloneDir = path.join(appPath, ".next", "standalone");
+
+  await rm(artifactDir, { recursive: true, force: true });
+  await stageNextjsStandaloneArtifact({
+    standaloneDir,
+    artifactDir,
+    appPath,
+  });
+
+  const publicDir = path.join(appPath, "public");
+  if (await directoryExists(publicDir)) {
+    await cp(publicDir, path.join(artifactDir, "public"), {
+      recursive: true,
+      verbatimSymlinks: true,
+    });
+  }
+
+  const staticDir = path.join(appPath, ".next", "static");
+  if (await directoryExists(staticDir)) {
+    await cp(staticDir, path.join(artifactDir, ".next", "static"), {
+      recursive: true,
+      verbatimSymlinks: true,
+    });
+  }
 }
 
 export async function normalizeArtifactSymlinks(
@@ -241,6 +274,7 @@ async function copyPathMaterializingSymlinks(
   options: {
     standaloneRoot: string;
     appRoot: string;
+    sourceRoot: string;
   },
 ): Promise<void> {
   const sourceStat = await lstat(sourcePath);
@@ -278,13 +312,17 @@ async function resolveSymlinkTarget(
   options: {
     standaloneRoot: string;
     appRoot: string;
+    sourceRoot: string;
   },
 ): Promise<string> {
   const linkTarget = await readlink(symlinkPath);
   const resolvedTarget = path.resolve(path.dirname(symlinkPath), linkTarget);
 
   if (await pathExists(resolvedTarget)) {
-    if (!isPathWithin(options.appRoot, resolvedTarget)) {
+    if (
+      !isPathWithin(options.appRoot, resolvedTarget) &&
+      !isPathWithin(options.sourceRoot, resolvedTarget)
+    ) {
       throw new Error(`Build artifact symlink escapes the app directory: ${resolvedTarget}`);
     }
 
@@ -311,6 +349,48 @@ async function pathExists(targetPath: string): Promise<boolean> {
   try {
     await stat(targetPath);
     return true;
+  } catch {
+    return false;
+  }
+}
+
+async function directoryExists(targetPath: string): Promise<boolean> {
+  try {
+    const targetStat = await stat(targetPath);
+    return targetStat.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function resolveSourceRoot(appRoot: string): Promise<string> {
+  let current = path.resolve(appRoot);
+
+  while (true) {
+    if (
+      await pathExists(path.join(current, ".git")) ||
+      await pathExists(path.join(current, "pnpm-workspace.yaml")) ||
+      await pathExists(path.join(current, "bun.lock")) ||
+      await pathExists(path.join(current, "bun.lockb")) ||
+      await packageJsonDeclaresWorkspaces(current)
+    ) {
+      return current;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return path.resolve(appRoot);
+    }
+
+    current = parent;
+  }
+}
+
+async function packageJsonDeclaresWorkspaces(directory: string): Promise<boolean> {
+  try {
+    const content = await readFile(path.join(directory, "package.json"), "utf8");
+    const parsed = JSON.parse(content) as { workspaces?: unknown };
+    return Boolean(parsed.workspaces);
   } catch {
     return false;
   }

--- a/packages/cli/tests/app-build.test.ts
+++ b/packages/cli/tests/app-build.test.ts
@@ -18,6 +18,10 @@ describe("preview build strategy", () => {
     const nextBin = path.join(appPath, "node_modules", ".bin", "next");
 
     await mkdir(path.join(standaloneDir, ".next", "static"), { recursive: true });
+    await mkdir(path.join(appPath, ".next", "static"), { recursive: true });
+    await writeFile(path.join(appPath, ".next", "static", "client.js"), "console.log('static');\n", "utf8");
+    await mkdir(path.join(appPath, "public"), { recursive: true });
+    await writeFile(path.join(appPath, "public", "hello.txt"), "hello\n", "utf8");
     await mkdir(path.dirname(nextBin), { recursive: true });
     await writeFile(path.join(appPath, "next.config.ts"), "export default { output: 'standalone' };\n", "utf8");
     await writeFile(path.join(standaloneDir, "server.js"), "console.log('next');\n", "utf8");
@@ -33,6 +37,8 @@ describe("preview build strategy", () => {
     expect(result.buildType).toBe("nextjs");
     expect(result.artifact.entrypoint).toBe("server.js");
     expect(result.artifact.defaultPortMapping).toEqual({ http: 3000 });
+    await expect(readFile(path.join(result.artifact.directory, ".next", "static", "client.js"), "utf8")).resolves.toContain("static");
+    await expect(readFile(path.join(result.artifact.directory, "public", "hello.txt"), "utf8")).resolves.toContain("hello");
     await result.artifact.cleanup?.();
   });
 
@@ -117,6 +123,34 @@ describe("preview build strategy", () => {
     expect((await lstat(copiedFallbackTarget)).isSymbolicLink()).toBe(false);
     await expect(readFile(path.join(copiedStandaloneTarget, "index.js"), "utf8")).resolves.toContain("sharp = true");
     await expect(readFile(path.join(copiedFallbackTarget, "index.js"), "utf8")).resolves.toContain("semver = true");
+  });
+
+  it("stages Next.js standalone symlinks that resolve through the monorepo root", async () => {
+    const { stageNextjsStandaloneArtifact } = await import("../src/lib/app/preview-build");
+    const cwd = await createTempCwd();
+    const repoRoot = path.join(cwd, "repo");
+    const appPath = path.join(repoRoot, "apps", "web");
+    const standaloneDir = path.join(appPath, ".next", "standalone");
+    const artifactDir = path.join(cwd, "artifact");
+    const rootDependency = path.join(repoRoot, "node_modules", "pg");
+    const standaloneLink = path.join(standaloneDir, "node_modules", "pg");
+
+    await mkdir(path.join(repoRoot, ".git"), { recursive: true });
+    await mkdir(rootDependency, { recursive: true });
+    await writeFile(path.join(rootDependency, "index.js"), "export const pg = true;\n", "utf8");
+    await mkdir(path.dirname(standaloneLink), { recursive: true });
+    await symlink(path.relative(path.dirname(standaloneLink), rootDependency), standaloneLink, "dir");
+
+    await stageNextjsStandaloneArtifact({
+      standaloneDir,
+      artifactDir,
+      appPath,
+    });
+
+    const copiedDependency = path.join(artifactDir, "node_modules", "pg");
+
+    expect((await lstat(copiedDependency)).isSymbolicLink()).toBe(false);
+    await expect(readFile(path.join(copiedDependency, "index.js"), "utf8")).resolves.toContain("pg = true");
   });
 
   it("rejects Next.js standalone symlinks that escape the app directory", async () => {


### PR DESCRIPTION
### Summary
Next.js standalone output can preserve relative `node_modules` symlinks that are valid in the source tree but resolve outside the app after the artifact is copied into a temp build directory. In monorepos this surfaced as: Build artifact symlink escapes the app directory: `/var/folders/.../T/node_modules/pg`.

- Restage Next.js standalone artifacts from the original app path, materialize symlinks against the app/repo root, and keep public plus `.next/static` assets in the final artifact.
- Add regression coverage for a monorepo-root dependency symlink.

Finding: Next docs also call out that standalone output and monorepos have special tracing behavior via outputFileTracingRoot, so this is a known sharp edge rather than a Prisma target-resolution issue.

### Testing
Verified in the populated workspace: pnpm --filter @prisma/cli test tests/app-build.test.ts; pnpm --filter @prisma/cli build; pnpm --filter @prisma/cli test.