### PR TITLE
fix(build): hoist pnpm transitive deps for Next.js standalone

### DIFF
--- a/docs/onboarding/testing.md
+++ b/docs/onboarding/testing.md
@@ -17,6 +17,17 @@ pnpm build:cli
 pnpm prepare:cli-publish
 ```
 
+Run the Next.js artifact smoke before publishing a preview CLI build that
+touches build, archive, or deploy packaging. This uses the compiled
+`packages/cli/dist/cli.js` against `examples/next-smoke` and verifies that the
+staged standalone artifact can resolve Next's pnpm-managed transitive
+dependencies:
+
+```bash
+pnpm build:cli
+pnpm smoke:cli-nextjs
+```
+
 ## What To Test
 
 - Command behavior and resolution rules.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build:cli": "pnpm --filter @prisma/cli build",
     "prepare:cli-publish": "node scripts/prepare-cli-publish.mjs",
+    "smoke:cli-nextjs": "node scripts/smoke-cli-nextjs-artifact.mjs",
     "test": "pnpm --filter @prisma/cli test",
     "prisma-cli": "tsx packages/cli/src/bin.ts",
     "prisma": "tsx packages/cli/src/bin.ts"

--- a/packages/cli/src/lib/app/preview-build.ts
+++ b/packages/cli/src/lib/app/preview-build.ts
@@ -179,6 +179,7 @@ export async function stageNextjsStandaloneArtifact(options: {
     appRoot,
     sourceRoot,
   });
+  await hoistPnpmDependencies(path.join(artifactRoot, "node_modules"));
 }
 
 async function restageNextjsArtifact(artifactDir: string, appPath: string): Promise<void> {
@@ -204,6 +205,51 @@ async function restageNextjsArtifact(artifactDir: string, appPath: string): Prom
     await cp(staticDir, path.join(artifactDir, ".next", "static"), {
       recursive: true,
       verbatimSymlinks: true,
+    });
+  }
+}
+
+async function hoistPnpmDependencies(nodeModulesDir: string): Promise<void> {
+  const pnpmNodeModulesDir = path.join(nodeModulesDir, ".pnpm", "node_modules");
+  if (!await directoryExists(pnpmNodeModulesDir)) {
+    return;
+  }
+
+  const entries = await readdir(pnpmNodeModulesDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const sourcePath = path.join(pnpmNodeModulesDir, entry.name);
+
+    if (entry.name.startsWith("@") && entry.isDirectory()) {
+      const scopedEntries = await readdir(sourcePath, { withFileTypes: true });
+      for (const scopedEntry of scopedEntries) {
+        const scopedDestination = path.join(nodeModulesDir, entry.name, scopedEntry.name);
+        if (await pathExists(scopedDestination)) {
+          continue;
+        }
+
+        await mkdir(path.dirname(scopedDestination), { recursive: true });
+        await copyPathMaterializingSymlinks(
+          path.join(sourcePath, scopedEntry.name),
+          scopedDestination,
+          {
+            standaloneRoot: pnpmNodeModulesDir,
+            appRoot: nodeModulesDir,
+            sourceRoot: nodeModulesDir,
+          },
+        );
+      }
+      continue;
+    }
+
+    const destinationPath = path.join(nodeModulesDir, entry.name);
+    if (await pathExists(destinationPath)) {
+      continue;
+    }
+
+    await copyPathMaterializingSymlinks(sourcePath, destinationPath, {
+      standaloneRoot: pnpmNodeModulesDir,
+      appRoot: nodeModulesDir,
+      sourceRoot: nodeModulesDir,
     });
   }
 }

--- a/packages/cli/tests/app-build.test.ts
+++ b/packages/cli/tests/app-build.test.ts
@@ -1,4 +1,5 @@
 import { chmod, lstat, mkdir, readFile, symlink, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -151,6 +152,56 @@ describe("preview build strategy", () => {
 
     expect((await lstat(copiedDependency)).isSymbolicLink()).toBe(false);
     await expect(readFile(path.join(copiedDependency, "index.js"), "utf8")).resolves.toContain("pg = true");
+  });
+
+  it("keeps pnpm transitive dependencies resolvable after flattening Next.js standalone packages", async () => {
+    const { stageNextjsStandaloneArtifact } = await import("../src/lib/app/preview-build");
+    const cwd = await createTempCwd();
+    const appPath = path.join(cwd, "app");
+    const standaloneDir = path.join(appPath, ".next", "standalone");
+    const artifactDir = path.join(cwd, "artifact");
+    const nextStorePackage = path.join(
+      standaloneDir,
+      "node_modules/.pnpm/next@16.2.3/node_modules/next",
+    );
+    const nextLink = path.join(standaloneDir, "node_modules/next");
+    const swcHelperPackage = path.join(
+      standaloneDir,
+      "node_modules/.pnpm/@swc+helpers@0.5.15/node_modules/@swc/helpers/_",
+    );
+    const swcHoistedLink = path.join(
+      standaloneDir,
+      "node_modules/.pnpm/node_modules/@swc/helpers",
+    );
+
+    await mkdir(path.join(nextStorePackage, "dist/shared/lib"), { recursive: true });
+    await writeFile(
+      path.join(nextStorePackage, "dist/shared/lib/constants.js"),
+      "module.exports = require('@swc/helpers/_/_interop_require_default');\n",
+      "utf8",
+    );
+    await mkdir(path.dirname(nextLink), { recursive: true });
+    await symlink(".pnpm/next@16.2.3/node_modules/next", nextLink, "dir");
+
+    await mkdir(swcHelperPackage, { recursive: true });
+    await writeFile(
+      path.join(swcHelperPackage, "_interop_require_default.js"),
+      "module.exports = { default: true };\n",
+      "utf8",
+    );
+    await mkdir(path.dirname(swcHoistedLink), { recursive: true });
+    await symlink("../../@swc+helpers@0.5.15/node_modules/@swc/helpers", swcHoistedLink, "dir");
+
+    await stageNextjsStandaloneArtifact({
+      standaloneDir,
+      artifactDir,
+      appPath,
+    });
+
+    const constants = path.join(artifactDir, "node_modules/next/dist/shared/lib/constants.js");
+    const requireFromNext = createRequire(constants);
+
+    expect(() => requireFromNext.resolve("@swc/helpers/_/_interop_require_default")).not.toThrow();
   });
 
   it("rejects Next.js standalone symlinks that escape the app directory", async () => {

--- a/scripts/smoke-cli-nextjs-artifact.mjs
+++ b/scripts/smoke-cli-nextjs-artifact.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+
+import { createRequire } from "node:module";
+import { rm } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const cliPath = path.join(repoRoot, "packages/cli/dist/cli.js");
+const fixturePath = path.join(repoRoot, "examples/next-smoke");
+
+await runFixtureInstall();
+const result = await runCliBuild();
+const artifactDir = result.result?.directory;
+
+if (!artifactDir || typeof artifactDir !== "string") {
+  throw new Error("CLI build output did not include result.directory");
+}
+
+try {
+  const constantsPath = path.join(
+    artifactDir,
+    "node_modules/next/dist/shared/lib/constants.js",
+  );
+  const requireFromNext = createRequire(constantsPath);
+  const resolved = requireFromNext.resolve("@swc/helpers/_/_interop_require_default");
+
+  process.stdout.write(`Next.js artifact smoke passed: ${resolved}\n`);
+} finally {
+  await rm(path.dirname(artifactDir), { recursive: true, force: true });
+}
+
+async function runFixtureInstall() {
+  const exit = await runCommand("pnpm", ["install", "--frozen-lockfile"], {
+    cwd: fixturePath,
+    env: process.env,
+  });
+
+  if (exit !== 0) {
+    throw new Error(`Next.js smoke fixture install failed with exit code ${exit}`);
+  }
+}
+
+async function runCliBuild() {
+  const child = spawn(
+    process.execPath,
+    [cliPath, "app", "build", "--build-type", "nextjs", "--json"],
+    {
+      cwd: fixturePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        INIT_CWD: fixturePath,
+      },
+    },
+  );
+
+  const [stdout, stderr, exit] = await Promise.all([
+    collect(child.stdout),
+    collect(child.stderr),
+    waitForExit(child),
+  ]);
+
+  if (exit !== 0) {
+    throw new Error(
+      `CLI Next.js build smoke failed with exit code ${exit}\n\nstderr:\n${stderr}\n\nstdout:\n${stdout}`,
+    );
+  }
+
+  try {
+    return JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(
+      `CLI Next.js build smoke returned invalid JSON: ${error instanceof Error ? error.message : String(error)}\n\nstdout:\n${stdout}`,
+    );
+  }
+}
+
+async function runCommand(command, args, options) {
+  const child = spawn(command, args, {
+    cwd: options.cwd,
+    stdio: "inherit",
+    env: options.env,
+  });
+
+  return waitForExit(child);
+}
+
+function collect(stream) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    stream.on("data", (chunk) => {
+      chunks.push(chunk);
+    });
+    stream.on("error", reject);
+    stream.on("end", () => {
+      resolve(Buffer.concat(chunks).toString("utf8"));
+    });
+  });
+}
+
+function waitForExit(child) {
+  return new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      resolve(code ?? 1);
+    });
+  });
+}


### PR DESCRIPTION
### Summary
The previous Next.js standalone symlink fix solved the monorepo/root dependency escape, but it broke normal pnpm-managed Next.js deploys after publish.

Runtime failure:

```
Cannot find module '@swc/helpers/_/_interop_require_default' from '/mnt/app/app/bundle/node_modules/next/dist/shared/lib/constants.js'
```

Root cause: we flattened top-level packages like `node_modules/next`, so Bun resolved from `bundle/node_modules/next` instead of the original pnpm store ancestry. pnpm-managed transitive deps such as `@swc/helpers` were still present under `.pnpm/node_modules`, but no longer visible to runtime resolution from the flattened `next` directory.

Fix:
- Hoist entries from `node_modules/.pnpm/node_modules` into staged top-level `node_modules` while preserving existing direct dependencies.
- Add a regression that verifies `@swc/helpers/_/_interop_require_default` resolves from `node_modules/next/dist/shared/lib/constants.js` after staging.
- Add `pnpm smoke:cli-nextjs` as a local pre-publish gate using the compiled `packages/cli/dist/cli.js` against `examples/next-smoke`.

### Testing
- `pnpm --filter @prisma/cli test tests/app-build.test.ts`
- `pnpm build:cli`
- `pnpm smoke:cli-nextjs`
- `pnpm --filter @prisma/cli test`