### PR TITLE
Require explicit Project binding for Project-scoped CLI commands

### DIFF
--- a/docs/product/cli-style-guide.md
+++ b/docs/product/cli-style-guide.md
@@ -64,11 +64,13 @@ Recommended symbols:
 Human-oriented command output in TTY mode should usually start with a compact header:
 
 ```text
-project show → Showing the project resolved for this directory.
+project show → No Project linked to this directory.
 
-│  project:    Acme Dashboard
 │  workspace:  Acme Inc
-│  source:     package-name
+│  project:    unbound
+│  suggested:  billing-api (package name)
+│  match:      Billing API
+│  next:       prisma-cli project link <id-or-name>
 │
 │  Read more   docs/product/command-spec.md#prisma-cli-project-show
 ```

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -80,10 +80,8 @@ Commands resolve project context in this order:
 2. `PRISMA_PROJECT_ID` when set for headless deploy/domain commands
 3. `.prisma/local.json` project pin when present, revalidated against platform data
 4. durable platform mapping when available
-5. remembered local project context, revalidated against platform data
-6. `package.json` name matched exactly against an existing accessible Project for non-mutating resolution
-7. explicit setup choice from `project link`, `project create`, an interactive setup picker, `app deploy --project`, or `app deploy --create-project`
-8. structured failure in `--json` / `--no-interactive` mode
+5. explicit setup choice from `project link`, `project create`, an interactive setup picker, `app deploy --project`, or `app deploy --create-project`
+6. structured failure when no explicit or durable Project binding exists
 
 `--project` is an explicit Project choice. When used from an unbound directory
 with `app deploy`, it writes `.prisma/local.json` after validation and before
@@ -93,10 +91,13 @@ suggest setup defaults, but they never authorize Project creation by themselves.
 When `PRISMA_PROJECT_ID` is set, `app deploy` and `app domain` commands skip
 `.prisma/local.json` reads and do not write a new pin.
 
-`app deploy` is stricter than general inspection commands: it does not use
-package-name matching or remembered local context as Project scope. Without a
-pin, durable mapping, env var, or explicit Project flag, it enters explicit
-setup or fails with `PROJECT_SETUP_REQUIRED`.
+Project-scoped commands never use package-name matching, directory-name
+matching, or remembered local context as selected Project scope. Local metadata
+may suggest setup defaults and candidate Projects, but only explicit input or
+durable state may select a Project. Without a pin, durable mapping, supported
+env var, or explicit Project flag, Project-scoped commands fail with
+`PROJECT_SETUP_REQUIRED`; `app deploy` may enter explicit interactive setup
+before failing.
 
 ### App Selection
 
@@ -376,17 +377,19 @@ prisma-cli project list --json
 
 Purpose:
 
-- show the Prisma project resolved for this directory
+- show this directory's Prisma Project binding
 
 Behavior:
 
 - requires auth
-- resolves project context without creating projects
+- inspects explicit or durable project context without creating projects
 - does not prompt for project selection
 - does not mutate local state
 - `--project <id-or-name>` resolves only the explicit project
-- returns Workspace, Project, and `resolution.projectSource`
-- fails with `PROJECT_UNRESOLVED`, `PROJECT_NOT_FOUND`, `PROJECT_AMBIGUOUS`, or `LOCAL_STATE_STALE` when resolution cannot continue safely
+- when bound, returns Workspace, Project, and `resolution.projectSource`
+- when unbound, exits successfully with `project: null`, `resolution.projectSource: "unbound"`, a suggested Project name, matching Project candidates, and recovery commands
+- package names and directory names only power unbound suggestions
+- fails with `PROJECT_NOT_FOUND`, `PROJECT_AMBIGUOUS`, or `LOCAL_STATE_STALE` when explicit or durable binding validation cannot continue safely
 
 Examples:
 

--- a/docs/product/error-conventions.md
+++ b/docs/product/error-conventions.md
@@ -159,7 +159,6 @@ These codes are the minimum stable set for the MVP:
 
 - `USAGE_ERROR`
 - `AUTH_REQUIRED`
-- `PROJECT_UNRESOLVED`
 - `PROJECT_SETUP_REQUIRED`
 - `PROJECT_CREATE_FAILED`
 - `PROJECT_NOT_FOUND`
@@ -199,13 +198,12 @@ Recommended meanings:
 
 - `USAGE_ERROR`: invalid arguments or invalid command combination
 - `AUTH_REQUIRED`: command needs an authenticated session
-- `PROJECT_UNRESOLVED`: command needs project context and none could be resolved
-- `PROJECT_SETUP_REQUIRED`: `app deploy` needs an explicit Project setup choice before it can continue
+- `PROJECT_SETUP_REQUIRED`: command needs explicit or durable Project context before it can continue
 - `PROJECT_CREATE_FAILED`: Project creation failed before deployment or linking could continue
 - `PROJECT_NOT_FOUND`: requested project does not exist or is not accessible
 - `PROJECT_AMBIGUOUS`: multiple safe project candidates matched
 - `APP_AMBIGUOUS`: multiple apps matched the inferred or explicit app target
-- `LOCAL_STATE_STALE`: local Project pin or remembered context no longer matches platform data and continuing would be ambiguous
+- `LOCAL_STATE_STALE`: local Project pin no longer matches platform data and continuing would be ambiguous
 - `BRANCH_NOT_DEPLOYABLE`: command tried to deploy to a non-deployable branch context
 - `FRAMEWORK_NOT_DETECTED`: app deploy could not detect a supported Beta framework and no explicit framework/build type was provided
 - `DEPLOYMENT_NOT_FOUND`: requested deployment id does not exist

--- a/docs/product/output-conventions.md
+++ b/docs/product/output-conventions.md
@@ -220,11 +220,13 @@ Human output should:
 Recommended header shape:
 
 ```text
-project show → Showing the project resolved for this directory.
+project show → No Project linked to this directory.
 
-│  project:    Acme Dashboard
 │  workspace:  Acme Inc
-│  source:     package-name
+│  project:    unbound
+│  suggested:  billing-api (package name)
+│  match:      Billing API
+│  next:       prisma-cli project link <id-or-name>
 │
 │  Read more   docs/product/command-spec.md#prisma-cli-project-show
 ```

--- a/docs/product/resource-model.md
+++ b/docs/product/resource-model.md
@@ -193,20 +193,18 @@ Commands resolve project context in this order:
 2. `PRISMA_PROJECT_ID` when set for headless deploy/domain commands
 3. `.prisma/local.json` project pin when present, revalidated against platform data
 4. durable platform mapping when available
-5. remembered local project context, revalidated against platform data
-6. `package.json` name matched exactly against an existing accessible Project for non-mutating resolution
-7. explicit setup choice: `project link`, `project create`, interactive setup picker, `app deploy --project`, or `app deploy --create-project`
-8. structured failure in `--json` / `--no-interactive` mode
+5. explicit setup choice: `project link`, `project create`, interactive setup picker, `app deploy --project`, or `app deploy --create-project`
+6. structured failure when no explicit or durable Project binding exists
 
-Remembered local project context is an internal convenience after successful
-resolution. It must be revalidated before use and must not be described to users
-as durable linking. Package names and directory names may be suggested during
-setup, but they do not authorize Project creation by themselves.
+Package names and directory names may suggest setup defaults and matching
+Project candidates, but they do not select Project scope. Remembered local
+context may help with app/deployment convenience after a Project is explicit,
+but it is not a Project binding source.
 
-`app deploy` is stricter than general inspection commands: if the directory is
-not pinned and no explicit Project source is provided, it enters explicit setup
-or fails with `PROJECT_SETUP_REQUIRED` instead of using package-name or
-remembered-local inference.
+Project-scoped commands require explicit or durable Project context. If the
+directory is not pinned and no explicit Project source is provided, they fail
+with `PROJECT_SETUP_REQUIRED`; `app deploy` may enter explicit interactive setup
+before failing.
 
 ### App Selection Resolution
 

--- a/packages/cli/src/controllers/app-env.ts
+++ b/packages/cli/src/controllers/app-env.ts
@@ -21,7 +21,6 @@ import type {
   EnvVariableMetadata,
 } from "../types/app-env";
 import { requireAuthenticatedAuthState } from "./auth";
-import { createSelectPromptPort } from "./select-prompt-port";
 import { listRealWorkspaceProjects } from "./project";
 
 interface ResolvedScope {
@@ -72,7 +71,7 @@ export async function runEnvAdd(
     );
   }
 
-  const { client, projectId } = await requireClientAndProject(context, flags.projectRef);
+  const { client, projectId } = await requireClientAndProject(context, flags.projectRef, "project env add");
   const resolved = await resolveScopeToApi(client, projectId, scope, {
     createBranchIfMissing: true,
   });
@@ -152,7 +151,7 @@ export async function runEnvUpdate(
     );
   }
 
-  const { client, projectId } = await requireClientAndProject(context, flags.projectRef);
+  const { client, projectId } = await requireClientAndProject(context, flags.projectRef, "project env update");
   const resolved = await resolveScopeToApi(client, projectId, scope, {
     createBranchIfMissing: false,
   });
@@ -203,7 +202,7 @@ export async function runEnvList(
   const explicit = resolveEnvScope(flags, { requireExplicit: false, command: "list" });
   const scope = explicit ?? defaultRoleScope();
 
-  const { client, projectId } = await requireClientAndProject(context, flags.projectRef);
+  const { client, projectId } = await requireClientAndProject(context, flags.projectRef, "project env list");
   const resolved = await resolveScopeToApi(client, projectId, scope, {
     createBranchIfMissing: false,
   });
@@ -249,7 +248,7 @@ export async function runEnvRemove(
     );
   }
 
