### PR TITLE
fix: coordinate CLI auth refreshes

### DIFF
--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -63,6 +63,8 @@ The CLI accepts two authentication sources, in this fixed precedence:
 1. `PRISMA_SERVICE_TOKEN` environment variable — long-lived service token, intended for CI and other headless contexts.
 2. Stored OAuth session — created by `prisma-cli auth login`, kept in the OS-appropriate credentials store, refreshed automatically.
 
+Stored OAuth sessions include a short-lived access token and a refresh token. Commands refresh the access token automatically when the API rejects it, coordinate refreshes across concurrent CLI processes, and tolerate short refresh-token rotation races. If the stored session cannot be refreshed, commands fail with a structured `AUTH_REQUIRED` error instead of surfacing SDK stack traces.
+
 When `PRISMA_SERVICE_TOKEN` is set and non-empty, the token is fully sufficient for authenticated commands. If `PRISMA_SERVICE_TOKEN` is set but empty or only whitespace, commands fail with an auth configuration error instead of falling back to stored OAuth. The CLI does not read any locally stored OAuth session when a non-empty service token is present, so behavior is identical on a fresh runner and a developer machine that happens to be signed in. The active workspace is derived from the token's `sub` claim; no additional flag or environment variable is required for the common case where the token is scoped to a single workspace.
 
 `auth login` and `auth logout` operate on the stored OAuth session. They do not affect the `PRISMA_SERVICE_TOKEN` environment variable.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,7 @@
     "@prisma/compute-sdk": "^0.18.0",
     "c12": "4.0.0-beta.4",
     "@prisma/credentials-store": "^7.7.0",
-    "@prisma/management-api-sdk": "^1.27.0",
+    "@prisma/management-api-sdk": "^1.32.1",
     "colorette": "^2.0.20",
     "commander": "^12.1.0",
     "magicast": "^0.3.5",

--- a/packages/cli/src/adapters/token-storage.ts
+++ b/packages/cli/src/adapters/token-storage.ts
@@ -1,5 +1,6 @@
 import { CredentialsStore } from "@prisma/credentials-store";
 import type { TokenStorage, Tokens } from "@prisma/management-api-sdk";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { getAuthFilePath } from "../lib/auth/client";
@@ -88,28 +89,34 @@ export class FileTokenStorage implements TokenStorage {
   }
 
   async withRefreshLock<T>(fn: () => Promise<T>): Promise<T> {
-    await this.acquireRefreshLock();
+    const lockId = await this.acquireRefreshLock();
     try {
       return await fn();
     } finally {
-      await fs.unlink(this.lockFilePath).catch(() => {});
+      await this.releaseRefreshLock(lockId);
     }
   }
 
