### PR TITLE
ci(cli): simplify dev version format

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -56,7 +56,6 @@ jobs:
         id: cli_version
         run: |
           node scripts/resolve-cli-version.mjs dev \
-            --sha "${GITHUB_SHA}" \
             --run-number "${GITHUB_RUN_NUMBER}" \
             --run-attempt "${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,13 +63,14 @@ The CLI must preserve the unified command model:
 Official beta releases use `@prisma/cli` and expose the `prisma-cli` binary.
 The `latest` dist-tag points at the latest manually published beta.
 
-The `dev` dist-tag points at the latest successful `main` build. Trusted
-same-repo pull requests receive pkg.pr.new preview comments for testing exact
-unmerged commits. Fork pull requests do not publish preview packages
-automatically. Preview publishing is best-effort and requires the pkg.pr.new
-GitHub App to be installed for this repository. Once that app is installed, set
-the repository variable `CLI_PR_PREVIEW_REQUIRED=true` to make preview
-publishing failures block CI.
+The `dev` dist-tag points at the latest successful `main` build, published as
+`3.0.0-dev.<run_number>.<run_attempt>`. Commit traceability comes from npm
+provenance and the GitHub Actions run. Trusted same-repo pull requests receive
+pkg.pr.new preview comments for testing exact unmerged commits. Fork pull
+requests do not publish preview packages automatically. Preview publishing is
+best-effort and requires the pkg.pr.new GitHub App to be installed for this
+repository. Once that app is installed, set the repository variable
+`CLI_PR_PREVIEW_REQUIRED=true` to make preview publishing failures block CI.
 
 Do not publish from a local checkout unless the release owner has explicitly
 asked you to do so. Release publishing is intended to happen through the

--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ Release channels:
   it computes the next `3.0.0-beta.N`, publishes with the `latest` dist-tag, and
   creates `cli-v<version>`.
 - `@prisma/cli@dev`: latest successful `main` build. Every push to `main`
-  publishes a unique dev version with the `dev` dist-tag.
+  publishes a unique `3.0.0-dev.<run_number>.<run_attempt>` version with the
+  `dev` dist-tag. Commit traceability comes from npm provenance and the GitHub
+  Actions run.
 - PR preview packages: trusted same-repo pull requests get an installable
   pkg.pr.new comment for the exact commit. Fork PRs do not publish preview
   packages automatically. Preview publishing is best-effort and requires the

--- a/docs/architecture/adrs/0001-preview-package-and-publishing.md
+++ b/docs/architecture/adrs/0001-preview-package-and-publishing.md
@@ -22,7 +22,9 @@ Release versions are injected into the staged package by CI:
 
 - Manual official releases compute the next `3.0.0-beta.N`, publish to
   `latest`, and create `cli-v<version>`.
-- Pushes to `main` publish unique dev builds to the `dev` dist-tag.
+- Pushes to `main` publish unique `3.0.0-dev.<run_number>.<run_attempt>`
+  builds to the `dev` dist-tag. Commit traceability comes from npm provenance
+  and the GitHub Actions run.
 - Trusted same-repo pull requests publish installable pkg.pr.new previews for
   the exact commit. Fork pull requests do not publish preview packages
   automatically. Preview publishing is best-effort because it depends on the

--- a/packages/cli/tests/resolve-cli-version.test.ts
+++ b/packages/cli/tests/resolve-cli-version.test.ts
@@ -35,8 +35,7 @@ describe("resolve cli version", () => {
     expect(resolveDevVersion({
       runNumber: "123",
       runAttempt: "2",
-      sha: "abcdef1234567890",
-    })).toBe("3.0.0-dev.123.2.shaabcdef123456");
+    })).toBe("3.0.0-dev.123.2");
   });
 
   it("computes an exact PR preview version", () => {

--- a/scripts/resolve-cli-version.mjs
+++ b/scripts/resolve-cli-version.mjs
@@ -8,9 +8,8 @@ export const CLI_RELEASE_BASE_VERSION = "3.0.0";
 export function resolveDevVersion(options) {
   const runNumber = requireValue(options.runNumber, "runNumber");
   const runAttempt = requireValue(options.runAttempt, "runAttempt");
-  const sha = shortSha(requireValue(options.sha, "sha"));
 
-  return `${CLI_RELEASE_BASE_VERSION}-dev.${runNumber}.${runAttempt}.sha${sha}`;
+  return `${CLI_RELEASE_BASE_VERSION}-dev.${runNumber}.${runAttempt}`;
 }
 
 export function resolvePrVersion(options) {
@@ -86,7 +85,6 @@ function main() {
     process.stdout.write(`version=${resolveDevVersion({
       runNumber: options["run-number"],
       runAttempt: options["run-attempt"],
-      sha: options.sha,
     })}\n`);
     return;
   }


### PR DESCRIPTION
## Summary
- change dev publish versions from `3.0.0-dev.<run_number>.<run_attempt>.sha<short_sha>` to `3.0.0-dev.<run_number>.<run_attempt>`
- remove the unused SHA argument from the main dev publish workflow
- document that commit traceability comes from npm provenance and the GitHub Actions run

## Why
Dev versions should stay easy to read before the first official beta release. We still keep immutable package versions, while source traceability lives in provenance and Actions metadata.

## Validation
- `pnpm --filter @prisma/cli exec vitest run tests/resolve-cli-version.test.ts`
- workflow YAML parse for `.github/workflows/publish-cli.yml`
- `node scripts/resolve-cli-version.mjs dev --run-number 31 --run-attempt 1`
- `git diff --check`