### PR TITLE
fix(cli): drop dangling pnpm hoist symlinks from Next.js standalone build

### DIFF
--- a/packages/cli/src/lib/app/preview-build.ts
+++ b/packages/cli/src/lib/app/preview-build.ts
@@ -343,6 +343,9 @@ async function copyPathMaterializingSymlinks(
 
   if (sourceStat.isSymbolicLink()) {
     const resolvedTarget = await resolveSymlinkTarget(sourcePath, options);
+    if (resolvedTarget === null) {
+      return;
+    }
     await copyPathMaterializingSymlinks(resolvedTarget, destinationPath, options);
     return;
   }
@@ -376,7 +379,7 @@ async function resolveSymlinkTarget(
     appRoot: string;
     sourceRoot: string;
   },
-): Promise<string> {
+): Promise<string | null> {
   const linkTarget = await readlink(symlinkPath);
   const resolvedTarget = path.resolve(path.dirname(symlinkPath), linkTarget);
 
@@ -402,9 +405,27 @@ async function resolveSymlinkTarget(
     }
   }
 
+  // pnpm's hoist layer (.pnpm/node_modules/*) contains speculative links that
+  // are routinely dangling — Next's tracer doesn't always align with what pnpm
+  // populated. Drop these silently. Dangling links elsewhere still throw so a
+  // real missing dep doesn't get masked.
+  if (isPnpmHoistLink(symlinkPath)) {
+    return null;
+  }
+
   throw new Error(
     `Next.js standalone symlink target is missing: ${symlinkPath} -> ${linkTarget} (resolved to ${resolvedTarget})`,
   );
+}
+
+function isPnpmHoistLink(symlinkPath: string): boolean {
+  const parts = path.dirname(symlinkPath).split(path.sep);
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (parts[i] === ".pnpm" && parts[i + 1] === "node_modules") {
+      return true;
+    }
+  }
+  return false;
 }
 
 async function pathExists(targetPath: string): Promise<boolean> {

--- a/packages/cli/tests/app-build.test.ts
+++ b/packages/cli/tests/app-build.test.ts
@@ -239,6 +239,77 @@ describe("preview build strategy", () => {
     ).resolves.toContain("static");
   });
 
+  it("drops dangling pnpm hoist symlinks when staging Next.js standalone artifacts", async () => {
+    const { stageNextjsStandaloneArtifact } = await import("../src/lib/app/preview-build");
+    const cwd = await createTempCwd();
+    const appPath = path.join(cwd, "app");
+    const standaloneDir = path.join(appPath, ".next", "standalone");
+    const artifactDir = path.join(cwd, "artifact");
+
+    const realTarget = path.join(
+      standaloneDir,
+      "node_modules/.pnpm/real@1.0.0/node_modules/real",
+    );
+    const realLink = path.join(
+      standaloneDir,
+      "node_modules/.pnpm/node_modules/real",
+    );
+    await mkdir(realTarget, { recursive: true });
+    await writeFile(path.join(realTarget, "index.js"), "export const real = true;\n", "utf8");
+    await mkdir(path.dirname(realLink), { recursive: true });
+    await symlink("../real@1.0.0/node_modules/real", realLink, "dir");
+
+    const danglingLink = path.join(
+      standaloneDir,
+      "node_modules/.pnpm/node_modules/missing-pkg",
+    );
+    await symlink("../missing-pkg@1.0.0/node_modules/missing-pkg", danglingLink, "dir");
+
+    const danglingScopedLink = path.join(
+      standaloneDir,
+      "node_modules/.pnpm/node_modules/@scope/missing-pkg",
+    );
+    await mkdir(path.dirname(danglingScopedLink), { recursive: true });
+    await symlink("../../@scope+missing-pkg@1.0.0/node_modules/@scope/missing-pkg", danglingScopedLink, "dir");
+
+    await stageNextjsStandaloneArtifact({
+      standaloneDir,
+      artifactDir,
+      appPath,
+    });
+
+    await expect(
+      readFile(path.join(artifactDir, "node_modules/real/index.js"), "utf8"),
+    ).resolves.toContain("real = true");
+    await expect(
+      lstat(path.join(artifactDir, "node_modules/.pnpm/node_modules/missing-pkg")),
+    ).rejects.toThrow();
+    await expect(
+      lstat(path.join(artifactDir, "node_modules/missing-pkg")),
+    ).rejects.toThrow();
+    await expect(
+      lstat(path.join(artifactDir, "node_modules/@scope/missing-pkg")),
+    ).rejects.toThrow();
+  });
+
+  it("still rejects dangling Next.js standalone symlinks outside the pnpm hoist layer", async () => {
+    const { stageNextjsStandaloneArtifact } = await import("../src/lib/app/preview-build");
+    const cwd = await createTempCwd();
+    const appPath = path.join(cwd, "app");
+    const standaloneDir = path.join(appPath, ".next", "standalone");
+    const artifactDir = path.join(cwd, "artifact");
+
+    const brokenTopLevelLink = path.join(standaloneDir, "node_modules", "missing-direct");
+    await mkdir(path.dirname(brokenTopLevelLink), { recursive: true });
+    await symlink(".pnpm/missing-direct@1.0.0/node_modules/missing-direct", brokenTopLevelLink, "dir");
+
+    await expect(stageNextjsStandaloneArtifact({
+      standaloneDir,
+      artifactDir,
+      appPath,
+    })).rejects.toThrow("symlink target is missing");
+  });
+
   it("rejects Next.js standalone symlinks that escape the app directory", async () => {
     const { stageNextjsStandaloneArtifact } = await import("../src/lib/app/preview-build");
     const cwd = await createTempCwd();


### PR DESCRIPTION
## Summary

Fixes Next.js standalone deploys that fail on pnpm monorepos because of dangling symlinks in `.pnpm/node_modules/`.

Next's standalone output reproduces pnpm's flat hoist layer (`node_modules/.pnpm/node_modules/<pkg>`), which routinely contains symlinks whose targets are absent — Next's require-trace doesn't always align with what pnpm actually populated in the store. The CLI's standalone-staging pass (`copyPathMaterializingSymlinks` → `resolveSymlinkTarget`) treated any dangling link as fatal and threw `Next.js standalone symlink target is missing: …`, failing the build.

After this change, dangling symlinks under `.pnpm/node_modules/` are silently skipped — the artifact simply has no entry at that path. Dangling symlinks **anywhere else** in the standalone tree still throw, so a genuinely missing top-level dependency isn't masked.

## What changed

- `resolveSymlinkTarget` now returns `string | null`. It returns `null` instead of throwing when a dangling link sits under the pnpm hoist layer.
- `copyPathMaterializingSymlinks` returns early when `resolveSymlinkTarget` returns `null`, so the broken link is never propagated to the artifact.
- New `isPnpmHoistLink` helper matches both flat (`.pnpm/node_modules/<pkg>`) and scoped (`.pnpm/node_modules/@scope/<pkg>`) paths via a path-component scan.
- The standalone source tree (`.next/standalone`) is untouched — we just don't propagate the broken link forward into the artifact that gets deployed.

## Why narrow, not broad

The original throw was a deliberate tripwire — better to fail loudly at build than ship a subtly-broken artifact. We're preserving that for top-level `node_modules/<pkg>` symlinks (the load-bearing ones Next emits from its require-trace). We're only relaxing it for `.pnpm/node_modules/<pkg>` — pnpm's flat hoist layer is structurally noisy and dangling entries there don't indicate anything wrong with the app.