### PR TITLE
fix: support current app deploy frameworks

### DIFF
--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -627,7 +627,7 @@ Behavior:
 - accepts repeated `--env NAME=VALUE` flags
 - maps user-facing framework names to deploy build strategies
 - uses `src/index.ts` as the Hono deploy entrypoint when the app has no `package.json#main` or `package.json#module` and that file exists
-- supports vanilla Bun apps with `--framework bun --entry <path>`
+- supports vanilla Bun apps with `--framework bun` using `package.json#main` or `package.json#module`, or with `--entry <path>`
 - treats `--entry <path>` without `--framework` as a Bun app deploy
 - does not print secret values
 - returns app, deployment id, URL, and next steps in `--json` output

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -591,7 +591,7 @@ prisma-cli app run --build-type nextjs
 prisma-cli app run --build-type bun --entry server.ts --port 3000
 ```
 
-## `prisma-cli app deploy --project <id-or-name> --create-project <name> --app <name> --branch <name> --framework <nextjs|hono|tanstack-start> --entry <path> --http-port <port> --env <name=value>`
+## `prisma-cli app deploy --project <id-or-name> --create-project <name> --app <name> --branch <name> --framework <nextjs|hono|tanstack-start|bun> --entry <path> --http-port <port> --env <name=value>`
 
 Purpose:
 
@@ -626,7 +626,9 @@ Behavior:
 - success human output prints `Live in <duration>`, the URL on its own line, and `Logs   prisma-cli app logs`
 - accepts repeated `--env NAME=VALUE` flags
 - maps user-facing framework names to deploy build strategies
-- accepts `--build-type <auto|bun|nextjs|nuxt|astro|tanstack-start>` as a legacy passthrough, but `--framework` wins when both are passed
+- uses `src/index.ts` as the Hono deploy entrypoint when the app has no `package.json#main` or `package.json#module` and that file exists
+- supports vanilla Bun apps with `--framework bun --entry <path>`
+- treats `--entry <path>` without `--framework` as a Bun app deploy
 - does not print secret values
 - returns app, deployment id, URL, and next steps in `--json` output
 
@@ -639,6 +641,8 @@ prisma-cli app deploy --create-project my-app --yes
 prisma-cli app deploy --app my-app --env DATABASE_URL=postgresql://example
 prisma-cli app deploy --framework nextjs --http-port 3000
 prisma-cli app deploy --branch feat-login --framework hono --http-port 3000
+prisma-cli app deploy --framework bun --entry src/server.ts --http-port 3000
+prisma-cli app deploy --entry src/server.ts --http-port 3000
 ```
 
 ## `prisma-cli project env`

--- a/examples/next-smoke/README.md
+++ b/examples/next-smoke/README.md
@@ -16,7 +16,7 @@ pnpm prisma app deploy --app next-smoke
 pnpm prisma app list-deploys
 pnpm prisma app show-deploy <deployment-id>
 pnpm prisma app deploy
-pnpm prisma app deploy --app next-smoke --build-type nextjs --http-port 3000
+pnpm prisma app deploy --app next-smoke --framework nextjs --http-port 3000
 ```
 
 What this validates:
@@ -26,7 +26,7 @@ What this validates:
 - first deploy bootstraps an example-local `prisma.config.ts` when no project is linked
 - first deploy can create or reuse the `next-smoke` app
 - first deploy uses the Next.js standalone build path without needing `--http-port`
-- `--build-type nextjs --http-port 3000` is available as an explicit repair or override path
+- `--framework nextjs --http-port 3000` is available as an explicit repair or override path
 - second deploy reuses saved local app selection from `.prisma/cli/state.json`
 
 Local files intentionally ignored in this example:

