### PR TITLE
fix(cli): place Next.js public/static next to nested server.js for mo…

### DIFF
--- a/packages/cli/src/lib/app/preview-build.ts
+++ b/packages/cli/src/lib/app/preview-build.ts
@@ -220,6 +220,7 @@ export async function restageNextjsArtifact(artifact: BuildArtifact, appPath: st
 }
 
 function nextjsServerSubpath(entrypoint: string): string {
+  // SDK emits posix-style entrypoints (path.posix.join).
   const dir = path.posix.dirname(entrypoint);
   return dir === "." ? "" : dir;
 }

--- a/packages/cli/src/lib/app/preview-build.ts
+++ b/packages/cli/src/lib/app/preview-build.ts
@@ -77,7 +77,7 @@ export async function executePreviewBuild(options: {
 
   try {
     if (buildType === "nextjs") {
-      await restageNextjsArtifact(artifact.directory, options.appPath);
+      await restageNextjsArtifact(artifact, options.appPath);
     }
 
     await normalizeArtifactSymlinks(artifact.directory, options.appPath);
@@ -182,7 +182,8 @@ export async function stageNextjsStandaloneArtifact(options: {
   await hoistPnpmDependencies(path.join(artifactRoot, "node_modules"));
 }
 
-async function restageNextjsArtifact(artifactDir: string, appPath: string): Promise<void> {
+export async function restageNextjsArtifact(artifact: BuildArtifact, appPath: string): Promise<void> {
+  const artifactDir = artifact.directory;
   const standaloneDir = path.join(appPath, ".next", "standalone");
 
   await rm(artifactDir, { recursive: true, force: true });
@@ -192,9 +193,18 @@ async function restageNextjsArtifact(artifactDir: string, appPath: string): Prom
     appPath,
   });
 
+  // The SDK's Next.js strategy reports the entrypoint relative to the
+  // artifact root (e.g. "server.js" for single-app, "apps/web/server.js"
+  // for a monorepo). Next expects public/ and .next/static/ to live next
+  // to server.js, so re-stage them at the same subpath.
+  const serverSubpath = nextjsServerSubpath(artifact.entrypoint);
+  const serverDir = serverSubpath
+    ? path.join(artifactDir, serverSubpath)
+    : artifactDir;
+
   const publicDir = path.join(appPath, "public");
   if (await directoryExists(publicDir)) {
-    await cp(publicDir, path.join(artifactDir, "public"), {
+    await cp(publicDir, path.join(serverDir, "public"), {
       recursive: true,
       verbatimSymlinks: true,
     });
@@ -202,11 +212,16 @@ async function restageNextjsArtifact(artifactDir: string, appPath: string): Prom
 
   const staticDir = path.join(appPath, ".next", "static");
   if (await directoryExists(staticDir)) {
-    await cp(staticDir, path.join(artifactDir, ".next", "static"), {
+    await cp(staticDir, path.join(serverDir, ".next", "static"), {
       recursive: true,
       verbatimSymlinks: true,
     });
   }
+}
+
+function nextjsServerSubpath(entrypoint: string): string {
+  const dir = path.posix.dirname(entrypoint);
+  return dir === "." ? "" : dir;
 }
 
 async function hoistPnpmDependencies(nodeModulesDir: string): Promise<void> {

--- a/packages/cli/tests/app-build.test.ts
+++ b/packages/cli/tests/app-build.test.ts
@@ -204,6 +204,41 @@ describe("preview build strategy", () => {
     expect(() => requireFromNext.resolve("@swc/helpers/_/_interop_require_default")).not.toThrow();
   });
 
+  it("places public and .next/static next to server.js when the entrypoint is nested (monorepo)", async () => {
+    const { restageNextjsArtifact } = await import("../src/lib/app/preview-build");
+    const cwd = await createTempCwd();
+    const appPath = path.join(cwd, "repo", "apps", "web");
+    const standaloneDir = path.join(appPath, ".next", "standalone");
+    const nestedServerDir = path.join(standaloneDir, "apps", "web");
+    const artifactDir = path.join(cwd, "artifact");
+
+    await mkdir(path.join(cwd, "repo", ".git"), { recursive: true });
+    await mkdir(nestedServerDir, { recursive: true });
+    await writeFile(path.join(nestedServerDir, "server.js"), "// nested server\n", "utf8");
+    await mkdir(path.join(standaloneDir, "node_modules"), { recursive: true });
+
+    await mkdir(path.join(appPath, "public"), { recursive: true });
+    await writeFile(path.join(appPath, "public", "hello.txt"), "hello\n", "utf8");
+    await mkdir(path.join(appPath, ".next", "static"), { recursive: true });
+    await writeFile(path.join(appPath, ".next", "static", "client.js"), "// static\n", "utf8");
+
+    // Seed an existing (incorrect) artifact directory to mirror what the SDK
+    // produces before the CLI re-stages it.
+    await mkdir(artifactDir, { recursive: true });
+
+    await restageNextjsArtifact(
+      { directory: artifactDir, entrypoint: "apps/web/server.js" },
+      appPath,
+    );
+
+    await expect(
+      readFile(path.join(artifactDir, "apps", "web", "public", "hello.txt"), "utf8"),
+    ).resolves.toContain("hello");
+    await expect(
+      readFile(path.join(artifactDir, "apps", "web", ".next", "static", "client.js"), "utf8"),
+    ).resolves.toContain("static");
+  });
+
   it("rejects Next.js standalone symlinks that escape the app directory", async () => {
     const { stageNextjsStandaloneArtifact } = await import("../src/lib/app/preview-build");
     const cwd = await createTempCwd();


### PR DESCRIPTION
This PR pairs with: https://github.com/prisma/project-compute/pull/78

Deploying a Next.js app from inside a monorepo failed because the artifact's declared entrypoint and the on-disk location of `server.js` disagreed.

When `output: "standalone"` runs in a monorepo, Next preserves the workspace-relative path from the workspace root down to the app. So for an app at `apps/web`, `server.js` lands at `.next/standalone/apps/web/server.js`, not at the standalone root. The deploy pipeline assumed `server.js` was always at the root: the SDK reported `entrypoint: "server.js"` and the CLI copied `public/` and `.next/static/` to the artifact root, so the runtime couldn't find the server and static assets 404'd.

Fix:
- (in `@prisma/compute-sdk`, see [link to SDK PR]) the Next adapter now scans the standalone output for `server.js` (skipping `node_modules` to avoid third-party decoys) and reports a posix-joined entrypoint such as `apps/web/server.js`.
- This PR makes `restageNextjsArtifact` accept the `BuildArtifact`, derive the server subpath from `entrypoint`, and place `public/` and `.next/static/` next to `server.js` instead of at the artifact root.
- Add a regression test covering the monorepo case (server.js nested at `apps/web/server.js`, assets land under `apps/web/public/` and `apps/web/.next/static/`).

Single-app deploys (entrypoint `"server.js"`, derived subpath `""`) are unchanged.

### Coupling with the SDK
This change requires `@prisma/compute-sdk` ≥ 0.19 to take effect — that's the version that actually emits the nested entrypoint. Against 0.18.x the entrypoint is always `"server.js"`, the derived subpath is empty, and behavior matches the prior code. The dep bump can land in this PR or a follow-up.