-  const { client, projectId } = await requireClientAndProject(context, flags.projectRef);
+  const { client, projectId } = await requireClientAndProject(context, flags.projectRef, "project env remove");
   const resolved = await resolveScopeToApi(client, projectId, scope, {
     createBranchIfMissing: false,
   });
@@ -293,6 +292,7 @@ export async function runEnvRemove(
 async function requireClientAndProject(
   context: CommandContext,
   explicitProject: string | undefined,
+  commandName: string,
 ): Promise<{ client: ManagementApiClient; projectId: string }> {
   const authState = await requireAuthenticatedAuthState(context);
   const client = await requireComputeAuth(context.runtime.env);
@@ -308,8 +308,7 @@ async function requireClientAndProject(
     workspace: authState.workspace,
     explicitProject,
     listProjects: () => listRealWorkspaceProjects(client, authState.workspace!),
-    prompt: createSelectPromptPort(context),
-    remember: true,
+    commandName,
   });
 
   return { client, projectId: target.project.id };

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -622,7 +622,7 @@ export async function runAppDomainAdd(
   },
 ): Promise<CommandSuccess<AppDomainAddResult>> {
   const normalizedHostname = normalizeDomainHostname(hostname);
-  const target = await resolveAppDomainTarget(context, options);
+  const target = await resolveAppDomainTarget(context, options, `app domain add ${normalizedHostname}`);
 
   const added = await target.provider.addDomain({
     appId: target.app.id,
@@ -656,7 +656,7 @@ export async function runAppDomainShow(
   },
 ): Promise<CommandSuccess<AppDomainShowResult>> {
   const normalizedHostname = normalizeDomainHostname(hostname);
-  const target = await resolveAppDomainTarget(context, options);
+  const target = await resolveAppDomainTarget(context, options, `app domain show ${normalizedHostname}`);
   const domain = await resolveDomainByHostname(target.provider, target.app.id, normalizedHostname, "show");
   const detail = await target.provider.showDomain(domain.id).catch((error) => {
     throw domainCommandError("show", error, normalizedHostname);
@@ -683,7 +683,7 @@ export async function runAppDomainRemove(
   },
 ): Promise<CommandSuccess<AppDomainRemoveResult>> {
   const normalizedHostname = normalizeDomainHostname(hostname);
-  const target = await resolveAppDomainTarget(context, options);
+  const target = await resolveAppDomainTarget(context, options, `app domain remove ${normalizedHostname}`);
   const domain = await resolveDomainByHostname(target.provider, target.app.id, normalizedHostname, "remove");
 
   await confirmDomainRemoval(context, target.resultTarget, normalizedHostname);
@@ -714,7 +714,7 @@ export async function runAppDomainRetry(
   },
 ): Promise<CommandSuccess<AppDomainRetryResult>> {
   const normalizedHostname = normalizeDomainHostname(hostname);
-  const target = await resolveAppDomainTarget(context, options);
+  const target = await resolveAppDomainTarget(context, options, `app domain retry ${normalizedHostname}`);
   const domain = await resolveDomainByHostname(target.provider, target.app.id, normalizedHostname, "retry");
   const retried = await target.provider.retryDomain(domain.id).catch((error) => {
     throw domainCommandError("retry", error, normalizedHostname);
@@ -743,7 +743,7 @@ export async function runAppDomainWait(
 ): Promise<void> {
   const normalizedHostname = normalizeDomainHostname(hostname);
   const timeoutMs = parseDomainWaitTimeout(options?.timeout);
-  const target = await resolveAppDomainTarget(context, options);
+  const target = await resolveAppDomainTarget(context, options, `app domain wait ${normalizedHostname}`);
   const domain = await resolveDomainByHostname(target.provider, target.app.id, normalizedHostname, "wait");
 
   if (!context.flags.json && !context.flags.quiet) {
@@ -1200,6 +1200,7 @@ async function resolveAppDomainTarget(
     projectRef?: string;
     branchName?: string;
   },
+  commandName = "app domain",
 ): Promise<ResolvedAppDomainTarget> {
   ensurePreviewAppMode(context);
 
@@ -1218,18 +1219,11 @@ async function resolveAppDomainTarget(
 
   const envProjectId = readDeployEnvOverride(context, PRISMA_PROJECT_ID_ENV_VAR);
   const envAppId = readDeployEnvOverride(context, PRISMA_APP_ID_ENV_VAR);
-  const skipLocalPin = Boolean(envProjectId || options?.projectRef);
-  const localPin = skipLocalPin
-    ? ({ kind: "missing" } satisfies LocalResolutionPinReadResult)
-    : await readLocalResolutionPin(context.runtime.cwd);
-  if (!skipLocalPin && localPin.kind === "invalid") {
-    throw localResolutionPinStaleError();
-  }
 
-  const { provider, target, projectId } = await requireProviderAndDeployProjectContext(context, options?.projectRef, {
+  const { provider, target, projectId } = await requireProviderAndProjectContext(context, options?.projectRef, {
     branch,
+    commandName,
     envProjectId,
-    localPin,
   });
   const apps = await listApps(context, provider, projectId, target.branch.name);
   const selectedApp = await resolveDomainAppSelection(context, projectId, apps, {
@@ -2184,6 +2178,7 @@ async function requireProviderAndProjectContext(
   options?: {
     branch?: ResolvedDeployBranch;
     commandName?: string;
+    envProjectId?: string;
   },
 ): Promise<{
   client: ManagementApiClient;
@@ -2244,6 +2239,7 @@ async function resolveProjectContext(
     context,
     workspace: authState.workspace,
     explicitProject,
+    envProjectId: options?.envProjectId,
     listProjects: () => listRealWorkspaceProjects(client, authState.workspace!),
     commandName: options?.commandName,
   });

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -2232,6 +2232,7 @@ async function resolveProjectContext(
   explicitProject: string | undefined,
   options?: {
     branch?: ResolvedDeployBranch;
+    commandName?: string;
   },
 ): Promise<ResolvedAppProjectContext> {
   const authState = await requireAuthenticatedAuthState(context);
@@ -3237,12 +3238,12 @@ function localResolutionPinStaleError(): CliError {
     domain: "project",
     summary: "Local project binding is stale",
     why: `The target recorded in ${LOCAL_RESOLUTION_PIN_RELATIVE_PATH} is no longer available in the selected workspace.`,
-    fix: `Delete ${LOCAL_RESOLUTION_PIN_RELATIVE_PATH} and re-run to re-bootstrap.`,
+    fix: `Delete ${LOCAL_RESOLUTION_PIN_RELATIVE_PATH}, then choose a Project explicitly.`,
     meta: {
       pinPath: LOCAL_RESOLUTION_PIN_RELATIVE_PATH,
     },
     exitCode: 1,
-    nextSteps: ["prisma-cli app deploy"],
+    nextSteps: ["prisma-cli project list", "prisma-cli project link <id-or-name>", "prisma-cli app deploy --project <id-or-name>"],
   });
 }
 

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -360,7 +360,9 @@ export async function runAppListDeploys(
 ): Promise<CommandSuccess<AppListDeploysResult>> {
   ensurePreviewAppMode(context);
 
-  const { provider, target, projectId } = await requireProviderAndProjectContext(context, projectRef);
+  const { provider, target, projectId } = await requireProviderAndProjectContext(context, projectRef, {
+    commandName: "app list-deploys",
+  });
   const apps = await listApps(context, provider, projectId, target.branch.name);
   const selectedApp = await resolveExistingAppSelection(context, projectId, apps, appName);
 
@@ -419,7 +421,9 @@ export async function runAppShow(
 ): Promise<CommandSuccess<AppShowResult>> {
   ensurePreviewAppMode(context);
 
-  const { provider, target, projectId } = await requireProviderAndProjectContext(context, projectRef);
+  const { provider, target, projectId } = await requireProviderAndProjectContext(context, projectRef, {
+    commandName: "app show",
+  });
   const apps = await listApps(context, provider, projectId, target.branch.name);
   const selectedApp = await resolveExistingAppSelection(context, projectId, apps, appName);
 
@@ -536,7 +540,9 @@ export async function runAppOpen(
 ): Promise<CommandSuccess<AppOpenResult>> {
   ensurePreviewAppMode(context);
 
-  const { provider, target, projectId } = await requireProviderAndProjectContext(context, projectRef);
+  const { provider, target, projectId } = await requireProviderAndProjectContext(context, projectRef, {
+    commandName: "app open",
+  });
   const apps = await listApps(context, provider, projectId, target.branch.name);
   const selectedApp = await resolveExistingAppSelection(context, projectId, apps, appName);
 
@@ -817,7 +823,9 @@ export async function runAppLogs(
 ): Promise<void> {
   ensurePreviewAppMode(context);
 
-  const { provider, target: resolvedTarget, projectId } = await requireProviderAndProjectContext(context, projectRef);
+  const { provider, target: resolvedTarget, projectId } = await requireProviderAndProjectContext(context, projectRef, {
+    commandName: "app logs",
+  });
   const target = deploymentId
     ? await resolveExplicitLogDeployment(context, provider, projectId, resolvedTarget.branch.name, appName, deploymentId)
     : await resolveLiveLogDeployment(context, provider, projectId, resolvedTarget.branch.name, appName);
@@ -1013,7 +1021,9 @@ export async function runAppPromote(
 ): Promise<CommandSuccess<AppPromoteResult>> {
   ensurePreviewAppMode(context);
 
-  const { provider, target, projectId } = await requireProviderAndProjectContext(context, projectRef);
+  const { provider, target, projectId } = await requireProviderAndProjectContext(context, projectRef, {
+    commandName: "app promote",
+  });
   const apps = await listApps(context, provider, projectId, target.branch.name);
   const selectedApp = await requireReleaseAppSelection(context, projectId, apps, appName, "promote");
   const deploymentsResult = await provider.listDeployments(selectedApp.id).catch((error) => {
@@ -1079,7 +1089,9 @@ export async function runAppRollback(
 ): Promise<CommandSuccess<AppRollbackResult>> {
   ensurePreviewAppMode(context);
 
-  const { provider, target, projectId } = await requireProviderAndProjectContext(context, projectRef);
+  const { provider, target, projectId } = await requireProviderAndProjectContext(context, projectRef, {
+    commandName: "app rollback",
+  });
   const apps = await listApps(context, provider, projectId, target.branch.name);
   const selectedApp = await requireReleaseAppSelection(context, projectId, apps, appName, "rollback");
   const deploymentsResult = await provider.listDeployments(selectedApp.id).catch((error) => {
@@ -1146,7 +1158,9 @@ export async function runAppRemove(
 ): Promise<CommandSuccess<AppRemoveResult>> {
   ensurePreviewAppMode(context);
 
-  const { provider, target, projectId } = await requireProviderAndProjectContext(context, projectRef);
+  const { provider, target, projectId } = await requireProviderAndProjectContext(context, projectRef, {
+    commandName: "app remove",
+  });
   const apps = await listApps(context, provider, projectId, target.branch.name);
   const selectedApp = await requireReleaseAppSelection(context, projectId, apps, appName, "remove");
 
@@ -2102,9 +2116,9 @@ async function listApps(
         domain: "project",
         summary: "Project not found",
         why: `The resolved project "${projectId}" does not exist in the authenticated workspace or is no longer accessible.`,
-        fix: "Pass --project <id-or-name>, or run prisma-cli project show to inspect resolution for this directory.",
+        fix: "Pass --project <id-or-name>, or run prisma-cli project show to inspect this directory's binding.",
         exitCode: 1,
-        nextSteps: ["prisma-cli project show", "prisma-cli app deploy --project <id-or-name>"],
+        nextSteps: ["prisma-cli project show", "prisma-cli project link <id-or-name>"],
       });
     }
 
@@ -2169,6 +2183,7 @@ async function requireProviderAndProjectContext(
   explicitProject: string | undefined,
   options?: {
     branch?: ResolvedDeployBranch;
+    commandName?: string;
   },
 ): Promise<{
   client: ManagementApiClient;
@@ -2229,7 +2244,7 @@ async function resolveProjectContext(
     workspace: authState.workspace,
     explicitProject,
     listProjects: () => listRealWorkspaceProjects(client, authState.workspace!),
-    remember: true,
+    commandName: options?.commandName,
   });
   const branch = options?.branch ?? await resolveDeployBranch(context, undefined);
 

--- a/packages/cli/src/controllers/project.ts
+++ b/packages/cli/src/controllers/project.ts
@@ -8,9 +8,11 @@ import {
 } from "../adapters/git";
 import { requireComputeAuth } from "../lib/auth/guard";
 import {
+  inspectProjectBinding,
   resolveProjectTarget,
   sortProjects,
   type ProjectCandidate,
+  type ResolvedProjectTarget,
 } from "../lib/project/resolution";
 import {
   bindProjectToDirectory,
@@ -211,7 +213,7 @@ export async function runGitConnect(
       throw authRequiredError();
     }
 
-    const target = await resolveProjectShowInRealMode(context, workspace, options.project);
+    const target = await resolveRequiredProjectInRealMode(context, workspace, options.project, "git connect");
     const repository = await resolveRepositoryForConnect(context, gitUrl);
     const api = client as unknown as SourceRepositoryApiClient;
     const existing = await readFirstSourceRepository(api, target.project.id);
@@ -258,7 +260,7 @@ export async function runGitConnect(
     };
   }
 
-  const target = await resolveProjectShowInFixtureMode(context, workspace, options.project);
+  const target = await resolveRequiredProjectInFixtureMode(context, workspace, options.project, "git connect");
   const repository = await resolveRepositoryForConnect(context, gitUrl);
   const existingConnection = await context.stateStore.readRepositoryConnection(target.project.id);
 
@@ -308,7 +310,7 @@ export async function runGitDisconnect(
       throw authRequiredError();
     }
 
-    const target = await resolveProjectShowInRealMode(context, workspace, options.project);
+    const target = await resolveRequiredProjectInRealMode(context, workspace, options.project, "git disconnect");
     const api = client as unknown as SourceRepositoryApiClient;
     const existing = await readFirstSourceRepository(api, target.project.id);
 
@@ -339,7 +341,7 @@ export async function runGitDisconnect(
     };
   }
 
-  const target = await resolveProjectShowInFixtureMode(context, workspace, options.project);
+  const target = await resolveRequiredProjectInFixtureMode(context, workspace, options.project, "git disconnect");
   const existingConnection = await context.stateStore.readRepositoryConnection(target.project.id);
 
   if (!existingConnection) {
@@ -369,12 +371,32 @@ async function resolveProjectShowInRealMode(
     throw authRequiredError();
   }
 
+  return inspectProjectBinding({
+    context,
+    workspace,
+    explicitProject,
+    listProjects: () => listRealWorkspaceProjects(client, workspace),
+    commandName: "project show",
+  });
+}
+
+async function resolveRequiredProjectInRealMode(
+  context: CommandContext,
+  workspace: AuthWorkspace,
+  explicitProject: string | undefined,
+  commandName: string,
+): Promise<ResolvedProjectTarget> {
+  const client = await requireComputeAuth(context.runtime.env);
+  if (!client) {
+    throw authRequiredError();
+  }
+
   return resolveProjectTarget({
     context,
     workspace,
     explicitProject,
     listProjects: () => listRealWorkspaceProjects(client, workspace),
-    remember: false,
+    commandName,
   });
 }
 
@@ -395,12 +417,27 @@ async function resolveProjectShowInFixtureMode(
   workspace: AuthWorkspace,
   explicitProject: string | undefined,
 ): Promise<ProjectShowResult> {
+  return inspectProjectBinding({
+    context,
+    workspace,
+    explicitProject,
+    listProjects: async () => listFixtureWorkspaceProjects(context, workspace),
+    commandName: "project show",
+  });
+}
+
+async function resolveRequiredProjectInFixtureMode(
+  context: CommandContext,
+  workspace: AuthWorkspace,
+  explicitProject: string | undefined,
+  commandName: string,
+): Promise<ResolvedProjectTarget> {
   return resolveProjectTarget({
     context,
     workspace,
     explicitProject,
     listProjects: async () => listFixtureWorkspaceProjects(context, workspace),
-    remember: false,
+    commandName,
   });
 }
 

--- a/packages/cli/src/controllers/project.ts
+++ b/packages/cli/src/controllers/project.ts
@@ -1175,10 +1175,3 @@ function repoConnectionFixForStatus(status: number): string {
 
   return "Re-run with --trace for the underlying API response details.";
 }
-
-function toProjectSummary(project: ProjectCandidate) {
-  return {
-    id: project.id,
-    name: project.name,
-  };
-}

--- a/packages/cli/src/lib/project/resolution.ts
+++ b/packages/cli/src/lib/project/resolution.ts
@@ -19,11 +19,8 @@ export interface ProjectCandidate extends ProjectSummary {
   workspace: AuthWorkspace;
 }
 
-export interface ResolvedProjectTarget {
-  workspace: AuthWorkspace;
-  project: ProjectSummary;
-  resolution: ProjectResolution;
-}
+export type ResolvedProjectTarget = BoundProjectShowResult;
+type BoundProjectSource = Exclude<ProjectSource, "unbound">;
 
 export type InferredTargetNameSource = "package-name" | "directory-name";
 
@@ -43,51 +40,10 @@ export interface ResolveProjectOptions {
 
 export async function resolveProjectTarget(options: ResolveProjectOptions): Promise<ResolvedProjectTarget> {
   const projects = await options.listProjects();
+  const target = await resolveBoundProjectTarget(options, projects, { allowEnvProjectId: true });
 
-  if (options.explicitProject) {
-    return resolvedTarget(options.workspace, resolveExplicitProject(options.explicitProject, projects, options.workspace), "explicit", {
-      targetName: options.explicitProject,
-      targetNameSource: "explicit",
-    });
-  }
-
-  if (options.envProjectId) {
-    const project = projects.find((candidate) => candidate.id === options.envProjectId);
-    if (!project) {
-      throw projectNotFoundError(options.envProjectId, options.workspace);
-    }
-    return resolvedTarget(options.workspace, project, "env", {
-      targetName: options.envProjectId,
-      targetNameSource: "env",
-    });
-  }
-
-  const localPin = await readLocalResolutionPin(options.context.runtime.cwd);
-  if (localPin.kind === "invalid") {
-    throw localStateStaleError();
-  }
-  if (localPin.kind === "present") {
-    if (localPin.pin.workspaceId !== options.workspace.id) {
-      throw localStateStaleError();
-    }
-
-    const project = projects.find((candidate) => candidate.id === localPin.pin.projectId);
-    if (!project) {
-      throw localStateStaleError();
-    }
-
-    return resolvedTarget(options.workspace, project, "local-pin", {
-      targetName: project.name,
-      targetNameSource: "local-pin",
-    });
-  }
-
-  const platformMapping = await resolveDurablePlatformMapping();
-  if (platformMapping && platformMapping.workspace.id === options.workspace.id) {
-    return resolvedTarget(options.workspace, platformMapping, "platform-mapping", {
-      targetName: platformMapping.name,
-      targetNameSource: "platform-mapping",
-    });
+  if (target) {
+    return target;
   }
 
   throw await projectSetupRequiredError({
@@ -99,40 +55,10 @@ export async function resolveProjectTarget(options: ResolveProjectOptions): Prom
 
 export async function inspectProjectBinding(options: ResolveProjectOptions): Promise<ProjectShowResult> {
   const projects = await options.listProjects();
+  const target = await resolveBoundProjectTarget(options, projects, { allowEnvProjectId: false });
 
-  if (options.explicitProject) {
-    return resolvedTarget(options.workspace, resolveExplicitProject(options.explicitProject, projects, options.workspace), "explicit", {
-      targetName: options.explicitProject,
-      targetNameSource: "explicit",
-    });
-  }
-
-  const localPin = await readLocalResolutionPin(options.context.runtime.cwd);
-  if (localPin.kind === "invalid") {
-    throw localStateStaleError();
-  }
-  if (localPin.kind === "present") {
-    if (localPin.pin.workspaceId !== options.workspace.id) {
-      throw localStateStaleError();
-    }
-
-    const project = projects.find((candidate) => candidate.id === localPin.pin.projectId);
-    if (!project) {
-      throw localStateStaleError();
-    }
-
-    return resolvedTarget(options.workspace, project, "local-pin", {
-      targetName: project.name,
-      targetNameSource: "local-pin",
-    });
-  }
-
-  const platformMapping = await resolveDurablePlatformMapping();
-  if (platformMapping && platformMapping.workspace.id === options.workspace.id) {
-    return resolvedTarget(options.workspace, platformMapping, "platform-mapping", {
-      targetName: platformMapping.name,
-      targetNameSource: "platform-mapping",
-    });
+  if (target) {
+    return target;
   }
 
   return {
@@ -233,7 +159,7 @@ export async function projectSetupRequiredError(options: {
     summary: "Choose a Project before running this command",
     why: `This directory is not linked to a Prisma Project, and ${commandLabel} will not choose one from package or directory names.`,
     fix: "Link the directory to an existing Project, or pass --project <id-or-name> for this command.",
-    meta: suggestion,
+    meta: { ...suggestion },
     exitCode: 1,
     nextSteps: ["prisma-cli project list", ...suggestion.recoveryCommands],
   });
@@ -307,10 +233,66 @@ export async function resolveDurablePlatformMapping(): Promise<ProjectCandidate 
   return null;
 }
 
+async function resolveBoundProjectTarget(
+  options: ResolveProjectOptions,
+  projects: ProjectCandidate[],
+  settings: {
+    allowEnvProjectId: boolean;
+  },
+): Promise<BoundProjectShowResult | null> {
+  if (options.explicitProject) {
+    return resolvedTarget(options.workspace, resolveExplicitProject(options.explicitProject, projects, options.workspace), "explicit", {
+      targetName: options.explicitProject,
+      targetNameSource: "explicit",
+    });
+  }
+
+  if (settings.allowEnvProjectId && options.envProjectId) {
+    const project = projects.find((candidate) => candidate.id === options.envProjectId);
+    if (!project) {
+      throw projectNotFoundError(options.envProjectId, options.workspace);
+    }
+    return resolvedTarget(options.workspace, project, "env", {
+      targetName: options.envProjectId,
+      targetNameSource: "env",
+    });
+  }
+
+  const localPin = await readLocalResolutionPin(options.context.runtime.cwd);
+  if (localPin.kind === "invalid") {
+    throw localStateStaleError();
+  }
+  if (localPin.kind === "present") {
+    if (localPin.pin.workspaceId !== options.workspace.id) {
+      throw localStateStaleError();
+    }
+
+    const project = projects.find((candidate) => candidate.id === localPin.pin.projectId);
+    if (!project) {
+      throw localStateStaleError();
+    }
+
+    return resolvedTarget(options.workspace, project, "local-pin", {
+      targetName: project.name,
+      targetNameSource: "local-pin",
+    });
+  }
+
+  const platformMapping = await resolveDurablePlatformMapping();
+  if (platformMapping && platformMapping.workspace.id === options.workspace.id) {
+    return resolvedTarget(options.workspace, platformMapping, "platform-mapping", {
+      targetName: platformMapping.name,
+      targetNameSource: "platform-mapping",
+    });
+  }
+
+  return null;
+}
+
 function resolvedTarget(
   workspace: AuthWorkspace,
   project: ProjectCandidate,
-  projectSource: ProjectSource,
+  projectSource: BoundProjectSource,
   resolutionDetails?: Omit<ProjectResolution, "projectSource">,
 ): BoundProjectShowResult {
   return {

--- a/packages/cli/src/lib/project/resolution.ts
+++ b/packages/cli/src/lib/project/resolution.ts
@@ -2,10 +2,17 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 
 import { CliError } from "../../shell/errors";
-import { canPrompt, type CommandContext } from "../../shell/runtime";
+import type { CommandContext } from "../../shell/runtime";
 import type { AuthWorkspace } from "../../types/auth";
-import type { ProjectResolution, ProjectSource, ProjectSummary } from "../../types/project";
-import type { SelectPromptPort } from "../../use-cases/contracts";
+import type {
+  BoundProjectShowResult,
+  ProjectResolution,
+  ProjectSetupSuggestion,
+  ProjectSource,
+  ProjectSummary,
+  ProjectShowResult,
+} from "../../types/project";
+import { LOCAL_RESOLUTION_PIN_RELATIVE_PATH, readLocalResolutionPin } from "./local-pin";
 
 export interface ProjectCandidate extends ProjectSummary {
   slug?: string | null;
@@ -29,123 +36,116 @@ export interface ResolveProjectOptions {
   context: CommandContext;
   workspace: AuthWorkspace;
   explicitProject?: string;
+  envProjectId?: string;
+  commandName?: string;
   listProjects(): Promise<ProjectCandidate[]>;
-  createProject?: (name: string) => Promise<ProjectCandidate>;
-  prompt?: SelectPromptPort;
-  allowCreate?: boolean;
-  remember?: boolean;
 }
 
 export async function resolveProjectTarget(options: ResolveProjectOptions): Promise<ResolvedProjectTarget> {
   const projects = await options.listProjects();
-  const inferredName = await inferTargetName(options.context.runtime.cwd);
 
   if (options.explicitProject) {
-    return rememberIfRequested(
-      options,
-      resolveExplicitProject(options.explicitProject, projects, options.workspace),
-      "explicit",
-      {
-        targetName: options.explicitProject,
-        targetNameSource: "explicit",
-      },
-    );
+    return resolvedTarget(options.workspace, resolveExplicitProject(options.explicitProject, projects, options.workspace), "explicit", {
+      targetName: options.explicitProject,
+      targetNameSource: "explicit",
+    });
+  }
+
+  if (options.envProjectId) {
+    const project = projects.find((candidate) => candidate.id === options.envProjectId);
+    if (!project) {
+      throw projectNotFoundError(options.envProjectId, options.workspace);
+    }
+    return resolvedTarget(options.workspace, project, "env", {
+      targetName: options.envProjectId,
+      targetNameSource: "env",
+    });
+  }
+
+  const localPin = await readLocalResolutionPin(options.context.runtime.cwd);
+  if (localPin.kind === "invalid") {
+    throw localStateStaleError();
+  }
+  if (localPin.kind === "present") {
+    if (localPin.pin.workspaceId !== options.workspace.id) {
+      throw localStateStaleError();
+    }
+
+    const project = projects.find((candidate) => candidate.id === localPin.pin.projectId);
+    if (!project) {
+      throw localStateStaleError();
+    }
+
+    return resolvedTarget(options.workspace, project, "local-pin", {
+      targetName: project.name,
+      targetNameSource: "local-pin",
+    });
   }
 
   const platformMapping = await resolveDurablePlatformMapping();
-  if (platformMapping) {
-    return rememberIfRequested(options, platformMapping, "platform-mapping");
-  }
-
-  let staleRemembered = false;
-
-  if (!options.allowCreate) {
-    const rememberedResult = await resolveRememberedProject(options, projects);
-    if (rememberedResult.target) {
-      return rememberedResult.target;
-    }
-    staleRemembered = rememberedResult.stale;
-  }
-
-  const packageName = inferredName.source === "package-name" ? inferredName.name : null;
-  if (packageName) {
-    const matches = projects.filter((project) => projectMatchesPackageName(project, packageName));
-    if (matches.length === 1) {
-      return rememberIfRequested(options, matches[0], "package-name", {
-        targetName: packageName,
-        targetNameSource: "package-name",
-      });
-    }
-    if (matches.length > 1) {
-      return resolveAmbiguousProject(options, matches, packageName, "package-name");
-    }
-  }
-
-  if (options.allowCreate && options.createProject) {
-    if (inferredName.name) {
-      const existing = projects.filter((project) => projectMatchesPackageName(project, inferredName.name));
-      if (existing.length === 1) {
-        return rememberIfRequested(options, existing[0], inferredName.source, {
-          targetName: inferredName.name,
-          targetNameSource: inferredName.source,
-        });
-      }
-      if (existing.length > 1) {
-        return resolveAmbiguousProject(options, existing, inferredName.name, inferredName.source);
-      }
-
-      const created = await options.createProject(inferredName.name);
-      return rememberIfRequested(options, created, "created", {
-        targetName: inferredName.name,
-        targetNameSource: inferredName.source,
-      });
-    }
-  }
-
-  if (options.prompt && canPrompt(options.context) && projects.length > 0) {
-    const selected = await options.prompt.select({
-      message: "Select a project",
-      choices: sortProjects(projects).map((project) => ({
-        label: `${project.name} (${project.id})`,
-        value: project,
-      })),
+  if (platformMapping && platformMapping.workspace.id === options.workspace.id) {
+    return resolvedTarget(options.workspace, platformMapping, "platform-mapping", {
+      targetName: platformMapping.name,
+      targetNameSource: "platform-mapping",
     });
-    return rememberIfRequested(options, selected, "prompt");
   }
 
-  if (staleRemembered && projects.length > 1) {
-    throw localStateStaleError();
-  }
-
-  throw projectUnresolvedError();
+  throw await projectSetupRequiredError({
+    cwd: options.context.runtime.cwd,
+    projects,
+    commandName: options.commandName,
+  });
 }
 
-async function resolveRememberedProject(
-  options: ResolveProjectOptions,
-  projects: ProjectCandidate[],
-): Promise<{ target: ResolvedProjectTarget | null; stale: boolean }> {
-  const remembered = await options.context.stateStore.readRememberedProject(options.workspace.id);
-  if (!remembered) {
-    return {
-      target: null,
-      stale: false,
-    };
+export async function inspectProjectBinding(options: ResolveProjectOptions): Promise<ProjectShowResult> {
+  const projects = await options.listProjects();
+
+  if (options.explicitProject) {
+    return resolvedTarget(options.workspace, resolveExplicitProject(options.explicitProject, projects, options.workspace), "explicit", {
+      targetName: options.explicitProject,
+      targetNameSource: "explicit",
+    });
   }
 
-  const matched = projects.find((project) => project.id === remembered.id);
-  if (!matched) {
-    return {
-      target: null,
-      stale: true,
-    };
+  const localPin = await readLocalResolutionPin(options.context.runtime.cwd);
+  if (localPin.kind === "invalid") {
+    throw localStateStaleError();
+  }
+  if (localPin.kind === "present") {
+    if (localPin.pin.workspaceId !== options.workspace.id) {
+      throw localStateStaleError();
+    }
+
+    const project = projects.find((candidate) => candidate.id === localPin.pin.projectId);
+    if (!project) {
+      throw localStateStaleError();
+    }
+
+    return resolvedTarget(options.workspace, project, "local-pin", {
+      targetName: project.name,
+      targetNameSource: "local-pin",
+    });
+  }
+
+  const platformMapping = await resolveDurablePlatformMapping();
+  if (platformMapping && platformMapping.workspace.id === options.workspace.id) {
+    return resolvedTarget(options.workspace, platformMapping, "platform-mapping", {
+      targetName: platformMapping.name,
+      targetNameSource: "platform-mapping",
+    });
   }
 
   return {
-    target: await rememberIfRequested(options, matched, "remembered-local", {
-      targetName: remembered.name,
-      targetNameSource: "remembered-local",
+    workspace: options.workspace,
+    project: null,
+    resolution: {
+      projectSource: "unbound",
+    },
+    ...await buildProjectSetupSuggestion({
+      cwd: options.context.runtime.cwd,
+      projects,
+      commandName: options.commandName ?? "project show",
     }),
-    stale: false,
   };
 }
 
@@ -186,27 +186,56 @@ export function projectAmbiguousError(projectRef: string | null, matches: Projec
   });
 }
 
-export function projectUnresolvedError(): CliError {
-  return new CliError({
-    code: "PROJECT_UNRESOLVED",
-    domain: "project",
-    summary: "No project is resolved for this directory",
-    why: "No project could be resolved from explicit input, platform mappings, remembered local context, or package metadata.",
-    fix: "Pass --project <id-or-name> on the command that needs a project, or add a package.json name that matches an accessible project.",
-    exitCode: 1,
-    nextSteps: ["prisma-cli project list", "prisma-cli project show --project <id-or-name>"],
-  });
-}
-
 export function localStateStaleError(): CliError {
   return new CliError({
     code: "LOCAL_STATE_STALE",
     domain: "project",
-    summary: "Remembered project context is stale",
-    why: "The remembered project is no longer available in the selected workspace, and automatic resolution would be ambiguous.",
-    fix: "Pass --project <id-or-name> to choose the project explicitly.",
+    summary: "Local project binding is stale",
+    why: `The target recorded in ${LOCAL_RESOLUTION_PIN_RELATIVE_PATH} is no longer available in the selected workspace.`,
+    fix: `Delete ${LOCAL_RESOLUTION_PIN_RELATIVE_PATH}, then choose a Project explicitly.`,
+    meta: {
+      pinPath: LOCAL_RESOLUTION_PIN_RELATIVE_PATH,
+    },
     exitCode: 1,
-    nextSteps: ["prisma-cli project list"],
+    nextSteps: ["prisma-cli project list", "prisma-cli project link <id-or-name>"],
+  });
+}
+
+export async function buildProjectSetupSuggestion(options: {
+  cwd: string;
+  projects: ProjectCandidate[];
+  commandName?: string;
+}): Promise<ProjectSetupSuggestion> {
+  const suggestedName = await inferTargetName(options.cwd);
+  const candidates = sortProjects(
+    options.projects.filter((project) => projectMatchesSuggestedName(project, suggestedName.name)),
+  ).map(toProjectSummary);
+
+  return {
+    suggestedProjectName: suggestedName.name,
+    suggestedProjectNameSource: suggestedName.source,
+    candidates,
+    recoveryCommands: buildProjectRecoveryCommands(options.commandName),
+  };
+}
+
+export async function projectSetupRequiredError(options: {
+  cwd: string;
+  projects: ProjectCandidate[];
+  commandName?: string;
+}): Promise<CliError> {
+  const suggestion = await buildProjectSetupSuggestion(options);
+  const commandLabel = options.commandName ? `prisma-cli ${options.commandName}` : "this command";
+
+  return new CliError({
+    code: "PROJECT_SETUP_REQUIRED",
+    domain: "project",
+    summary: "Choose a Project before running this command",
+    why: `This directory is not linked to a Prisma Project, and ${commandLabel} will not choose one from package or directory names.`,
+    fix: "Link the directory to an existing Project, or pass --project <id-or-name> for this command.",
+    meta: suggestion,
+    exitCode: 1,
+    nextSteps: ["prisma-cli project list", ...suggestion.recoveryCommands],
   });
 }
 
@@ -270,60 +299,36 @@ function resolveExplicitProject(
   throw projectNotFoundError(projectRef, workspace);
 }
 
-function resolveAmbiguousProject(
-  options: ResolveProjectOptions,
-  matches: ProjectCandidate[],
-  projectRef: string,
-  targetNameSource: InferredTargetNameSource,
-): Promise<ResolvedProjectTarget> {
-  if (options.prompt && canPrompt(options.context)) {
-    return options.prompt
-      .select({
-        message: "Select a project",
-        choices: sortProjects(matches).map((project) => ({
-          label: `${project.name} (${project.id})`,
-          value: project,
-        })),
-      })
-      .then((selected) => rememberIfRequested(options, selected, "prompt", {
-        targetName: projectRef,
-        targetNameSource,
-      }));
-  }
-
-  throw projectAmbiguousError(projectRef, matches);
-}
-
-function projectMatchesPackageName(project: ProjectCandidate, packageName: string): boolean {
-  return project.id === packageName || project.name === packageName || project.slug === packageName;
+function projectMatchesSuggestedName(project: ProjectCandidate, suggestedName: string): boolean {
+  return project.id === suggestedName || project.name === suggestedName || project.slug === suggestedName;
 }
 
 export async function resolveDurablePlatformMapping(): Promise<ProjectCandidate | null> {
   return null;
 }
 
-async function rememberIfRequested(
-  options: ResolveProjectOptions,
+function resolvedTarget(
+  workspace: AuthWorkspace,
   project: ProjectCandidate,
   projectSource: ProjectSource,
   resolutionDetails?: Omit<ProjectResolution, "projectSource">,
-): Promise<ResolvedProjectTarget> {
-  if (options.remember) {
-    await options.context.stateStore.setRememberedProject({
-      id: project.id,
-      name: project.name,
-      workspaceId: options.workspace.id,
-    });
-  }
-
+): BoundProjectShowResult {
   return {
-    workspace: options.workspace,
+    workspace,
     project: toProjectSummary(project),
     resolution: {
       projectSource,
       ...resolutionDetails,
     },
   };
+}
+
+function buildProjectRecoveryCommands(commandName: string | undefined): string[] {
+  const commands = ["prisma-cli project link <id-or-name>"];
+  if (commandName) {
+    commands.push(`prisma-cli ${commandName} --project <id-or-name>`);
+  }
+  return commands;
 }
 
 function toProjectSummary(project: Pick<ProjectCandidate, "id" | "name">): ProjectSummary {

--- a/packages/cli/src/presenters/project.ts
+++ b/packages/cli/src/presenters/project.ts
@@ -54,9 +54,29 @@ export function renderProjectShow(
   descriptor: CommandDescriptor,
   result: ProjectShowResult,
 ): string[] {
+  if (result.project === null) {
+    return renderShow(
+      {
+        title: "No Project linked to this directory.",
+        descriptor,
+        fields: [
+          { key: "workspace", value: result.workspace.name },
+          { key: "project", value: "unbound", tone: "warning" },
+          {
+            key: "suggested",
+            value: `${result.suggestedProjectName} (${formatSuggestionSource(result.suggestedProjectNameSource)})`,
+          },
+          { key: "match", value: formatCandidateList(result.candidates) },
+          { key: "next", value: result.recoveryCommands[0] ?? "prisma-cli project link <id-or-name>" },
+        ],
+      },
+      context.ui,
+    );
+  }
+
   return renderShow(
     {
-      title: "Showing the project Prisma resolves for this directory.",
+      title: "Showing this directory's Project binding.",
       descriptor,
       fields: [
         { key: "workspace", value: result.workspace.name },
@@ -149,17 +169,29 @@ function formatProjectSource(source: ProjectShowResult["resolution"]["projectSou
       return "local pin";
     case "platform-mapping":
       return "platform mapping";
-    case "remembered-local":
-      return "remembered local context";
-    case "package-name":
-      return "package name";
-    case "directory-name":
-      return "directory name";
     case "created":
       return "created";
     case "prompt":
       return "prompt";
+    case "unbound":
+      return "unbound";
   }
+}
+
+function formatSuggestionSource(source: "package-name" | "directory-name"): string {
+  switch (source) {
+    case "package-name":
+      return "package name";
+    case "directory-name":
+      return "directory name";
+  }
+}
+
+function formatCandidateList(candidates: Array<{ name: string }>): string {
+  if (candidates.length === 0) {
+    return "none";
+  }
+  return candidates.map((project) => project.name).join(", ");
 }
 
 function formatGitConnectionDetail(status: GitRepositoryConnection["status"]): string {

--- a/packages/cli/src/shell/command-meta.ts
+++ b/packages/cli/src/shell/command-meta.ts
@@ -86,7 +86,7 @@ const DESCRIPTORS: CommandDescriptor[] = [
   {
     id: "project.show",
     path: ["prisma", "project", "show"],
-    description: "Show which project is active for this directory",
+    description: "Show this directory's Project binding",
     examples: ["prisma-cli project show", "prisma-cli project show --project proj_123 --json"],
   },
   {

--- a/packages/cli/src/types/project.ts
+++ b/packages/cli/src/types/project.ts
@@ -86,5 +86,5 @@ export interface GitRepositoryConnection {
 }
 
 export interface ProjectRepositoryConnectionResult extends BoundProjectShowResult {
-  repositoryConnection: GitRepositoryConnection | null;
+  repositoryConnection: GitRepositoryConnection;
 }

--- a/packages/cli/src/types/project.ts
+++ b/packages/cli/src/types/project.ts
@@ -10,16 +10,14 @@ export type ProjectSource =
   | "env"
   | "local-pin"
   | "platform-mapping"
-  | "remembered-local"
-  | "package-name"
-  | "directory-name"
   | "created"
-  | "prompt";
+  | "prompt"
+  | "unbound";
 
 export interface ProjectResolution {
   projectSource: ProjectSource;
   targetName?: string | null;
-  targetNameSource?: "explicit" | "env" | "local-pin" | "package-name" | "directory-name" | "remembered-local" | "platform-mapping" | "prompt";
+  targetNameSource?: "explicit" | "env" | "local-pin" | "package-name" | "directory-name" | "platform-mapping" | "prompt";
 }
 
 export interface ProjectListResult {
@@ -27,11 +25,28 @@ export interface ProjectListResult {
   projects: ProjectSummary[];
 }
 
-export interface ProjectShowResult {
+export interface ProjectSetupSuggestion {
+  suggestedProjectName: string;
+  suggestedProjectNameSource: "package-name" | "directory-name";
+  candidates: ProjectSummary[];
+  recoveryCommands: string[];
+}
+
+export interface BoundProjectShowResult {
   workspace: AuthWorkspace;
   project: ProjectSummary;
   resolution: ProjectResolution;
 }
+
+export interface UnboundProjectShowResult extends ProjectSetupSuggestion {
+  workspace: AuthWorkspace;
+  project: null;
+  resolution: ProjectResolution & {
+    projectSource: "unbound";
+  };
+}
+
+export type ProjectShowResult = BoundProjectShowResult | UnboundProjectShowResult;
 
 export interface ProjectSetupResult {
   workspace: AuthWorkspace;
@@ -70,6 +85,6 @@ export interface GitRepositoryConnection {
   updatedAt: string | null;
 }
 
-export interface ProjectRepositoryConnectionResult extends ProjectShowResult {
+export interface ProjectRepositoryConnectionResult extends BoundProjectShowResult {
   repositoryConnection: GitRepositoryConnection | null;
 }

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -431,6 +431,67 @@ describe("app controller", () => {
     expect(result.result.project.id).toBe("proj_123");
   });
 
+  it("domain add requires Project setup instead of entering interactive setup", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+    const createProject = vi.fn();
+    const listApps = vi.fn();
+    const addDomain = vi.fn();
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/preview-provider", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("../src/lib/app/preview-provider")>();
+      return {
+        ...actual,
+        createPreviewAppProvider: vi.fn(() => ({
+          createProject,
+          listApps,
+          addDomain,
+        })),
+      };
+    });
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runAppDomainAdd } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    await writePackageJson(cwd, { name: "acme-dashboard" });
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      isTTY: true,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await expect(runAppDomainAdd(context, "shop.acme.com", {
+      appName: "shop",
+    })).rejects.toMatchObject({
+      code: "PROJECT_SETUP_REQUIRED",
+      domain: "project",
+      meta: {
+        suggestedProjectName: "acme-dashboard",
+        suggestedProjectNameSource: "package-name",
+        candidates: [
+          {
+            id: "proj_123",
+            name: "Acme Dashboard",
+          },
+        ],
+        recoveryCommands: expect.arrayContaining([
+          "prisma-cli project link <id-or-name>",
+          "prisma-cli app domain add shop.acme.com --project <id-or-name>",
+        ]),
+      },
+    });
+    expect(createProject).not.toHaveBeenCalled();
+    expect(listApps).not.toHaveBeenCalled();
+    expect(addDomain).not.toHaveBeenCalled();
+  });
+
   it("domain add does not synthesize DNS records when the API omits them", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
     const listApps = vi.fn().mockResolvedValue([

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -964,7 +964,6 @@ describe("app controller", () => {
       isTTY: false,
       env: {
         ...process.env,
-        PRISMA_CLI_TEST_REMEMBER_PROJECT_ID: "",
         PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
       },
     });
@@ -2593,6 +2592,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppListDeploys } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
       cwd,
@@ -2626,6 +2626,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppListDeploys } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
       cwd,
@@ -2688,6 +2689,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppListDeploys } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
       cwd,
@@ -2712,6 +2714,56 @@ describe("app controller", () => {
     ]);
   });
 
+  it("show requires Project setup even when package name matches a Project", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+    const listApps = vi.fn();
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/preview-provider", () => ({
+      createPreviewAppProvider: vi.fn(() => ({
+        createProject: vi.fn(),
+        listApps,
+        deployApp: vi.fn(),
+        listDeployments: vi.fn(),
+        promoteDeployment: vi.fn(),
+        showDeployment: vi.fn(),
+      })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runAppShow } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    await writePackageJson(cwd, { name: "acme-dashboard" });
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_TEST_REMEMBER_PROJECT_ID: "",
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await expect(runAppShow(context, "hello-world")).rejects.toMatchObject({
+      code: "PROJECT_SETUP_REQUIRED",
+      domain: "project",
+      meta: {
+        suggestedProjectName: "acme-dashboard",
+        suggestedProjectNameSource: "package-name",
+        candidates: [
+          {
+            id: "proj_123",
+            name: "Acme Dashboard",
+          },
+        ],
+      },
+    });
+    expect(listApps).not.toHaveBeenCalled();
+  });
+
   it("show returns undeployed state when the resolved project has no apps", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
     const listApps = vi.fn().mockResolvedValue([]);
@@ -2733,6 +2785,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppShow } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
       cwd,
@@ -2808,6 +2861,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppShow } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
       cwd,
@@ -2907,6 +2961,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppShow } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
       cwd,
@@ -3178,6 +3233,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppOpen } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
       cwd,
@@ -3246,6 +3302,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppOpen } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
       cwd,
@@ -3312,6 +3369,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppOpen } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
       cwd,
@@ -3375,6 +3433,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppOpen } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
       cwd,
@@ -3440,6 +3499,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppPromote } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
       cwd,
@@ -3515,6 +3575,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppPromote } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
       cwd,
@@ -3579,6 +3640,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppRollback } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
       cwd,
@@ -3662,6 +3724,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppRollback } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
       cwd,
@@ -3741,6 +3804,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppRollback } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
       cwd,
@@ -3802,6 +3866,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppRollback } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
       cwd,
@@ -3914,6 +3979,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppLogs } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
       cwd,
@@ -3965,6 +4031,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppLogs } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context, stdout } = await createTestCommandContext({
       cwd,
@@ -4011,6 +4078,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppLogs } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
       cwd,
@@ -4058,6 +4126,7 @@ describe("app controller", () => {
 
     const { createTempCwd, executeCli } = await import("./helpers");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
 
     const result = await executeCli({
@@ -4121,6 +4190,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppRemove } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
       cwd,
@@ -4191,6 +4261,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppRemove } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
       cwd,
@@ -4238,6 +4309,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppRemove } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
       cwd,
@@ -4282,6 +4354,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppRemove } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
       cwd,
@@ -4330,6 +4403,7 @@ describe("app controller", () => {
     const { createTempCwd, createTestCommandContext } = await import("./helpers");
     const { runAppRemove } = await import("../src/controllers/app");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
       cwd,

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -1753,7 +1753,7 @@ describe("app controller", () => {
       meta: {
         pinPath: ".prisma/local.json",
       },
-      fix: "Delete .prisma/local.json and re-run to re-bootstrap.",
+      fix: "Delete .prisma/local.json, then choose a Project explicitly.",
     });
     expect(listApps).not.toHaveBeenCalled();
     expect(deployApp).not.toHaveBeenCalled();

--- a/packages/cli/tests/app-env-vars.test.ts
+++ b/packages/cli/tests/app-env-vars.test.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { writeFile } from "node:fs/promises";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -126,6 +127,96 @@ describe("app env vars", () => {
         API_TOKEN: "",
       }),
     ).toEqual(["API_TOKEN", "DATABASE_URL", "ZOO"]);
+  });
+
+  it("project env list requires explicit or durable Project binding", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runEnvList } = await import("../src/controllers/app-env");
+    const cwd = await createTempCwd();
+    await writeFile(path.join(cwd, "package.json"), `${JSON.stringify({ name: "acme-dashboard" }, null, 2)}\n`);
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await expect(runEnvList(context, {})).rejects.toMatchObject({
+      code: "PROJECT_SETUP_REQUIRED",
+      domain: "project",
+      meta: {
+        suggestedProjectName: "acme-dashboard",
+        suggestedProjectNameSource: "package-name",
+        candidates: [
+          {
+            id: "proj_123",
+            name: "Acme Dashboard",
+          },
+        ],
+        recoveryCommands: expect.arrayContaining([
+          "prisma-cli project link <id-or-name>",
+          "prisma-cli project env list --project <id-or-name>",
+        ]),
+      },
+    });
+  });
+
+  it("project env list uses an explicit Project", async () => {
+    const client = {
+      token: "token",
+      GET: vi.fn().mockImplementation((pathName: string) => {
+        if (pathName === "/v1/projects") {
+          return createProjectClient().GET(pathName);
+        }
+        if (pathName === "/v1/environment-variables") {
+          return {
+            data: {
+              data: [],
+              pagination: {
+                hasMore: false,
+                nextCursor: null,
+              },
+            },
+          };
+        }
+        throw new Error(`Unexpected path ${pathName}`);
+      }),
+    };
+    const requireComputeAuth = vi.fn().mockResolvedValue(client);
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runEnvList } = await import("../src/controllers/app-env");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_TEST_REMEMBER_PROJECT_ID: "",
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    const result = await runEnvList(context, { projectRef: "proj_123" });
+
+    expect(result.result).toMatchObject({
+      projectId: "proj_123",
+      variables: [],
+    });
   });
 
   it("passes env vars to provider deploy without surfacing values", async () => {

--- a/packages/cli/tests/app-env.test.ts
+++ b/packages/cli/tests/app-env.test.ts
@@ -1,3 +1,6 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 beforeEach(() => {
@@ -62,6 +65,15 @@ function expectNoApiCalls(client: MockClient) {
   expect(client.POST).not.toHaveBeenCalled();
   expect(client.PATCH).not.toHaveBeenCalled();
   expect(client.DELETE).not.toHaveBeenCalled();
+}
+
+async function writeLocalPin(cwd: string, projectId = "proj_123") {
+  await mkdir(path.join(cwd, ".prisma"), { recursive: true });
+  await writeFile(
+    path.join(cwd, ".prisma/local.json"),
+    `${JSON.stringify({ workspaceId: "ws_123", projectId }, null, 2)}\n`,
+    "utf8",
+  );
 }
 
 async function loadControllers(client: MockClient, projectId: string) {
@@ -144,6 +156,7 @@ describe("env add", () => {
     const { controllers, createTempCwd, createTestCommandContext } =
       await loadControllers(client, "proj_123");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
     const { context } = await createTestCommandContext({ cwd });
 
     const result = await controllers.runEnvAdd(
@@ -224,6 +237,7 @@ describe("env add", () => {
     const { controllers, createTempCwd, createTestCommandContext } =
       await loadControllers(client, "proj_123");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
     const { context } = await createTestCommandContext({ cwd });
 
     await expect(
@@ -266,6 +280,7 @@ describe("env add", () => {
     const { controllers, createTempCwd, createTestCommandContext } =
       await loadControllers(client, "proj_123");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
     const { context } = await createTestCommandContext({ cwd });
 
     const result = await controllers.runEnvAdd(
@@ -336,6 +351,7 @@ describe("env add", () => {
     const { controllers, createTempCwd, createTestCommandContext } =
       await loadControllers(client, "proj_123");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
     const { context } = await createTestCommandContext({ cwd });
 
     await controllers.runEnvAdd(context, "DATABASE_URL=postgresql://branch", {
@@ -377,6 +393,7 @@ describe("env add", () => {
     const { controllers, createTempCwd, createTestCommandContext } =
       await loadControllers(client, "proj_123");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
     const { context } = await createTestCommandContext({ cwd });
 
     await expect(
@@ -406,6 +423,7 @@ describe("env add", () => {
     const { controllers, createTempCwd, createTestCommandContext } =
       await loadControllers(client, "proj_123");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
     const { context } = await createTestCommandContext({ cwd });
 
     await expect(
@@ -424,6 +442,7 @@ describe("env add", () => {
     const { controllers, createTempCwd, createTestCommandContext } =
       await loadControllers(client, "proj_123");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
     const { context } = await createTestCommandContext({ cwd });
 
     await expect(
@@ -442,6 +461,7 @@ describe("env add", () => {
     const { controllers, createTempCwd, createTestCommandContext } =
       await loadControllers(client, "proj_123");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
     const { context } = await createTestCommandContext({ cwd });
 
     await expect(
@@ -457,6 +477,7 @@ describe("env add", () => {
     const { controllers, createTempCwd, createTestCommandContext } =
       await loadControllers(client, "proj_123");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
     const { context } = await createTestCommandContext({ cwd });
 
     await expect(
@@ -474,6 +495,7 @@ describe("env add", () => {
     const { controllers, createTempCwd, createTestCommandContext } =
       await loadControllers(client, "proj_123");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
     const { context } = await createTestCommandContext({ cwd });
 
     await expect(
@@ -505,6 +527,7 @@ describe("env update", () => {
     const { controllers, createTempCwd, createTestCommandContext } =
       await loadControllers(client, "proj_123");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
     const { context } = await createTestCommandContext({ cwd });
 
     const result = await controllers.runEnvUpdate(
@@ -538,6 +561,7 @@ describe("env update", () => {
     const { controllers, createTempCwd, createTestCommandContext } =
       await loadControllers(client, "proj_123");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
     const { context } = await createTestCommandContext({ cwd });
 
     await expect(
@@ -587,6 +611,7 @@ describe("env update", () => {
     const { controllers, createTempCwd, createTestCommandContext } =
       await loadControllers(client, "proj_123");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
     const { context } = await createTestCommandContext({ cwd });
 
     await controllers.runEnvUpdate(
@@ -609,6 +634,7 @@ describe("env update", () => {
     const { controllers, createTempCwd, createTestCommandContext } =
       await loadControllers(client, "proj_123");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
     const { context } = await createTestCommandContext({ cwd });
 
     await expect(
@@ -637,6 +663,7 @@ describe("env list", () => {
     const { controllers, createTempCwd, createTestCommandContext } =
       await loadControllers(client, "proj_123");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
     const { context } = await createTestCommandContext({ cwd });
 
     const result = await controllers.runEnvList(context, {
@@ -673,6 +700,7 @@ describe("env list", () => {
     const { controllers, createTempCwd, createTestCommandContext } =
       await loadControllers(client, "proj_123");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
     const { context } = await createTestCommandContext({ cwd });
 
     const result = await controllers.runEnvList(context, {});
@@ -728,6 +756,7 @@ describe("env list", () => {
     const { controllers, createTempCwd, createTestCommandContext } =
       await loadControllers(client, "proj_123");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
     const { context } = await createTestCommandContext({ cwd });
 
     const result = await controllers.runEnvList(context, {
@@ -768,6 +797,7 @@ describe("env remove", () => {
     const { controllers, createTempCwd, createTestCommandContext } =
       await loadControllers(client, "proj_123");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
     const { context } = await createTestCommandContext({ cwd });
 
     const result = await controllers.runEnvRemove(context, "STRIPE_KEY", {
@@ -797,6 +827,7 @@ describe("env remove", () => {
     const { controllers, createTempCwd, createTestCommandContext } =
       await loadControllers(client, "proj_123");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
     const { context } = await createTestCommandContext({ cwd });
 
     await expect(
@@ -844,6 +875,7 @@ describe("env remove", () => {
     const { controllers, createTempCwd, createTestCommandContext } =
       await loadControllers(client, "proj_123");
     const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
     const { context } = await createTestCommandContext({ cwd });
 
     await controllers.runEnvRemove(context, "DATABASE_URL", {

--- a/packages/cli/tests/project-controller.test.ts
+++ b/packages/cli/tests/project-controller.test.ts
@@ -15,7 +15,7 @@ afterEach(() => {
 });
 
 describe("project controller", () => {
-  it("returns PROJECT_UNRESOLVED when automatic resolution cannot choose a project", async () => {
+  it("returns an unbound binding inspection when no durable Project source exists", async () => {
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");
     const { context } = await createTestCommandContext({
@@ -32,9 +32,18 @@ describe("project controller", () => {
     });
 
     const { runProjectShow } = await import("../src/controllers/project");
-    await expect(runProjectShow(context, undefined)).rejects.toMatchObject({
-      code: "PROJECT_UNRESOLVED",
-      domain: "project",
+    const result = await runProjectShow(context, undefined);
+
+    expect(result.result).toMatchObject({
+      project: null,
+      resolution: {
+        projectSource: "unbound",
+      },
+      candidates: [],
+      recoveryCommands: [
+        "prisma-cli project link <id-or-name>",
+        "prisma-cli project show --project <id-or-name>",
+      ],
     });
   });
 

--- a/packages/cli/tests/project.test.ts
+++ b/packages/cli/tests/project.test.ts
@@ -20,41 +20,11 @@ async function writePackageJson(cwd: string, name: string) {
   await writeFile(path.join(cwd, "package.json"), `${JSON.stringify({ name }, null, 2)}\n`, "utf8");
 }
 
-async function writeStaleProjectState(stateDir: string) {
-  await mkdir(stateDir, { recursive: true });
+async function writeLocalPin(cwd: string, pin: unknown | string) {
+  await mkdir(path.join(cwd, ".prisma"), { recursive: true });
   await writeFile(
-    path.join(stateDir, "state.json"),
-    `${JSON.stringify(
-      {
-        auth: {
-          provider: "github",
-          userId: "usr_456",
-          workspaceId: "ws_123",
-        },
-        project: {
-          rememberedByWorkspace: {
-            ws_123: {
-              id: "proj_missing",
-              name: "Missing Project",
-              workspaceId: "ws_123",
-            },
-          },
-          lastResolved: {
-            id: "proj_missing",
-            name: "Missing Project",
-            workspaceId: "ws_123",
-          },
-          repositoryConnectionsByProject: {},
-        },
-        branch: { active: "preview" },
-        app: {
-          selectedByProject: {},
-          knownLiveDeploymentByProject: {},
-        },
-      },
-      null,
-      2,
-    )}\n`,
+    path.join(cwd, ".prisma/local.json"),
+    typeof pin === "string" ? pin : `${JSON.stringify(pin, null, 2)}\n`,
     "utf8",
   );
 }
@@ -94,7 +64,7 @@ describe("project commands", () => {
     );
   });
 
-  it("shows the project resolved from package.json in JSON mode", async () => {
+  it("shows unbound suggestions from package.json in JSON mode", async () => {
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");
     await writePackageJson(cwd, "billing-api");
@@ -117,15 +87,22 @@ describe("project commands", () => {
           id: "ws_123",
           name: "Acme Inc",
         },
-        project: {
-          id: "proj_456",
-          name: "Billing API",
-        },
+        project: null,
         resolution: {
-          projectSource: "package-name",
-          targetName: "billing-api",
-          targetNameSource: "package-name",
+          projectSource: "unbound",
         },
+        suggestedProjectName: "billing-api",
+        suggestedProjectNameSource: "package-name",
+        candidates: [
+          {
+            id: "proj_456",
+            name: "Billing API",
+          },
+        ],
+        recoveryCommands: [
+          "prisma-cli project link <id-or-name>",
+          "prisma-cli project show --project <id-or-name>",
+        ],
       },
       warnings: [],
       nextSteps: [],
@@ -148,6 +125,37 @@ describe("project commands", () => {
     expect(result.exitCode).toBe(0);
     expect(JSON.parse(result.stdout).result.resolution.projectSource).toBe("explicit");
     expect(state.project?.lastResolved ?? null).toBe(null);
+    await expect(readFile(path.join(cwd, ".prisma/local.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("shows the pinned project from local state", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    await writeLocalPin(cwd, {
+      workspaceId: "ws_123",
+      projectId: "proj_123",
+    });
+    await login(cwd, stateDir);
+
+    const result = await executeCli({
+      argv: ["project", "show", "--json"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout).result).toMatchObject({
+      project: {
+        id: "proj_123",
+        name: "Acme Dashboard",
+      },
+      resolution: {
+        projectSource: "local-pin",
+        targetName: "Acme Dashboard",
+        targetNameSource: "local-pin",
+      },
+    });
   });
 
   it("returns PROJECT_NOT_FOUND for an inaccessible explicit project", async () => {
@@ -166,7 +174,7 @@ describe("project commands", () => {
     expect(JSON.parse(result.stdout).error.code).toBe("PROJECT_NOT_FOUND");
   });
 
-  it("returns PROJECT_UNRESOLVED when automatic resolution has no safe source", async () => {
+  it("shows an unbound directory when there is no safe source", async () => {
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");
     await login(cwd, stateDir);
@@ -178,11 +186,21 @@ describe("project commands", () => {
       fixturePath,
     });
 
-    expect(result.exitCode).toBe(1);
-    expect(JSON.parse(result.stdout).error.code).toBe("PROJECT_UNRESOLVED");
+    const payload = JSON.parse(result.stdout);
+
+    expect(result.exitCode).toBe(0);
+    expect(payload.result).toMatchObject({
+      project: null,
+      resolution: {
+        projectSource: "unbound",
+      },
+      suggestedProjectName: path.basename(cwd),
+      suggestedProjectNameSource: "directory-name",
+      candidates: [],
+    });
   });
 
-  it("treats a primitive package.json root as missing package metadata", async () => {
+  it("uses the directory name as the suggestion when package metadata is unusable", async () => {
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");
     await writeFile(path.join(cwd, "package.json"), "null\n", "utf8");
@@ -195,8 +213,15 @@ describe("project commands", () => {
       fixturePath,
     });
 
-    expect(result.exitCode).toBe(1);
-    expect(JSON.parse(result.stdout).error.code).toBe("PROJECT_UNRESOLVED");
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout).result).toMatchObject({
+      project: null,
+      resolution: {
+        projectSource: "unbound",
+      },
+      suggestedProjectName: path.basename(cwd),
+      suggestedProjectNameSource: "directory-name",
+    });
   });
 
   it("does not prompt for project selection in interactive human mode", async () => {
@@ -213,13 +238,13 @@ describe("project commands", () => {
     });
     const stderr = stripAnsi(result.stderr);
 
-    expect(result.exitCode).toBe(1);
-    expect(stderr).toContain("No project is resolved for this directory [PROJECT_UNRESOLVED]");
-    expect(stderr).toContain("prisma-cli project list");
+    expect(result.exitCode).toBe(0);
+    expect(stderr).toContain("No Project linked to this directory.");
+    expect(stderr).toContain("project:    unbound");
     expect(stderr).not.toContain("Select a project");
   });
 
-  it("returns PROJECT_AMBIGUOUS when package inference matches multiple projects", async () => {
+  it("shows all matching candidates when package inference matches multiple projects", async () => {
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");
     const ambiguousFixturePath = await createAmbiguousFixture(cwd);
@@ -233,14 +258,30 @@ describe("project commands", () => {
       fixturePath: ambiguousFixturePath,
     });
 
-    expect(result.exitCode).toBe(1);
-    expect(JSON.parse(result.stdout).error.code).toBe("PROJECT_AMBIGUOUS");
+    const payload = JSON.parse(result.stdout);
+
+    expect(result.exitCode).toBe(0);
+    expect(payload.result).toMatchObject({
+      project: null,
+      resolution: {
+        projectSource: "unbound",
+      },
+      suggestedProjectName: "acme-dashboard",
+      candidates: [
+        { id: "proj_123", name: "Acme Dashboard" },
+        { id: "proj_321", name: "Acme Dashboard" },
+      ],
+    });
   });
 
-  it("returns LOCAL_STATE_STALE when remembered context is invalid and continuing is ambiguous", async () => {
+  it("returns LOCAL_STATE_STALE when the local pin is invalid", async () => {
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");
-    await writeStaleProjectState(stateDir);
+    await writeLocalPin(cwd, {
+      workspaceId: "ws_123",
+      projectId: "proj_missing",
+    });
+    await login(cwd, stateDir);
 
     const result = await executeCli({
       argv: ["project", "show", "--json"],
@@ -409,7 +450,7 @@ describe("project commands", () => {
     expect(JSON.parse(result.stdout).error.code).toBe("REPO_PROVIDER_UNSUPPORTED");
   });
 
-  it("returns PROJECT_UNRESOLVED for repository connection without a resolved project", async () => {
+  it("returns PROJECT_SETUP_REQUIRED for repository connection without a Project binding", async () => {
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");
     await login(cwd, stateDir);
@@ -422,7 +463,7 @@ describe("project commands", () => {
     });
 
     expect(result.exitCode).toBe(1);
-    expect(JSON.parse(result.stdout).error.code).toBe("PROJECT_UNRESOLVED");
+    expect(JSON.parse(result.stdout).error.code).toBe("PROJECT_SETUP_REQUIRED");
   });
 
   it("shows Public Beta project, setup, and git help", async () => {
@@ -479,7 +520,7 @@ describe("project commands", () => {
     expect(gitHelp.exitCode).toBe(0);
     expect(stderr).toContain("project → Manage and inspect your Prisma projects");
     expect(stderr).toContain("git → Manage Git repository connections for a project");
-    expect(stderr).toContain("Show which project is active for this directory");
+    expect(stderr).toContain("Show this directory's Project binding");
     expect(stderr).toContain("Create a Project and link this directory");
     expect(stderr).toContain("Link this directory to an existing Project");
     expect(stderr).toContain("Connect the resolved project to a GitHub repository");


### PR DESCRIPTION
## Summary
- Require Project-scoped CLI commands to resolve Project scope only from explicit or durable bindings.
- Change `project show` to inspect the directory binding and return unbound success with suggestions/candidates instead of selecting by package name.
- Keep deploy setup explicit; app, domain, and project env commands now fail with `PROJECT_SETUP_REQUIRED` when unbound.

## Review
- Ran local thermonuclear review against `origin/main...HEAD`.
- Fixed strict resolver duplication/type drift.
- Fixed domain commands still entering deploy interactive setup.

## Validation
- `corepack pnpm --filter @prisma/cli build`
- `corepack pnpm --filter @prisma/cli test`
- `git diff --check origin/main...HEAD`
- `rg -n "PROJECT_UNRESOLVED|remembered-local|projectSource: \"package-name\"|source:     package-name|resolved for this directory|re-bootstrap" packages/cli/src packages/cli/tests docs/product`