--- a/packages/cli/src/commands/app/index.ts
+++ b/packages/cli/src/commands/app/index.ts
@@ -174,15 +174,9 @@ function createDeployCommand(runtime: CliRuntime): Command {
     .addOption(new Option("--branch <name>", "Branch name"))
     .addOption(
       new Option("--framework <name>", "Framework to deploy")
-        .choices(["nextjs", "hono", "tanstack-start"]),
+        .choices(["nextjs", "hono", "tanstack-start", "bun"]),
     )
-    .addOption(new Option("--entry <path>", "Entrypoint path for Bun or auto deploys"))
-    .addOption(
-      new Option("--build-type <type>", "Legacy deploy build type")
-        .choices([...PREVIEW_BUILD_TYPES])
-        .default("auto")
-        .hideHelp(),
-    )
+    .addOption(new Option("--entry <path>", "Entrypoint path for Bun deploys"))
     .addOption(new Option("--http-port <port>", "HTTP port override for the deployed app"))
     .addOption(
       new Option("--env <name=value>", "Environment variable")
@@ -193,7 +187,6 @@ function createDeployCommand(runtime: CliRuntime): Command {
   command.action(async (options) => {
     const appName = (options as { app?: string }).app;
     const entry = (options as { entry?: string }).entry;
-    const buildType = (options as { buildType?: string }).buildType;
     const branchName = (options as { branch?: string }).branch;
     const framework = (options as { framework?: string }).framework;
     const httpPort = (options as { httpPort?: string }).httpPort;
@@ -210,7 +203,6 @@ function createDeployCommand(runtime: CliRuntime): Command {
         createProjectName,
         branchName,
         entrypoint: entry,
-        buildType,
         framework,
         httpPort,
         envAssignments,

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -1204,7 +1204,7 @@ async function resolveAppDomainTarget(
 
   const envProjectId = readDeployEnvOverride(context, PRISMA_PROJECT_ID_ENV_VAR);
   const envAppId = readDeployEnvOverride(context, PRISMA_APP_ID_ENV_VAR);
-  const skipLocalPin = Boolean(envProjectId);
+  const skipLocalPin = Boolean(envProjectId || options?.projectRef);
   const localPin = skipLocalPin
     ? ({ kind: "missing" } satisfies LocalResolutionPinReadResult)
     : await readLocalResolutionPin(context.runtime.cwd);

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -45,7 +45,7 @@ import {
   resolveLocalBuildType,
   runLocalApp,
 } from "../lib/app/local-dev";
-import { readBunPackageJson, type BunPackageJsonLike } from "../lib/app/bun-project";
+import { readBunPackageEntrypoint, readBunPackageJson, type BunPackageJsonLike } from "../lib/app/bun-project";
 import {
   inferTargetName,
   projectNotFoundError,
@@ -94,9 +94,13 @@ import { listRealWorkspaceProjects } from "./project";
 import { createSelectPromptPort } from "./select-prompt-port";
 
 type AppDomainCommand = "add" | "show" | "remove" | "retry" | "wait";
-type DeployFramework = "nextjs" | "hono" | "tanstack-start";
+type DeployFramework = "nextjs" | "hono" | "tanstack-start" | "bun";
 
-const DEPLOY_FRAMEWORKS = ["nextjs", "hono", "tanstack-start"] as const satisfies readonly DeployFramework[];
+const DEPLOY_FRAMEWORKS = ["nextjs", "hono", "tanstack-start", "bun"] as const satisfies readonly DeployFramework[];
+const TANSTACK_START_PACKAGES = [
+  "@tanstack/react-start",
+  "@tanstack/solid-start",
+] as const;
 const FRAMEWORK_DEFAULT_HTTP_PORT = 3000;
 const PRISMA_PROJECT_ID_ENV_VAR = "PRISMA_PROJECT_ID";
 const PRISMA_APP_ID_ENV_VAR = "PRISMA_APP_ID";
@@ -210,7 +214,6 @@ export async function runAppDeploy(
     createProjectName?: string;
     branchName?: string;
     entrypoint?: string;
-    buildType?: string;
     framework?: string;
     httpPort?: string;
     envAssignments?: string[];
@@ -234,18 +237,10 @@ export async function runAppDeploy(
     throw localResolutionPinStaleError();
   }
 
-  const explicitBuildType = Boolean(options?.buildType && options.buildType !== "auto");
+  const branch = await resolveDeployBranch(context, options?.branchName);
   if (options?.httpPort) {
     parseDeployHttpPort(options.httpPort);
   }
-  assertSupportedEntrypointForRequestedDeployShape({
-    requestedFramework: options?.framework,
-    requestedBuildType: options?.buildType,
-    explicitBuildType,
-    entrypoint: options?.entrypoint,
-  });
-
-  const branch = await resolveDeployBranch(context, options?.branchName);
   const { provider, target, projectId } = await requireProviderAndDeployProjectContext(context, options?.projectRef, {
     branch,
     createProjectName: options?.createProjectName,
@@ -266,8 +261,7 @@ export async function runAppDeploy(
 
   let framework = await resolveDeployFramework(context, {
     requestedFramework: options?.framework,
-    requestedBuildType: options?.buildType,
-    explicitBuildType,
+    entrypoint: options?.entrypoint,
   });
   let runtime = resolveDeployRuntime(options?.httpPort, framework);
   assertSupportedEntrypoint(framework.buildType, options?.entrypoint, "deploy");
@@ -296,7 +290,7 @@ export async function runAppDeploy(
     runtime,
     firstDeploy: selectedApp.firstDeploy,
     explicitFramework: Boolean(options?.framework),
-    explicitBuildType,
+    explicitEntrypoint: Boolean(options?.entrypoint),
     explicitHttpPort: Boolean(options?.httpPort),
   });
   framework = customized.framework;
@@ -306,6 +300,7 @@ export async function runAppDeploy(
   // derives its entrypoint from build output, so validate --entry again after it.
   const buildType = framework.buildType;
   assertSupportedEntrypoint(buildType, options?.entrypoint, "deploy");
+  const entrypoint = await resolveDeployEntrypoint(context.runtime.cwd, framework, options?.entrypoint);
   const portMapping = parseDeployPortMapping(String(runtime.port));
 
   const progressState = createPreviewDeployProgressState();
@@ -317,7 +312,7 @@ export async function runAppDeploy(
     appId: selectedApp.appId,
     appName: selectedApp.appName,
     region: selectedApp.region,
-    entrypoint: options?.entrypoint,
+    entrypoint,
     buildType,
     portMapping,
     envVars,
@@ -2589,24 +2584,20 @@ async function resolveDeployFramework(
   context: CommandContext,
   options: {
     requestedFramework: string | undefined;
-    requestedBuildType: string | undefined;
-    explicitBuildType: boolean;
+    entrypoint: string | undefined;
   },
 ): Promise<ResolvedDeployFramework> {
   if (options.requestedFramework) {
     return frameworkFromUserFacingValue(options.requestedFramework, "set by --framework");
   }
 
-  if (options.explicitBuildType) {
-    const buildType = normalizeBuildType(options.requestedBuildType);
-    if (buildType !== "auto") {
-      return {
-        key: buildType,
-        buildType,
-        displayName: formatBuildTypeName(buildType),
-        annotation: "set by --build-type",
-      };
-    }
+  if (options.entrypoint) {
+    return {
+      key: "bun",
+      buildType: "bun",
+      displayName: "Bun",
+      annotation: "set by --entry",
+    };
   }
 
   const detected = await detectDeployFramework(context.runtime.cwd);
@@ -2634,24 +2625,30 @@ function resolveDeployRuntime(
   };
 }
 
-function assertSupportedEntrypointForRequestedDeployShape(options: {
-  requestedFramework: string | undefined;
-  requestedBuildType: string | undefined;
-  explicitBuildType: boolean;
-  entrypoint: string | undefined;
-}): void {
-  if (options.requestedFramework) {
-    const framework = frameworkFromUserFacingValue(options.requestedFramework, "set by --framework");
-    assertSupportedEntrypoint(framework.buildType, options.entrypoint, "deploy");
-    return;
+async function resolveDeployEntrypoint(
+  cwd: string,
+  framework: ResolvedDeployFramework,
+  explicitEntrypoint: string | undefined,
+): Promise<string | undefined> {
+  if (explicitEntrypoint || framework.key !== "hono") {
+    return explicitEntrypoint;
   }
 
-  if (!options.explicitBuildType) {
-    return;
+  const packageJson = await readBunPackageJson(cwd);
+  if (readBunPackageEntrypoint(packageJson)) {
+    return undefined;
   }
 
-  const buildType = normalizeBuildType(options.requestedBuildType);
-  assertSupportedEntrypoint(buildType, options.entrypoint, "deploy");
+  const defaultEntrypoint = "src/index.ts";
+  try {
+    await access(path.join(cwd, defaultEntrypoint));
+    return defaultEntrypoint;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+    return undefined;
+  }
 }
 
 async function detectDeployFramework(cwd: string): Promise<ResolvedDeployFramework | null> {
@@ -2680,7 +2677,7 @@ async function detectDeployFramework(cwd: string): Promise<ResolvedDeployFramewo
     };
   }
 
-  if (hasPackageDependency(packageJson, "@tanstack/start")) {
+  if (hasAnyPackageDependency(packageJson, TANSTACK_START_PACKAGES)) {
     return {
       key: "tanstack-start",
       buildType: "tanstack-start",
@@ -2698,6 +2695,7 @@ async function detectNextConfig(cwd: string): Promise<{ exists: boolean; standal
     "next.config.mjs",
     "next.config.cjs",
     "next.config.ts",
+    "next.config.mts",
   ];
 
   for (const candidate of candidates) {
@@ -2726,6 +2724,10 @@ function hasPackageDependency(packageJson: BunPackageJsonLike | null, dependency
     || hasDependency(packageJson?.devDependencies, dependencyName);
 }
 
+function hasAnyPackageDependency(packageJson: BunPackageJsonLike | null, dependencyNames: readonly string[]): boolean {
+  return dependencyNames.some((dependencyName) => hasPackageDependency(packageJson, dependencyName));
+}
+
 function hasDependency(dependencies: unknown, dependencyName: string): boolean {
   return Boolean(
     dependencies
@@ -2752,9 +2754,17 @@ function frameworkFromUserFacingValue(value: string, annotation: string): Resolv
         displayName: "Hono",
         annotation,
       };
+    case "bun":
+      return {
+        key: "bun",
+        buildType: "bun",
+        displayName: "Bun",
+        annotation,
+      };
     case "tanstack":
     case "tanstack-start":
-    case "@tanstack/start":
+    case "@tanstack/react-start":
+    case "@tanstack/solid-start":
       return {
         key: "tanstack-start",
         buildType: "tanstack-start",
@@ -2767,7 +2777,7 @@ function frameworkFromUserFacingValue(value: string, annotation: string): Resolv
 }
 
 function frameworkNotDetectedError(cwd: string | undefined, requestedFramework?: string): CliError {
-  const supported = "Next.js, Hono, TanStack Start";
+  const supported = "Next.js, Hono, TanStack Start, Bun";
   const directory = cwd ? ` in ${formatDeployDirectory(cwd)}` : "";
 
   return new CliError({
@@ -2777,12 +2787,14 @@ function frameworkNotDetectedError(cwd: string | undefined, requestedFramework?:
       ? `Unsupported framework "${requestedFramework}"`
       : `Cannot detect a supported framework${directory}`,
     why: `Supported Beta frameworks: ${supported}.`,
-    fix: "Add one of these frameworks as a dependency, or pass --framework <nextjs|hono|tanstack-start>.",
+    fix: "Add one of these frameworks as a dependency, pass --framework <nextjs|hono|tanstack-start|bun>, or pass --entry <path> for a Bun app.",
     exitCode: 2,
     nextSteps: [
       "prisma-cli app deploy --framework nextjs",
       "prisma-cli app deploy --framework hono",
       "prisma-cli app deploy --framework tanstack-start",
+      "prisma-cli app deploy --framework bun --entry server.ts",
+      "prisma-cli app deploy --entry server.ts",
     ],
   });
 }
@@ -2828,7 +2840,7 @@ async function maybeCustomizeDeploySettings(
     runtime: ResolvedDeployRuntime;
     firstDeploy: boolean;
     explicitFramework: boolean;
-    explicitBuildType: boolean;
+    explicitEntrypoint: boolean;
     explicitHttpPort: boolean;
   },
 ): Promise<{ framework: ResolvedDeployFramework; runtime: ResolvedDeployRuntime }> {
@@ -2836,7 +2848,7 @@ async function maybeCustomizeDeploySettings(
     !options.firstDeploy
     || context.flags.yes
     || options.explicitFramework
-    || options.explicitBuildType
+    || options.explicitEntrypoint
     || options.explicitHttpPort
     || !canPrompt(context)
   ) {
@@ -2912,6 +2924,8 @@ function frameworkDisplayName(framework: DeployFramework): string {
       return "Hono";
     case "tanstack-start":
       return "TanStack Start";
+    case "bun":
+      return "Bun";
   }
 }
 
@@ -2965,7 +2979,7 @@ function isPreviewBuildType(value: string): value is PreviewBuildType {
   return (PREVIEW_BUILD_TYPES as readonly string[]).includes(value);
 }
 
-function getBuildTypeExamples(commandName: "build" | "deploy"): string[] {
+function getBuildTypeExamples(commandName: "build"): string[] {
   return RESOLVED_PREVIEW_BUILD_TYPES.map((buildType) => {
     const entrypoint = buildType === "bun" ? " --entry server.ts" : "";
     return `prisma-cli app ${commandName} --build-type ${buildType}${entrypoint}`;
@@ -2980,6 +2994,19 @@ function assertSupportedEntrypoint(
   // Framework strategies derive their runtime entrypoints from build output.
   // Only Bun consumes a user-provided source entrypoint; auto may fall back to Bun.
   if (buildType !== "auto" && buildType !== "bun" && entrypoint) {
+    if (commandName === "deploy") {
+      throw usageError(
+        `App deploy does not accept --entry with ${formatBuildTypeName(buildType)}`,
+        `${formatBuildTypeName(buildType)} apps derive their runtime entrypoint from build output.`,
+        "Remove --entry, or use --framework bun when you want to target a Bun entrypoint directly.",
+        [
+          `prisma-cli app deploy --framework ${buildType}`,
+          "prisma-cli app deploy --framework bun --entry server.ts",
+        ],
+        "app",
+      );
+    }
+
     throw usageError(
       `App ${commandName} does not accept --entry with --build-type ${buildType}`,
       `${formatBuildTypeName(buildType)} apps do not use an entrypoint flag in the current preview.`,

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -241,6 +241,10 @@ export async function runAppDeploy(
   if (options?.httpPort) {
     parseDeployHttpPort(options.httpPort);
   }
+  assertSupportedEntrypointForRequestedDeployShape({
+    requestedFramework: options?.framework,
+    entrypoint: options?.entrypoint,
+  });
   const { provider, target, projectId } = await requireProviderAndDeployProjectContext(context, options?.projectRef, {
     branch,
     createProjectName: options?.createProjectName,
@@ -2623,6 +2627,18 @@ function resolveDeployRuntime(
     port: FRAMEWORK_DEFAULT_HTTP_PORT,
     annotation: `${framework.displayName} default`,
   };
+}
+
+function assertSupportedEntrypointForRequestedDeployShape(options: {
+  requestedFramework: string | undefined;
+  entrypoint: string | undefined;
+}): void {
+  if (!options.requestedFramework) {
+    return;
+  }
+
+  const framework = frameworkFromUserFacingValue(options.requestedFramework, "set by --framework");
+  assertSupportedEntrypoint(framework.buildType, options.entrypoint, "deploy");
 }
 
 async function resolveDeployEntrypoint(

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -2646,12 +2646,17 @@ async function resolveDeployEntrypoint(
   framework: ResolvedDeployFramework,
   explicitEntrypoint: string | undefined,
 ): Promise<string | undefined> {
-  if (explicitEntrypoint || framework.key !== "hono") {
+  if (explicitEntrypoint || framework.buildType !== "bun") {
     return explicitEntrypoint;
   }
 
   const packageJson = await readBunPackageJson(cwd);
-  if (readBunPackageEntrypoint(packageJson)) {
+  const packageEntrypoint = readBunPackageEntrypoint(packageJson);
+  if (packageEntrypoint) {
+    return packageEntrypoint;
+  }
+
+  if (framework.key !== "hono") {
     return undefined;
   }
 

--- a/packages/cli/src/shell/command-meta.ts
+++ b/packages/cli/src/shell/command-meta.ts
@@ -161,6 +161,7 @@ const DESCRIPTORS: CommandDescriptor[] = [
       "prisma-cli app deploy --app my-app --framework nextjs --http-port 3000",
       "prisma-cli app deploy --branch feat-login --framework hono",
       "pnpm dlx skills@latest add prisma/prisma-cli/skills#cli-v<cli-version> --all",
+      "prisma-cli app deploy --framework bun --entry src/server.ts",
     ],
   },
   {

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -103,6 +103,7 @@ async function writePackageJson(
   cwd: string,
   packageJson: {
     name?: string;
+    module?: string;
     dependencies?: Record<string, string>;
     devDependencies?: Record<string, string>;
   },
@@ -1195,9 +1196,15 @@ describe("app controller", () => {
       expectedBuildType: "bun",
     },
     {
-      name: "Bun from --framework bun",
+      name: "Bun from --framework bun with --entry",
       framework: "bun",
       entrypoint: "src/server.ts",
+      expectedBuildType: "bun",
+    },
+    {
+      name: "Bun from --framework bun with package.json module",
+      packageJson: { module: "index.ts" },
+      framework: "bun",
       expectedBuildType: "bun",
     },
     {

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -1205,6 +1205,7 @@ describe("app controller", () => {
       name: "Bun from --framework bun with package.json module",
       packageJson: { module: "index.ts" },
       framework: "bun",
+      expectedEntrypoint: "index.ts",
       expectedBuildType: "bun",
     },
     {

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -376,6 +376,61 @@ describe("app controller", () => {
     });
   });
 
+  it("domain add lets explicit --project skip stale local pins", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+    const domain = createDomain({ status: "active" });
+    const listApps = vi.fn().mockResolvedValue([
+      { id: "app_1", name: "shop", region: "eu-central-1", liveDeploymentId: "dep_live", liveUrl: "https://shop.prisma.app" },
+    ]);
+    const addDomain = vi.fn().mockResolvedValue({
+      domain,
+      existing: false,
+    });
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/preview-provider", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("../src/lib/app/preview-provider")>();
+      return {
+        ...actual,
+        createPreviewAppProvider: vi.fn(() => ({
+          listApps,
+          addDomain,
+        })),
+      };
+    });
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runAppDomainAdd } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    await writeLocalPin(cwd, {
+      workspaceId: "ws_123",
+      projectId: "proj_stale",
+      unsupportedKey: "not-supported",
+    });
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    const result = await runAppDomainAdd(context, "shop.acme.com", {
+      projectRef: "proj_123",
+      appName: "shop",
+    });
+
+    expect(addDomain).toHaveBeenCalledWith({
+      appId: "app_1",
+      hostname: "shop.acme.com",
+    });
+    expect(result.result.project.id).toBe("proj_123");
+  });
+
   it("domain add does not synthesize DNS records when the API omits them", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
     const listApps = vi.fn().mockResolvedValue([

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -1171,65 +1171,116 @@ describe("app controller", () => {
     });
   });
 
-  it("lets --framework win over legacy --build-type for deploy", async () => {
-    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
-    const listApps = vi.fn().mockResolvedValue([
-      { id: "app_1", name: "hello-world", region: "eu-central-1", liveDeploymentId: null, liveUrl: null },
-    ]);
-    const deployApp = vi.fn().mockResolvedValue({
-      projectId: "proj_123",
-      app: {
-        id: "app_1",
-        name: "hello-world",
-        region: "eu-central-1",
-        liveDeploymentId: "dep_123",
-        liveUrl: "https://hello-world.prisma.app",
-      },
-      deployment: {
-        id: "dep_123",
-        status: "running",
-        url: "https://hello-world.prisma.app",
-      },
-    });
+  it.each([
+    {
+      name: "Next.js from package.json",
+      packageJson: { dependencies: { next: "15.0.0" } },
+      expectedBuildType: "nextjs",
+    },
+    {
+      name: "Next.js from next.config.mts",
+      files: { "next.config.mts": "export default { output: \"standalone\" }\n" },
+      expectedBuildType: "nextjs",
+    },
+    {
+      name: "Hono from package.json",
+      packageJson: { dependencies: { hono: "4.0.0" } },
+      files: { "src/index.ts": "export default { fetch: () => new Response('ok') }\n" },
+      expectedEntrypoint: "src/index.ts",
+      expectedBuildType: "bun",
+    },
+    {
+      name: "Bun from --entry",
+      entrypoint: "src/server.ts",
+      expectedBuildType: "bun",
+    },
+    {
+      name: "Bun from --framework bun",
+      framework: "bun",
+      entrypoint: "src/server.ts",
+      expectedBuildType: "bun",
+    },
+    {
+      name: "TanStack Start React from package.json",
+      packageJson: { dependencies: { "@tanstack/react-start": "1.0.0" } },
+      expectedBuildType: "tanstack-start",
+    },
+    {
+      name: "TanStack Start Solid from package.json",
+      packageJson: { dependencies: { "@tanstack/solid-start": "1.0.0" } },
+      expectedBuildType: "tanstack-start",
+    },
+  ])(
+    "detects deploy framework: $name",
+    async ({ packageJson, files, framework, entrypoint, expectedEntrypoint, expectedBuildType }) => {
+      const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+      const listApps = vi.fn().mockResolvedValue([
+        { id: "app_1", name: "hello-world", region: "eu-central-1", liveDeploymentId: null, liveUrl: null },
+      ]);
+      const deployApp = vi.fn().mockResolvedValue({
+        projectId: "proj_123",
+        app: {
+          id: "app_1",
+          name: "hello-world",
+          region: "eu-central-1",
+          liveDeploymentId: "dep_123",
+          liveUrl: "https://hello-world.prisma.app",
+        },
+        deployment: {
+          id: "dep_123",
+          status: "running",
+          url: "https://hello-world.prisma.app",
+        },
+      });
 
-    vi.doMock("../src/lib/auth/guard", () => ({
-      requireComputeAuth,
-    }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() => ({
-        listApps,
-        deployApp,
-        listDeployments: vi.fn(),
-        showDeployment: vi.fn(),
-      })),
-    }));
+      vi.doMock("../src/lib/auth/guard", () => ({
+        requireComputeAuth,
+      }));
+      vi.doMock("../src/lib/app/preview-provider", () => ({
+        createPreviewAppProvider: vi.fn(() => ({
+          listApps,
+          deployApp,
+          listDeployments: vi.fn(),
+          showDeployment: vi.fn(),
+        })),
+      }));
 
-    const { createTempCwd, createTestCommandContext } = await import("./helpers");
-    const { runAppDeploy } = await import("../src/controllers/app");
-    const cwd = await createTempCwd();
-    const stateDir = path.join(cwd, ".state");
-    const { context } = await createTestCommandContext({
-      cwd,
-      stateDir,
-      env: {
-        ...process.env,
-        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
-      },
-    });
+      const { createTempCwd, createTestCommandContext } = await import("./helpers");
+      const { runAppDeploy } = await import("../src/controllers/app");
+      const cwd = await createTempCwd();
+      if (packageJson) {
+        await writePackageJson(cwd, packageJson);
+      }
+      for (const [fileName, content] of Object.entries(files ?? {})) {
+        const filePath = path.join(cwd, fileName);
+        await mkdir(path.dirname(filePath), { recursive: true });
+        await writeFile(filePath, content);
+      }
+      const stateDir = path.join(cwd, ".state");
+      const { context } = await createTestCommandContext({
+        cwd,
+        stateDir,
+        env: {
+          ...process.env,
+          PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+        },
+      });
 
-    await runAppDeploy(context, "hello-world", {
-      projectRef: "proj_123",
-      framework: "hono",
-      buildType: "nextjs",
-    });
+      await runAppDeploy(context, "hello-world", {
+        projectRef: "proj_123",
+        framework,
+        entrypoint,
+      });
 
-    expect(deployApp).toHaveBeenCalledWith(
-      expect.objectContaining({
-        buildType: "bun",
-        portMapping: { http: 3000 },
-      }),
-    );
-  });
+      expect(deployApp).toHaveBeenCalledWith(
+        expect.objectContaining({
+          entrypoint: expectedEntrypoint ?? entrypoint,
+          buildType: expectedBuildType,
+          portMapping: { http: 3000 },
+        }),
+      );
+    },
+  );
 
   it("lets PRISMA_PROJECT_ID skip the local pin and resolve the project", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
@@ -1771,7 +1822,7 @@ describe("app controller", () => {
     expect(deployApp).not.toHaveBeenCalled();
   });
 
-  it("rejects --entry together with --build-type nextjs for deploy", async () => {
+  it("rejects --entry together with --framework nextjs for deploy", async () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppDeploy } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
@@ -1786,12 +1837,12 @@ describe("app controller", () => {
     });
 
     await expect(runAppDeploy(context, "hello-world", {
-      buildType: "nextjs",
+      framework: "nextjs",
       entrypoint: "server.js",
     })).rejects.toMatchObject({
       code: "USAGE_ERROR",
       domain: "app",
-      summary: "App deploy does not accept --entry with --build-type nextjs",
+      summary: "App deploy does not accept --entry with Next.js",
     });
   });
 

--- a/packages/cli/tests/app-env-vars.test.ts
+++ b/packages/cli/tests/app-env-vars.test.ts
@@ -255,7 +255,7 @@ describe("app env vars", () => {
         "deploy",
         "--app",
         "hello-world",
-        "--build-type",
+        "--framework",
         "nextjs",
         "--http-port",
         "3000",
@@ -304,7 +304,7 @@ describe("app env vars", () => {
       "hello-world",
       {
         entrypoint: undefined,
-        buildType: "nextjs",
+        framework: "nextjs",
         httpPort: "3000",
         envAssignments: ["DATABASE_URL=postgresql://example"],
         projectRef: "proj_123",


### PR DESCRIPTION
## Summary
- detect current TanStack Start packages and `next.config.mts`
- support vanilla Bun deploys through `--framework bun` or `--entry`
- make official Hono scaffolds deploy without needing `--entry` by defaulting to `src/index.ts`
- remove the hidden deploy `--build-type` path so deploy uses `--framework`

## Checked
- `pnpm --filter @prisma/cli test`
- `pnpm --filter @prisma/cli build`
- official `create-next-app` deploy returned HTTP 200 with `Hello world!`
- official Hono, TanStack Start, and Bun local Compute builds passed
