### PR TITLE
ci(cli): create release tags with GitHub API

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -270,15 +270,19 @@ jobs:
         working-directory: .publish/cli
         run: npm publish --access public --tag latest --provenance
 
-      - name: Create and push release tag
+      - name: Create release tag
         if: ${{ !inputs.dry_run }}
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           VERSION='${{ steps.cli_version.outputs.version }}'
           TAG="cli-v${VERSION}"
-          git tag "${TAG}"
-          git -c http.https://github.com/.extraheader="AUTHORIZATION: bearer ${GITHUB_TOKEN}" push origin "refs/tags/${TAG}"
+          SHA="$(git rev-parse HEAD)"
+          gh api \
+            --method POST \
+            "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f ref="refs/tags/${TAG}" \
+            -f sha="${SHA}"
 
       - name: Summarize release
         run: |
@@ -292,7 +296,7 @@ jobs:
             echo "- Dry run: \`${{ inputs.dry_run }}\`"
             if [ '${{ inputs.dry_run }}' = 'true' ]; then
               echo "- Publish: skipped"
-              echo "- Tag/push: skipped"
+              echo "- Tag creation: skipped"
             else
               echo "- npm package: \`@prisma/cli@${VERSION}\`"
               echo "- npm dist-tag: \`latest\`"


### PR DESCRIPTION
## Summary
- replace the release tag git push with GitHub API ref creation
- keep the tag pointed at the checked-out main commit after the latest-main guard
- update the dry-run summary wording from tag/push to tag creation

## Why
The first official beta published successfully to npm, but the release workflow failed while pushing `cli-v3.0.0-beta.0` because checkout uses `persist-credentials: false` and the inline git extraheader did not authenticate the push. The missing `cli-v3.0.0-beta.0` tag has been repaired manually at the release commit.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-cli.yml")'`
- checked that no old `extraheader` / `git push origin` path remains
- `git diff --check`