-  private async acquireRefreshLock(): Promise<void> {
+  private async acquireRefreshLock(): Promise<string> {
+    const lockId = randomUUID();
     await fs.mkdir(path.dirname(this.lockFilePath), { recursive: true });
 
     while (true) {
       try {
         const handle = await fs.open(this.lockFilePath, "wx");
-        await handle.close();
-        return;
+        try {
+          await handle.writeFile(lockId, "utf8");
+        } finally {
+          await handle.close();
+        }
+        return lockId;
       } catch (error) {
         const code = (error as NodeJS.ErrnoException).code;
         if (code !== "EEXIST") throw error;
 
-        if (await this.isRefreshLockStale()) {
-          await fs.unlink(this.lockFilePath).catch(() => {});
+        const staleLockId = await this.getStaleRefreshLockId();
+        if (staleLockId) {
+          await this.releaseRefreshLock(staleLockId);
           continue;
         }
 
@@ -118,9 +125,18 @@ export class FileTokenStorage implements TokenStorage {
     }
   }
 
-  private async isRefreshLockStale(): Promise<boolean> {
+  private async getStaleRefreshLockId(): Promise<string | null> {
+    const lockId = await fs.readFile(this.lockFilePath, "utf8").catch(() => null);
+    if (lockId === null) return null;
+
     const stats = await fs.stat(this.lockFilePath).catch(() => null);
-    if (!stats) return false;
-    return Date.now() - stats.mtimeMs > 30_000;
+    if (!stats) return null;
+    return Date.now() - stats.mtimeMs > 30_000 ? lockId : null;
+  }
+
+  private async releaseRefreshLock(lockId: string): Promise<void> {
+    const currentLockId = await fs.readFile(this.lockFilePath, "utf8").catch(() => null);
+    if (currentLockId !== lockId) return;
+    await fs.unlink(this.lockFilePath).catch(() => {});
   }
 }

--- a/packages/cli/src/adapters/token-storage.ts
+++ b/packages/cli/src/adapters/token-storage.ts
@@ -1,5 +1,7 @@
 import { CredentialsStore } from "@prisma/credentials-store";
 import type { TokenStorage, Tokens } from "@prisma/management-api-sdk";
+import fs from "node:fs/promises";
+import path from "node:path";
 import { getAuthFilePath } from "../lib/auth/client";
 
 interface StoredCredential {
@@ -33,11 +35,26 @@ function findLatestValidTokens(allCredentials: StoredCredential[]): Tokens | nul
   return null;
 }
 
+function tokensEqual(a: Tokens | null, b: Tokens | null): boolean {
+  return (
+    a?.workspaceId === b?.workspaceId &&
+    a?.accessToken === b?.accessToken &&
+    a?.refreshToken === b?.refreshToken
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export class FileTokenStorage implements TokenStorage {
   private readonly credentialsStore: CredentialsStore;
+  private readonly lockFilePath: string;
 
   constructor(env: NodeJS.ProcessEnv = process.env) {
-    this.credentialsStore = new CredentialsStore(getAuthFilePath(env));
+    const authFilePath = getAuthFilePath(env);
+    this.credentialsStore = new CredentialsStore(authFilePath);
+    this.lockFilePath = `${authFilePath}.lock`;
   }
 
   async getTokens(): Promise<Tokens | null> {
@@ -62,5 +79,48 @@ export class FileTokenStorage implements TokenStorage {
     const tokens = findLatestValidTokens(all as StoredCredential[]);
     if (!tokens) return;
     await this.credentialsStore.deleteCredentials(tokens.workspaceId);
+  }
+
+  async clearTokensIfCurrent(tokens: Tokens): Promise<void> {
+    const current = await this.getTokens();
+    if (!tokensEqual(current, tokens)) return;
+    await this.clearTokens();
+  }
+
+  async withRefreshLock<T>(fn: () => Promise<T>): Promise<T> {
+    await this.acquireRefreshLock();
+    try {
+      return await fn();
+    } finally {
+      await fs.unlink(this.lockFilePath).catch(() => {});
+    }
+  }
+
+  private async acquireRefreshLock(): Promise<void> {
+    await fs.mkdir(path.dirname(this.lockFilePath), { recursive: true });
+
+    while (true) {
+      try {
+        const handle = await fs.open(this.lockFilePath, "wx");
+        await handle.close();
+        return;
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== "EEXIST") throw error;
+
+        if (await this.isRefreshLockStale()) {
+          await fs.unlink(this.lockFilePath).catch(() => {});
+          continue;
+        }
+
+        await sleep(100);
+      }
+    }
+  }
+
+  private async isRefreshLockStale(): Promise<boolean> {
+    const stats = await fs.stat(this.lockFilePath).catch(() => null);
+    if (!stats) return false;
+    return Date.now() - stats.mtimeMs > 30_000;
   }
 }

--- a/packages/cli/src/shell/command-runner.ts
+++ b/packages/cli/src/shell/command-runner.ts
@@ -1,7 +1,7 @@
 import { AuthError as SDKAuthError } from "@prisma/management-api-sdk";
 import type { CommandDescriptor } from "./command-meta";
 import { getCommandDescriptor } from "./command-meta";
-import { CliError } from "./errors";
+import { authRequiredError, CliError } from "./errors";
 import { resolveGlobalFlags } from "./global-flags";
 import type { CommandSuccess } from "./output";
 import { cliErrorToJson, writeHumanError, writeHumanLines, writeJsonError, writeJsonEvent, writeJsonSuccess } from "./output";
@@ -20,16 +20,7 @@ function toCliError(error: unknown): CliError | null {
   if (error instanceof CliError) return error;
 
   if (error instanceof SDKAuthError) {
-    return new CliError({
-      code: "AUTH_REQUIRED",
-      domain: "auth",
-      summary: "Authentication required",
-      why: "This command needs an authenticated session.",
-      fix: "Run prisma-cli auth login, then retry the command.",
-      debug: error.message,
-      exitCode: 1,
-      nextSteps: ["prisma-cli auth login"],
-    });
+    return authRequiredError(["prisma-cli auth login"], { debug: error.message });
   }
 
   return null;

--- a/packages/cli/src/shell/command-runner.ts
+++ b/packages/cli/src/shell/command-runner.ts
@@ -1,3 +1,4 @@
+import { AuthError as SDKAuthError } from "@prisma/management-api-sdk";
 import type { CommandDescriptor } from "./command-meta";
 import { getCommandDescriptor } from "./command-meta";
 import { CliError } from "./errors";
@@ -13,6 +14,25 @@ interface CommandPresenter<T> {
     result: T,
   ) => string[];
   renderJson?: (result: T) => unknown;
+}
+
+function toCliError(error: unknown): CliError | null {
+  if (error instanceof CliError) return error;
+
+  if (error instanceof SDKAuthError) {
+    return new CliError({
+      code: "AUTH_REQUIRED",
+      domain: "auth",
+      summary: "Authentication required",
+      why: "This command needs an authenticated session.",
+      fix: "Run prisma-cli auth login, then retry the command.",
+      debug: error.message,
+      exitCode: 1,
+      nextSteps: ["prisma-cli auth login"],
+    });
+  }
+
+  return null;
 }
 
 export async function runCommand<T>(
@@ -43,14 +63,15 @@ export async function runCommand<T>(
 
     writeHumanLines(context.output, presenter.renderHuman(context, descriptor, success.result));
   } catch (error) {
-    if (error instanceof CliError) {
+    const cliError = toCliError(error);
+    if (cliError) {
       if (flags.json) {
-        writeJsonError(context.output, commandName, error);
+        writeJsonError(context.output, commandName, cliError);
       } else {
-        writeHumanError(context.output, context.ui, error, { trace: flags.trace });
+        writeHumanError(context.output, context.ui, cliError, { trace: flags.trace });
       }
 
-      process.exitCode = error.exitCode;
+      process.exitCode = cliError.exitCode;
       return;
     }
 
@@ -81,21 +102,22 @@ export async function runStreamingCommand(
       });
     }
   } catch (error) {
-    if (error instanceof CliError) {
+    const cliError = toCliError(error);
+    if (cliError) {
       if (flags.json) {
         writeJsonEvent(context.output, {
           type: "error",
           command: commandName,
           timestamp: new Date().toISOString(),
-          error: cliErrorToJson(error),
+          error: cliErrorToJson(cliError),
           warnings: [],
-          nextSteps: error.nextSteps,
+          nextSteps: cliError.nextSteps,
         });
       } else {
-        writeHumanError(context.output, context.ui, error, { trace: flags.trace });
+        writeHumanError(context.output, context.ui, cliError, { trace: flags.trace });
       }
 
-      process.exitCode = error.exitCode;
+      process.exitCode = cliError.exitCode;
       return;
     }
 

--- a/packages/cli/src/shell/errors.ts
+++ b/packages/cli/src/shell/errors.ts
@@ -65,13 +65,17 @@ export function usageError(
   });
 }
 
-export function authRequiredError(nextSteps: string[] = ["prisma-cli auth login"]): CliError {
+export function authRequiredError(
+  nextSteps: string[] = ["prisma-cli auth login"],
+  options: { debug?: string | null } = {},
+): CliError {
   return new CliError({
     code: "AUTH_REQUIRED",
     domain: "auth",
     summary: "Authentication required",
     why: "This command needs an authenticated session.",
     fix: "Run prisma-cli auth login, or rerun the command in a TTY to sign in interactively.",
+    debug: options.debug,
     exitCode: 1,
     nextSteps,
   });

--- a/packages/cli/tests/command-runner-auth.test.ts
+++ b/packages/cli/tests/command-runner-auth.test.ts
@@ -1,0 +1,124 @@
+import { AuthError as SDKAuthError } from "@prisma/management-api-sdk";
+import { PassThrough, Writable } from "node:stream";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runCommand, runStreamingCommand } from "../src/shell/command-runner";
+import type { CliRuntime } from "../src/shell/runtime";
+import { createTempCwd } from "./helpers";
+
+class CaptureStream extends Writable {
+  buffer = "";
+  declare isTTY?: boolean;
+  declare columns?: number;
+  declare rows?: number;
+
+  _write(chunk: Buffer | string, _encoding: BufferEncoding, callback: (error?: Error | null) => void) {
+    this.buffer += chunk.toString();
+    callback();
+  }
+}
+
+class CaptureInput extends PassThrough {
+  declare isTTY?: boolean;
+  setRawMode(_value: boolean) {
+    return this;
+  }
+}
+
+async function createRuntime(argv: string[]): Promise<{
+  runtime: CliRuntime;
+  stdout: CaptureStream;
+  stderr: CaptureStream;
+}> {
+  const stdout = new CaptureStream();
+  const stderr = new CaptureStream();
+  stdout.isTTY = false;
+  stderr.isTTY = false;
+  stdout.columns = 80;
+  stderr.columns = 80;
+  stdout.rows = 24;
+  stderr.rows = 24;
+
+  const stdin = new CaptureInput();
+  stdin.isTTY = false;
+  stdin.end();
+
+  return {
+    runtime: {
+      argv,
+      cwd: await createTempCwd(),
+      env: { ...process.env },
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+    },
+    stdout,
+    stderr,
+  };
+}
+
+afterEach(() => {
+  process.exitCode = undefined;
+});
+
+describe("command runner auth errors", () => {
+  it("renders SDK auth failures as structured CLI errors", async () => {
+    const { runtime, stderr } = await createRuntime(["auth", "whoami"]);
+
+    await runCommand(
+      runtime,
+      "auth.whoami",
+      {},
+      async () => {
+        throw new SDKAuthError("invalid_grant: Invalid grant", true);
+      },
+      {
+        renderHuman: () => [],
+      },
+    );
+
+    expect(process.exitCode).toBe(1);
+    expect(stderr.buffer).toContain("Authentication required [AUTH_REQUIRED]");
+    expect(stderr.buffer).toContain("Next step:");
+    expect(stderr.buffer).toContain("prisma-cli auth login");
+    expect(stderr.buffer).not.toContain("invalid_grant");
+  });
+
+  it("shows SDK auth details only with trace enabled", async () => {
+    const { runtime, stderr } = await createRuntime(["auth", "whoami", "--trace"]);
+
+    await runCommand(
+      runtime,
+      "auth.whoami",
+      {},
+      async () => {
+        throw new SDKAuthError("invalid_grant: Invalid grant", true);
+      },
+      {
+        renderHuman: () => [],
+      },
+    );
+
+    expect(stderr.buffer).toContain("Trace:");
+    expect(stderr.buffer).toContain("invalid_grant: Invalid grant");
+  });
+
+  it("renders streaming SDK auth failures as JSON events", async () => {
+    const { runtime, stdout } = await createRuntime(["--json", "app", "deploy"]);
+
+    await runStreamingCommand(runtime, "app.deploy", {}, async () => {
+      throw new SDKAuthError("invalid_grant: Invalid grant", true);
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(stdout.buffer)).toMatchObject({
+      type: "error",
+      command: "app.deploy",
+      error: {
+        code: "AUTH_REQUIRED",
+        domain: "auth",
+      },
+      nextSteps: ["prisma-cli auth login"],
+    });
+  });
+});

--- a/packages/cli/tests/token-storage.test.ts
+++ b/packages/cli/tests/token-storage.test.ts
@@ -114,4 +114,74 @@ describe("FileTokenStorage", () => {
       code: "ENOENT",
     });
   });
+
+  it("does not remove another caller's active lock after stale takeover", async () => {
+    const cwd = await createTempCwd();
+    const authFilePath = path.join(cwd, "auth.json");
+    const lockFilePath = `${authFilePath}.lock`;
+    const firstStorage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+    const secondStorage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+    const events: string[] = [];
+    let releaseFirst!: () => void;
+    let markFirstStarted!: () => void;
+    let releaseSecond!: () => void;
+    let markSecondStarted!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+    const firstReleased = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const secondStarted = new Promise<void>((resolve) => {
+      markSecondStarted = resolve;
+    });
+    const secondReleased = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+
+    const first = firstStorage.withRefreshLock(async () => {
+      events.push("first:start");
+      markFirstStarted();
+      await firstReleased;
+      events.push("first:end");
+    });
+
+    await firstStarted;
+    const firstLockId = await fs.readFile(lockFilePath, "utf8");
+    const staleTime = new Date(Date.now() - 31_000);
+    await fs.utimes(lockFilePath, staleTime, staleTime);
+
+    const second = secondStorage.withRefreshLock(async () => {
+      events.push("second:start");
+      markSecondStarted();
+      await secondReleased;
+      events.push("second:end");
+    });
+
+    await secondStarted;
+    const secondLockId = await fs.readFile(lockFilePath, "utf8");
+    expect(secondLockId).not.toEqual(firstLockId);
+
+    releaseFirst();
+    await first;
+
+    await expect(fs.readFile(lockFilePath, "utf8")).resolves.toBe(secondLockId);
+
+    releaseSecond();
+    await second;
+
+    expect(events).toEqual([
+      "first:start",
+      "second:start",
+      "first:end",
+      "second:end",
+    ]);
+    await expect(fs.stat(lockFilePath)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
 });

--- a/packages/cli/tests/token-storage.test.ts
+++ b/packages/cli/tests/token-storage.test.ts
@@ -1,0 +1,117 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { FileTokenStorage } from "../src/adapters/token-storage";
+import { createTempCwd } from "./helpers";
+
+async function writeAuthFile(authFilePath: string, tokens: unknown[]): Promise<void> {
+  await fs.mkdir(path.dirname(authFilePath), { recursive: true });
+  await fs.writeFile(authFilePath, JSON.stringify({ tokens }, null, 2));
+}
+
+describe("FileTokenStorage", () => {
+  it("clears tokens only when they still match the caller's stale view", async () => {
+    const cwd = await createTempCwd();
+    const authFilePath = path.join(cwd, "auth.json");
+    const staleCredential = {
+      workspaceId: "workspace-1",
+      token: "old-access-token",
+      refreshToken: "old-refresh-token",
+    };
+    const freshCredential = {
+      workspaceId: "workspace-1",
+      token: "new-access-token",
+      refreshToken: "new-refresh-token",
+    };
+    await writeAuthFile(authFilePath, [freshCredential]);
+
+    const storage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+
+    await storage.clearTokensIfCurrent({
+      workspaceId: staleCredential.workspaceId,
+      accessToken: staleCredential.token,
+      refreshToken: staleCredential.refreshToken,
+    });
+
+    await expect(storage.getTokens()).resolves.toEqual({
+      workspaceId: freshCredential.workspaceId,
+      accessToken: freshCredential.token,
+      refreshToken: freshCredential.refreshToken,
+    });
+  });
+
+  it("serializes refresh work with an auth-file-adjacent lock", async () => {
+    const cwd = await createTempCwd();
+    const authFilePath = path.join(cwd, "auth.json");
+    const storage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+    const events: string[] = [];
+    let releaseFirst!: () => void;
+    let markFirstStarted!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+    const firstReleased = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = storage.withRefreshLock(async () => {
+      events.push("first:start");
+      markFirstStarted();
+      await firstReleased;
+      events.push("first:end");
+    });
+
+    await firstStarted;
+
+    const second = storage.withRefreshLock(async () => {
+      events.push("second:start");
+      events.push("second:end");
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(events).toEqual(["first:start"]);
+
+    releaseFirst();
+    await Promise.all([first, second]);
+
+    expect(events).toEqual([
+      "first:start",
+      "first:end",
+      "second:start",
+      "second:end",
+    ]);
+    await expect(fs.stat(`${authFilePath}.lock`)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("replaces stale refresh locks", async () => {
+    const cwd = await createTempCwd();
+    const authFilePath = path.join(cwd, "auth.json");
+    const lockFilePath = `${authFilePath}.lock`;
+    await fs.mkdir(path.dirname(lockFilePath), { recursive: true });
+    await fs.writeFile(lockFilePath, "stale");
+    const staleTime = new Date(Date.now() - 31_000);
+    await fs.utimes(lockFilePath, staleTime, staleTime);
+
+    const storage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+    let ran = false;
+
+    await storage.withRefreshLock(async () => {
+      ran = true;
+    });
+
+    expect(ran).toBe(true);
+    await expect(fs.stat(lockFilePath)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,13 +19,13 @@ importers:
         version: 1.2.0
       '@prisma/compute-sdk':
         specifier: ^0.18.0
-        version: 0.18.0(@prisma/management-api-sdk@1.27.0)
+        version: 0.18.0(@prisma/management-api-sdk@1.32.1)
       '@prisma/credentials-store':
         specifier: ^7.7.0
         version: 7.7.0
       '@prisma/management-api-sdk':
-        specifier: ^1.27.0
-        version: 1.27.0
+        specifier: ^1.32.1
+        version: 1.32.1
       c12:
         specifier: 4.0.0-beta.4
         version: 4.0.0-beta.4(jiti@2.6.1)(magicast@0.3.5)
@@ -292,8 +292,8 @@ packages:
   '@prisma/credentials-store@7.7.0':
     resolution: {integrity: sha512-SVaMCL1Q8rFPKQB5W9B7HDuRdD/KyBfKjCgZfnlN+sqrAXIrUGU/m/whcRgkuvygB5GFPAeeZ/4QgvvH0vPSWg==}
 
-  '@prisma/management-api-sdk@1.27.0':
-    resolution: {integrity: sha512-6DJibqnTp6RIrbPhQx1rYUCxA1dyDoRlaaSJL7c5biLcXfesFTxR61hUco34ehIOYFQ9hMJf4VYlIDWSMx/kRw==}
+  '@prisma/management-api-sdk@1.32.1':
+    resolution: {integrity: sha512-AroVoLGpLQ1cCC9P/5nDcoOA2kst0sPMwVkeT6PmVeSnXXh7RC1u97WAOCF6RPDdzotyRsHuVKVAHHYoBnhUuQ==}
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -1312,9 +1312,9 @@ snapshots:
 
   '@oxc-project/types@0.124.0': {}
 
-  '@prisma/compute-sdk@0.18.0(@prisma/management-api-sdk@1.27.0)':
+  '@prisma/compute-sdk@0.18.0(@prisma/management-api-sdk@1.32.1)':
     dependencies:
-      '@prisma/management-api-sdk': 1.27.0
+      '@prisma/management-api-sdk': 1.32.1
       better-result: 2.8.2
       tar-stream: 3.1.8
       tiny-invariant: 1.3.3
@@ -1330,7 +1330,7 @@ snapshots:
     dependencies:
       xdg-app-paths: 8.3.0
 
-  '@prisma/management-api-sdk@1.27.0':
+  '@prisma/management-api-sdk@1.32.1':
     dependencies:
       openapi-fetch: 0.14.0
 


### PR DESCRIPTION
## Summary

Fixes CLI re-login churn caused by refresh races between separate CLI processes.

The API/server half has already shipped in @prisma/management-api-sdk@1.32.1. This PR wires the CLI to that SDK version and adds the local process coordination needed for npx / concurrent CLI runs.

## What changed

- Bumps @prisma/management-api-sdk to ^1.32.1.
- Adds file-based refresh locking to FileTokenStorage.
- Adds compare-and-clear behavior so a losing process cannot delete a newer token pair.
- Converts SDK AuthError failures into structured AUTH_REQUIRED CLI errors.
- Keeps raw SDK auth details hidden by default and visible with --trace.
- Updates auth product docs to describe automatic refresh and structured auth failures.

## Why

The SDK previously coordinated refreshes only inside one process. Two separate CLI processes could both try to refresh the same stored token pair; one would win and write new tokens, while the other could receive invalid_grant and clear the session.

The new flow serializes refresh work around the local auth file and only clears tokens if the stored value still matches the failing process's stale view.

## Validation

- pnpm --filter @prisma/cli exec vitest run tests/token-storage.test.ts tests/command-runner-auth.test.ts
- pnpm --filter @prisma/cli build

## Rollout

After merge, publish @prisma/cli@preview.

Manual smoke after publish:

1. npx @prisma/cli@preview auth login
2. Wait for access-token expiry or force a 401 in a test env.
3. Run two authenticated commands concurrently, e.g. project list / app deploy.
4. Verify neither command forces re-login or prints an SDK stack trace.