### PR TITLE
Add agent-legible project setup next actions

### DIFF
--- a/docs/product/cli-style-guide.md
+++ b/docs/product/cli-style-guide.md
@@ -64,15 +64,14 @@ Recommended symbols:
 Human-oriented command output in TTY mode should usually start with a compact header:
 
 ```text
-project show → No Project linked to this directory.
+project show → This directory is not linked to a Prisma Project.
 
 │  workspace:  Acme Inc
-│  project:    unbound
-│  suggested:  billing-api (package name)
-│  match:      Billing API
-│  next:       prisma-cli project link <id-or-name>
-│
-│  Read more   docs/product/command-spec.md#prisma-cli-project-show
+│  project:    Not linked
+
+Next steps:
+- Link an existing Project: prisma-cli project link <id-or-name>
+- Create a new Project: prisma-cli project create billing-api
 ```
 
 Rules:
@@ -84,6 +83,7 @@ Rules:
 - prefer display labels in default human output and keep opaque ids in JSON unless a later verbose mode explicitly asks for them
 - mask sensitive values rather than omitting their presence entirely when the value matters to the flow
 - include only rows that are actually known for the current command
+- use human labels such as `Not linked` instead of internal resolution terms such as `unbound`
 - include a `Read more` row that points to the source-of-truth repo doc or anchor until a stable public docs URL exists
 - leave one blank line between the header block and the body
 

--- a/docs/product/command-principles.md
+++ b/docs/product/command-principles.md
@@ -194,12 +194,15 @@ The CLI must work well for both humans and agents.
 
 That means:
 
-- default output is human-readable
-- structured output is explicit
+- default output is concise, human-readable, and calm
+- structured output is explicit enough for agents to make safe choices
+- human output and JSON output describe the same truth, but may render it differently
 - targeting rules are deterministic
 - risky actions are surfaced clearly
 - nouns and verbs stay stable across help, docs, and output
 - shared UX rules stay centralized rather than reinvented per command group
+- local metadata may suggest defaults, but must not be presented as target selection
+- missing context ends with clear next actions, not implicit resolution
 
 ## No Dead Ends
 

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -365,6 +365,9 @@ Behavior:
 - lists projects visible to the active workspace
 - does not resolve the current directory
 - does not mutate local state
+- when the current directory is not linked, human output adds one setup hint after the list
+- in JSON, unlinked directories include a `user-choice` `nextActions` entry for Project setup
+- listed Projects are not marked selected unless durable local binding actually selects one
 
 Examples:
 
@@ -387,7 +390,8 @@ Behavior:
 - does not mutate local state
 - `--project <id-or-name>` resolves only the explicit project
 - when bound, returns Workspace, Project, and `resolution.projectSource`
-- when unbound, exits successfully with `project: null`, `resolution.projectSource: "unbound"`, a suggested Project name, matching Project candidates, and recovery commands
+- when unbound, human output says `project: Not linked` and shows link/create next steps
+- when unbound, JSON exits successfully with `project: null`, `localBinding.status: "not-linked"`, `resolution.projectSource: "unbound"`, a suggested Project name, matching Project candidates, recovery commands, and `user-choice` `nextActions`
 - package names and directory names only power unbound suggestions
 - fails with `PROJECT_NOT_FOUND`, `PROJECT_AMBIGUOUS`, or `LOCAL_STATE_STALE` when explicit or durable binding validation cannot continue safely
 
@@ -617,6 +621,7 @@ Behavior:
 
 - when "Create a new Project" is selected, prompts for a Project name with the package/directory name as a suggestion
 - when no Project is resolved in `--json` / `--no-interactive` mode, fails with `PROJECT_SETUP_REQUIRED`
+- `PROJECT_SETUP_REQUIRED` preserves readable recovery commands in `nextSteps` and includes structured `nextActions` for choosing, linking, creating, or retrying with an explicit Project
 - `--yes` alone does not choose Project scope; use `--project` or `--create-project`
 - `--project` and `--create-project` are mutually exclusive with each other and with `PRISMA_PROJECT_ID`
 - resolves or creates branch context from `--branch`, local Git branch, or `main`

--- a/docs/product/error-conventions.md
+++ b/docs/product/error-conventions.md
@@ -133,7 +133,8 @@ Commands run with `--json` should emit this envelope on failure:
     "docsUrl": null
   },
   "warnings": [],
-  "nextSteps": []
+  "nextSteps": [],
+  "nextActions": []
 }
 ```
 
@@ -150,7 +151,7 @@ Rules:
 - `error.where` points to the relevant location when applicable
 - `error.meta` is structured, not free-form prose
 - `error.docsUrl` may be `null` when no per-code doc exists yet
-- `warnings` and `nextSteps` are always present
+- `warnings`, `nextSteps`, and `nextActions` are always present
 - agents and CI should branch on structured error fields, not prose strings
 
 ## MVP Error Codes

--- a/docs/product/output-conventions.md
+++ b/docs/product/output-conventions.md
@@ -220,15 +220,14 @@ Human output should:
 Recommended header shape:
 
 ```text
-project show → No Project linked to this directory.
+project show → This directory is not linked to a Prisma Project.
 
 │  workspace:  Acme Inc
-│  project:    unbound
-│  suggested:  billing-api (package name)
-│  match:      Billing API
-│  next:       prisma-cli project link <id-or-name>
-│
-│  Read more   docs/product/command-spec.md#prisma-cli-project-show
+│  project:    Not linked
+
+Next steps:
+- Link an existing Project: prisma-cli project link <id-or-name>
+- Create a new Project: prisma-cli project create billing-api
 ```
 
 Rules:
@@ -238,6 +237,7 @@ Rules:
 - show only metadata that is relevant to the current invocation
 - include `Read more` when a stable repo doc reference exists
 - prefer display labels in default human output and keep opaque ids in JSON unless a later verbose mode explicitly asks for them
+- do not expose agent-only reasoning in human output when a clear status and next step is enough
 
 Recommended summary lines:
 
@@ -341,7 +341,8 @@ Recommended envelope:
   "command": "app.deploy",
   "result": {},
   "warnings": [],
-  "nextSteps": []
+  "nextSteps": [],
+  "nextActions": []
 }
 ```
 
@@ -352,7 +353,26 @@ Required conventions:
 - `result` holds command-specific data
 - `warnings` is always present
 - `nextSteps` is always present, even if empty
+- `nextActions` is always present, even if empty
 - human-readable guidance that matters to automation should also be represented in structured fields, not only on stderr
+
+`nextSteps` remains a compatibility surface for readable commands. `nextActions`
+is the structured surface for agents and automation:
+
+```ts
+type NextAction = {
+  kind: "run-command" | "user-choice" | "edit-file" | "done"
+  journey: "project-setup" | "deploy-app" | "inspect" | "recover"
+  label: string
+  command?: string
+  commands?: string[]
+  reason?: string
+}
+```
+
+Use `user-choice` when the next move requires the caller or user to choose a
+target. Do not encode local package names, directory names, or nearby matches as
+a selected target; put them in command-specific suggestion fields instead.
 
 ## Streaming JSON Shape
 
@@ -417,6 +437,14 @@ context, status, decoration, and errors stay on stderr.
   "nextSteps": [
     "prisma-cli app list-deploys --app hello-world",
     "prisma-cli app show-deploy dep_045"
+  ],
+  "nextActions": [
+    {
+      "kind": "run-command",
+      "journey": "inspect",
+      "label": "View deployment logs",
+      "command": "prisma-cli app logs"
+    }
   ]
 }
 ```
@@ -427,4 +455,6 @@ Human output and JSON output should describe the same underlying model.
 
 The CLI should never require users or agents to learn different meanings for the same command.
 
-Human output may be richer in layout and interaction, but not richer in meaning.
+Human output should stay optimized for people. JSON should carry the same model
+with enough explicit structure for agents to recognize stop points, user-choice
+moments, and safe recovery actions.

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -47,6 +47,7 @@ import {
 } from "../lib/app/local-dev";
 import { readBunPackageEntrypoint, readBunPackageJson, type BunPackageJsonLike } from "../lib/app/bun-project";
 import {
+  buildProjectSetupNextActions,
   inferTargetName,
   projectNotFoundError,
   resolveDurablePlatformMapping,
@@ -3152,12 +3153,36 @@ function appDeployFailedError(error: unknown, progress: PreviewDeployProgressSta
   const debug = formatDebugDetails(error);
 
   if (progress.buildStarted && !progress.buildCompleted) {
+    const standaloneOutputFailure = isNextStandaloneOutputFailure(why);
+    const fix = standaloneOutputFailure
+      ? "Add output: \"standalone\" to next.config.*, then rerun deploy."
+      : "Inspect the build output above, fix the error, and redeploy.";
+    const nextSteps = standaloneOutputFailure
+      ? ["Add output: \"standalone\" to next.config.*, then rerun prisma-cli app deploy"]
+      : [];
+    const nextActions = standaloneOutputFailure
+      ? [
+          {
+            kind: "edit-file" as const,
+            journey: "deploy-app" as const,
+            label: "Add Next.js standalone output",
+            reason: "Prisma Compute needs Next.js standalone output to build a deployable server artifact.",
+          },
+          {
+            kind: "run-command" as const,
+            journey: "deploy-app" as const,
+            label: "Rerun deploy",
+            command: "prisma-cli app deploy",
+          },
+        ]
+      : [];
+
     return new CliError({
       code: "BUILD_FAILED",
       domain: "app",
       summary: "Build failed locally.",
       why,
-      fix: "Inspect the build output above, fix the error, and redeploy.",
+      fix,
       debug,
       meta: { phase: "build" },
       humanLines: [
@@ -3165,10 +3190,11 @@ function appDeployFailedError(error: unknown, progress: PreviewDeployProgressSta
         "",
         `✗ Built       ${why}`,
         "",
-        "Fix: Inspect the build output above, fix the error, and redeploy.",
+        `Fix: ${fix}`,
       ],
       exitCode: 1,
-      nextSteps: [],
+      nextSteps,
+      nextActions,
     });
   }
 
@@ -3278,7 +3304,16 @@ function projectSetupRequiredError(
       "prisma-cli app deploy --project <id-or-name>",
       createCommand,
     ],
+    nextActions: buildProjectSetupNextActions({
+      commandName: "app deploy",
+      createCommand,
+      reason: "This directory is not linked to a Prisma Project. Ask the user which Project to use before deploying; package and directory names are setup suggestions only.",
+    }),
   });
+}
+
+function isNextStandaloneOutputFailure(message: string): boolean {
+  return /next\.?js/i.test(message) && /standalone output/i.test(message);
 }
 
 function noDeploymentsError(summary: string, why: string): CliError {

--- a/packages/cli/src/controllers/project.ts
+++ b/packages/cli/src/controllers/project.ts
@@ -8,12 +8,14 @@ import {
 } from "../adapters/git";
 import { requireComputeAuth } from "../lib/auth/guard";
 import {
+  buildProjectSetupNextActions,
   inspectProjectBinding,
   resolveProjectTarget,
   sortProjects,
   type ProjectCandidate,
   type ResolvedProjectTarget,
 } from "../lib/project/resolution";
+import { readLocalResolutionPin } from "../lib/project/local-pin";
 import {
   bindProjectToDirectory,
   isValidProjectSetupName,
@@ -54,6 +56,23 @@ function isRealMode(context: CommandContext): boolean {
   return !context.runtime.fixturePath && !context.runtime.env.PRISMA_CLI_MOCK_FIXTURE_PATH;
 }
 
+async function readProjectListLocalBinding(
+  cwd: string,
+  workspace: AuthWorkspace,
+  projects: Array<Pick<ProjectCandidate, "id">>,
+): Promise<ProjectListResult["localBinding"]> {
+  const pin = await readLocalResolutionPin(cwd);
+  if (pin.kind === "present") {
+    return pin.pin.workspaceId === workspace.id && projects.some((project) => project.id === pin.pin.projectId)
+      ? { status: "linked" }
+      : { status: "invalid" };
+  }
+  if (pin.kind === "invalid") {
+    return { status: "invalid" };
+  }
+  return { status: "not-linked" };
+}
+
 export async function runProjectList(context: CommandContext): Promise<CommandSuccess<ProjectListResult>> {
   const authState = await requireAuthenticatedAuthState(context);
   const workspace = authState.workspace;
@@ -66,27 +85,48 @@ export async function runProjectList(context: CommandContext): Promise<CommandSu
     if (!client) {
       throw authRequiredError();
     }
+    const projects = sortProjects(await listRealWorkspaceProjects(client, workspace));
+    const localBinding = await readProjectListLocalBinding(context.runtime.cwd, workspace, projects);
+    const nextActions = buildProjectListNextActions(localBinding);
 
     return {
       command: "project.list",
       result: {
         workspace,
-        projects: sortProjects(await listRealWorkspaceProjects(client, workspace)).map(toProjectSummary),
+        projects: projects.map(toProjectSummary),
+        localBinding,
       },
       warnings: [],
       nextSteps: [],
+      nextActions,
     };
   }
 
   const projectUseCases = createProjectUseCases(createCliUseCaseGateways(context));
   const result = await projectUseCases.list(authState);
+  const localBinding = await readProjectListLocalBinding(context.runtime.cwd, workspace, result.projects);
+  const nextActions = buildProjectListNextActions(localBinding);
 
   return {
     command: "project.list",
-    result,
+    result: {
+      ...result,
+      localBinding,
+    },
     warnings: [],
     nextSteps: [],
+    nextActions,
   };
+}
+
+function buildProjectListNextActions(localBinding: ProjectListResult["localBinding"]) {
+  return localBinding?.status === "linked"
+    ? []
+    : buildProjectSetupNextActions({
+        reason: localBinding?.status === "invalid"
+          ? "This directory has an invalid local Project binding. Ask the user which Prisma Project to link before running Project-scoped commands."
+          : "This directory is not linked to a Prisma Project. Project list shows available Projects, but none is selected for this directory.",
+      });
 }
 
 export async function runProjectShow(
@@ -108,6 +148,13 @@ export async function runProjectShow(
     result,
     warnings: [],
     nextSteps: [],
+    nextActions: result.project === null
+      ? buildProjectSetupNextActions({
+          commandName: "project show",
+          suggestedProjectName: result.suggestedProjectName,
+          reason: "This directory is not linked to a Prisma Project. Package and directory names can suggest setup defaults, but they do not select a Project.",
+        })
+      : [],
   };
 }
 

--- a/packages/cli/src/lib/project/resolution.ts
+++ b/packages/cli/src/lib/project/resolution.ts
@@ -180,10 +180,10 @@ export function buildProjectSetupNextActions(options: {
   createCommand?: string;
   reason?: string;
 } = {}): NextAction[] {
-  const commands = ["prisma-cli project list", "prisma-cli project link <id-or-name>"];
-  if (options.commandName) {
-    commands.push(`prisma-cli ${options.commandName} --project <id-or-name>`);
-  }
+  const recoveryCommands = buildProjectRecoveryCommands(options.commandName);
+  const linkCommand = recoveryCommands[0] ?? "prisma-cli project link <id-or-name>";
+  const retryCommand = recoveryCommands[1];
+  const commands = ["prisma-cli project list", ...recoveryCommands];
 
   const actions: NextAction[] = [
     {
@@ -198,7 +198,7 @@ export function buildProjectSetupNextActions(options: {
       kind: "run-command",
       journey: "project-setup",
       label: "Link the chosen Project",
-      command: "prisma-cli project link <id-or-name>",
+      command: linkCommand,
       reason: "Linking writes the durable local Project binding for this directory.",
     },
   ];
@@ -220,7 +220,7 @@ export function buildProjectSetupNextActions(options: {
       kind: "run-command",
       journey: "recover",
       label: "Retry with an explicit Project",
-      command: `prisma-cli ${options.commandName} --project <id-or-name>`,
+      command: retryCommand ?? `prisma-cli ${options.commandName} --project <id-or-name>`,
     });
   }
 

--- a/packages/cli/src/lib/project/resolution.ts
+++ b/packages/cli/src/lib/project/resolution.ts
@@ -1,7 +1,9 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
+import { formatCommandArgument } from "../../shell/command-arguments";
 import { CliError } from "../../shell/errors";
+import type { NextAction } from "../../shell/next-actions";
 import type { CommandContext } from "../../shell/runtime";
 import type { AuthWorkspace } from "../../types/auth";
 import type {
@@ -64,6 +66,9 @@ export async function inspectProjectBinding(options: ResolveProjectOptions): Pro
   return {
     workspace: options.workspace,
     project: null,
+    localBinding: {
+      status: "not-linked",
+    },
     resolution: {
       projectSource: "unbound",
     },
@@ -162,7 +167,64 @@ export async function projectSetupRequiredError(options: {
     meta: { ...suggestion },
     exitCode: 1,
     nextSteps: ["prisma-cli project list", ...suggestion.recoveryCommands],
+    nextActions: buildProjectSetupNextActions({
+      commandName: options.commandName,
+      suggestedProjectName: suggestion.suggestedProjectName,
+    }),
   });
+}
+
+export function buildProjectSetupNextActions(options: {
+  commandName?: string;
+  suggestedProjectName?: string;
+  createCommand?: string;
+  reason?: string;
+} = {}): NextAction[] {
+  const commands = ["prisma-cli project list", "prisma-cli project link <id-or-name>"];
+  if (options.commandName) {
+    commands.push(`prisma-cli ${options.commandName} --project <id-or-name>`);
+  }
+
+  const actions: NextAction[] = [
+    {
+      kind: "user-choice",
+      journey: "project-setup",
+      label: "Ask the user which Prisma Project this directory should use",
+      commands,
+      reason: options.reason
+        ?? "This directory is not linked to a Prisma Project. Package and directory names are suggestions only, not a safe Project selection.",
+    },
+    {
+      kind: "run-command",
+      journey: "project-setup",
+      label: "Link the chosen Project",
+      command: "prisma-cli project link <id-or-name>",
+      reason: "Linking writes the durable local Project binding for this directory.",
+    },
+  ];
+
+  const createCommand = options.createCommand
+    ?? (options.suggestedProjectName ? `prisma-cli project create ${formatCommandArgument(options.suggestedProjectName)}` : undefined);
+  if (createCommand) {
+    actions.push({
+      kind: "run-command",
+      journey: "project-setup",
+      label: "Create and link a new Project",
+      command: createCommand,
+      reason: "Use this when the user wants a new Prisma Project instead of an existing one.",
+    });
+  }
+
+  if (options.commandName) {
+    actions.push({
+      kind: "run-command",
+      journey: "recover",
+      label: "Retry with an explicit Project",
+      command: `prisma-cli ${options.commandName} --project <id-or-name>`,
+    });
+  }
+
+  return actions;
 }
 
 export async function readPackageName(cwd: string): Promise<string | null> {

--- a/packages/cli/src/lib/project/setup.ts
+++ b/packages/cli/src/lib/project/setup.ts
@@ -12,6 +12,7 @@ import {
   projectNotFoundError,
   type ProjectCandidate,
 } from "./resolution";
+export { formatCommandArgument } from "../../shell/command-arguments";
 
 export function isValidProjectSetupName(projectName: string): boolean {
   return projectName.trim().length > 0;
@@ -108,10 +109,6 @@ export function projectCreateFailedError(
     exitCode: 1,
     nextSteps: options.nextSteps,
   });
-}
-
-export function formatCommandArgument(value: string): string {
-  return /^[A-Za-z0-9._/-]+$/.test(value) ? value : JSON.stringify(value);
 }
 
 function formatSetupDirectory(cwd: string): string {

--- a/packages/cli/src/presenters/project.ts
+++ b/packages/cli/src/presenters/project.ts
@@ -1,4 +1,5 @@
 import type { CommandDescriptor } from "../shell/command-meta";
+import { formatCommandArgument } from "../shell/command-arguments";
 import type { CommandContext } from "../shell/runtime";
 import type {
   GitRepositoryConnection,
@@ -8,14 +9,14 @@ import type {
   ProjectShowResult,
 } from "../types/project";
 import { renderList, renderMutate, renderShow, serializeList } from "../output/patterns";
-import { renderSummaryLine } from "../shell/ui";
+import { renderNextSteps, renderSummaryLine } from "../shell/ui";
 
 export function renderProjectList(
   context: CommandContext,
   descriptor: CommandDescriptor,
   result: ProjectListResult,
 ): string[] {
-  return renderList(
+  const lines = renderList(
     {
       title: "Listing projects for the authenticated workspace.",
       descriptor,
@@ -33,20 +34,29 @@ export function renderProjectList(
     },
     context.ui,
   );
+
+  if (result.localBinding?.status === "not-linked" || result.localBinding?.status === "invalid") {
+    lines.push(...renderNextSteps(["Link the chosen Project: prisma-cli project link <id-or-name>"]));
+  }
+
+  return lines;
 }
 
 export function serializeProjectList(result: ProjectListResult) {
-  return serializeList({
-    context: {
-      workspace: result.workspace.name,
-    },
-    items: result.projects.map((project) => ({
-      noun: "project",
-      label: project.name,
-      id: project.id,
-      status: null,
-    })),
-  });
+  return {
+    ...serializeList({
+      context: {
+        workspace: result.workspace.name,
+      },
+      items: result.projects.map((project) => ({
+        noun: "project",
+        label: project.name,
+        id: project.id,
+        status: null,
+      })),
+    }),
+    localBinding: result.localBinding ?? null,
+  };
 }
 
 export function renderProjectShow(
@@ -55,23 +65,24 @@ export function renderProjectShow(
   result: ProjectShowResult,
 ): string[] {
   if (result.project === null) {
-    return renderShow(
+    const lines = renderShow(
       {
-        title: "No Project linked to this directory.",
+        title: "This directory is not linked to a Prisma Project.",
         descriptor,
         fields: [
           { key: "workspace", value: result.workspace.name },
-          { key: "project", value: "unbound", tone: "warning" },
-          {
-            key: "suggested",
-            value: `${result.suggestedProjectName} (${formatSuggestionSource(result.suggestedProjectNameSource)})`,
-          },
-          { key: "match", value: formatCandidateList(result.candidates) },
-          { key: "next", value: result.recoveryCommands[0] ?? "prisma-cli project link <id-or-name>" },
+          { key: "project", value: "Not linked", tone: "warning" },
         ],
       },
       context.ui,
     );
+
+    lines.push(...renderNextSteps([
+      "Link an existing Project: prisma-cli project link <id-or-name>",
+      `Create a new Project: prisma-cli project create ${formatCommandArgument(result.suggestedProjectName)}`,
+    ]));
+
+    return lines;
   }
 
   return renderShow(
@@ -176,22 +187,6 @@ function formatProjectSource(source: ProjectShowResult["resolution"]["projectSou
     case "unbound":
       return "unbound";
   }
-}
-
-function formatSuggestionSource(source: "package-name" | "directory-name"): string {
-  switch (source) {
-    case "package-name":
-      return "package name";
-    case "directory-name":
-      return "directory name";
-  }
-}
-
-function formatCandidateList(candidates: Array<{ name: string }>): string {
-  if (candidates.length === 0) {
-    return "none";
-  }
-  return candidates.map((project) => project.name).join(", ");
 }
 
 function formatGitConnectionDetail(status: GitRepositoryConnection["status"]): string {

--- a/packages/cli/src/shell/command-arguments.ts
+++ b/packages/cli/src/shell/command-arguments.ts
@@ -1,0 +1,3 @@
+export function formatCommandArgument(value: string): string {
+  return /^[A-Za-z0-9._/-]+$/.test(value) ? value : JSON.stringify(value);
+}

--- a/packages/cli/src/shell/command-arguments.ts
+++ b/packages/cli/src/shell/command-arguments.ts
@@ -1,3 +1,5 @@
 export function formatCommandArgument(value: string): string {
-  return /^[A-Za-z0-9._/-]+$/.test(value) ? value : JSON.stringify(value);
+  return /^[A-Za-z0-9._/-]+$/.test(value) && !value.startsWith("-")
+    ? value
+    : `'${value.replace(/'/g, "'\\''")}'`;
 }

--- a/packages/cli/src/shell/command-runner.ts
+++ b/packages/cli/src/shell/command-runner.ts
@@ -90,6 +90,7 @@ export async function runStreamingCommand(
         result: null,
         warnings: [],
         nextSteps: [],
+        nextActions: [],
       });
     }
   } catch (error) {
@@ -103,6 +104,7 @@ export async function runStreamingCommand(
           error: cliErrorToJson(cliError),
           warnings: [],
           nextSteps: cliError.nextSteps,
+          nextActions: cliError.nextActions,
         });
       } else {
         writeHumanError(context.output, context.ui, cliError, { trace: flags.trace });

--- a/packages/cli/src/shell/errors.ts
+++ b/packages/cli/src/shell/errors.ts
@@ -1,3 +1,5 @@
+import type { NextAction } from "./next-actions";
+
 export type ErrorDomain = "cli" | "auth" | "project" | "branch" | "app";
 export type ErrorSeverity = "error";
 
@@ -13,6 +15,7 @@ export interface CliErrorOptions {
   docsUrl?: string | null;
   exitCode?: number;
   nextSteps?: string[];
+  nextActions?: NextAction[];
   humanLines?: string[];
 }
 
@@ -29,6 +32,7 @@ export class CliError extends Error {
   readonly docsUrl: string | null;
   readonly exitCode: number;
   readonly nextSteps: string[];
+  readonly nextActions: NextAction[];
   readonly humanLines: string[] | null;
 
   constructor(options: CliErrorOptions) {
@@ -46,6 +50,7 @@ export class CliError extends Error {
     this.docsUrl = options.docsUrl ?? null;
     this.exitCode = options.exitCode ?? 1;
     this.nextSteps = options.nextSteps ?? [];
+    this.nextActions = options.nextActions ?? [];
     this.humanLines = options.humanLines && options.humanLines.length > 0
       ? [...options.humanLines]
       : null;

--- a/packages/cli/src/shell/next-actions.ts
+++ b/packages/cli/src/shell/next-actions.ts
@@ -1,0 +1,12 @@
+export type NextActionKind = "run-command" | "user-choice" | "edit-file" | "done";
+
+export type NextActionJourney = "project-setup" | "deploy-app" | "inspect" | "recover";
+
+export interface NextAction {
+  kind: NextActionKind;
+  journey: NextActionJourney;
+  label: string;
+  command?: string;
+  commands?: string[];
+  reason?: string;
+}

--- a/packages/cli/src/shell/output.ts
+++ b/packages/cli/src/shell/output.ts
@@ -1,6 +1,7 @@
 import type { Writable } from "node:stream";
 
 import type { CliError } from "./errors";
+import type { NextAction } from "./next-actions";
 import type { ShellUi } from "./ui";
 import { renderNextSteps, renderSummaryLine } from "./ui";
 
@@ -9,6 +10,7 @@ export interface CommandSuccess<T> {
   result: T;
   warnings: string[];
   nextSteps: string[];
+  nextActions?: NextAction[];
 }
 
 export interface CliOutput {
@@ -17,7 +19,7 @@ export interface CliOutput {
 }
 
 export function writeJsonSuccess<T>(output: CliOutput, success: CommandSuccess<T>): void {
-  output.stdout.write(`${JSON.stringify({ ok: true, ...success }, null, 2)}\n`);
+  output.stdout.write(`${JSON.stringify({ ok: true, nextActions: [], ...success }, null, 2)}\n`);
 }
 
 export function writeJsonEvent(output: CliOutput, event: Record<string, unknown>): void {
@@ -47,6 +49,7 @@ export function writeJsonError(output: CliOutput, command: string, error: CliErr
         error: cliErrorToJson(error),
         warnings: [],
         nextSteps: error.nextSteps,
+        nextActions: error.nextActions,
       },
       null,
       2,

--- a/packages/cli/src/types/project.ts
+++ b/packages/cli/src/types/project.ts
@@ -20,9 +20,14 @@ export interface ProjectResolution {
   targetNameSource?: "explicit" | "env" | "local-pin" | "package-name" | "directory-name" | "platform-mapping" | "prompt";
 }
 
+export interface ProjectLocalBindingState {
+  status: "linked" | "not-linked" | "invalid";
+}
+
 export interface ProjectListResult {
   workspace: AuthWorkspace;
   projects: ProjectSummary[];
+  localBinding?: ProjectLocalBindingState;
 }
 
 export interface ProjectSetupSuggestion {
@@ -41,6 +46,9 @@ export interface BoundProjectShowResult {
 export interface UnboundProjectShowResult extends ProjectSetupSuggestion {
   workspace: AuthWorkspace;
   project: null;
+  localBinding: {
+    status: "not-linked";
+  };
   resolution: ProjectResolution & {
     projectSource: "unbound";
   };

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -1133,6 +1133,69 @@ describe("app controller", () => {
     expect(stderr.buffer).toContain("Building locally...");
   });
 
+  it("surfaces a concrete Next.js standalone-output recovery action", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+    const listApps = vi.fn().mockResolvedValue([]);
+    const deployApp = vi.fn().mockImplementation(async (options: { progress?: { onBuildStart?: () => void } }) => {
+      options.progress?.onBuildStart?.();
+      throw new Error('Next.js build did not produce standalone output. Add output: "standalone" to your next.config file.');
+    });
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/preview-provider", () => ({
+      createPreviewAppProvider: vi.fn(() => ({
+        createProject: vi.fn(),
+        listApps,
+        deployApp,
+        listDeployments: vi.fn(),
+        showDeployment: vi.fn(),
+      })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runAppDeploy } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      isTTY: false,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await expect(runAppDeploy(context, "hello-world", {
+      projectRef: "proj_123",
+      framework: "nextjs",
+    })).rejects.toMatchObject({
+      code: "BUILD_FAILED",
+      fix: "Add output: \"standalone\" to next.config.*, then rerun deploy.",
+      humanLines: [
+        "Build failed locally.",
+        "",
+        "✗ Built       Next.js build did not produce standalone output. Add output: \"standalone\" to your next.config file.",
+        "",
+        "Fix: Add output: \"standalone\" to next.config.*, then rerun deploy.",
+      ],
+      nextSteps: ["Add output: \"standalone\" to next.config.*, then rerun prisma-cli app deploy"],
+      nextActions: [
+        expect.objectContaining({
+          kind: "edit-file",
+          journey: "deploy-app",
+          label: "Add Next.js standalone output",
+        }),
+        expect.objectContaining({
+          kind: "run-command",
+          command: "prisma-cli app deploy",
+        }),
+      ],
+    });
+  });
+
   it("renders runtime-failure copy with deployment logs after the container starts", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
     let appName = "";
@@ -1530,6 +1593,24 @@ describe("app controller", () => {
           `prisma-cli app deploy --create-project ${path.basename(cwd)}`,
         ]),
       },
+      nextActions: [
+        expect.objectContaining({
+          kind: "user-choice",
+          journey: "project-setup",
+        }),
+        expect.objectContaining({
+          kind: "run-command",
+          command: "prisma-cli project link <id-or-name>",
+        }),
+        expect.objectContaining({
+          kind: "run-command",
+          command: `prisma-cli app deploy --create-project ${path.basename(cwd)}`,
+        }),
+        expect.objectContaining({
+          kind: "run-command",
+          command: "prisma-cli app deploy --project <id-or-name>",
+        }),
+      ],
     });
     expect(createProject).not.toHaveBeenCalled();
     expect(listApps).not.toHaveBeenCalled();
@@ -2821,6 +2902,12 @@ describe("app controller", () => {
           },
         ],
       },
+      nextActions: expect.arrayContaining([
+        expect.objectContaining({
+          kind: "user-choice",
+          journey: "project-setup",
+        }),
+      ]),
     });
     expect(listApps).not.toHaveBeenCalled();
   });

--- a/packages/cli/tests/app-env-vars.test.ts
+++ b/packages/cli/tests/app-env-vars.test.ts
@@ -167,6 +167,12 @@ describe("app env vars", () => {
           "prisma-cli project env list --project <id-or-name>",
         ]),
       },
+      nextActions: expect.arrayContaining([
+        expect.objectContaining({
+          kind: "user-choice",
+          journey: "project-setup",
+        }),
+      ]),
     });
   });
 

--- a/packages/cli/tests/auth-real-mode.test.ts
+++ b/packages/cli/tests/auth-real-mode.test.ts
@@ -177,6 +177,7 @@ describe("real auth mode", () => {
       },
       warnings: [],
       nextSteps: [],
+      nextActions: [],
     });
   });
 

--- a/packages/cli/tests/auth.test.ts
+++ b/packages/cli/tests/auth.test.ts
@@ -86,6 +86,7 @@ describe("auth commands", () => {
       },
       warnings: [],
       nextSteps: [],
+      nextActions: [],
     });
   });
 
@@ -118,6 +119,7 @@ describe("auth commands", () => {
       },
       warnings: [],
       nextSteps: ["prisma-cli auth login"],
+      nextActions: [],
     });
   });
 

--- a/packages/cli/tests/branch.test.ts
+++ b/packages/cli/tests/branch.test.ts
@@ -75,6 +75,7 @@ describe("branch commands", () => {
       },
       warnings: [],
       nextSteps: ["prisma-cli app deploy --app <name>"],
+      nextActions: [],
     });
   });
 
@@ -110,6 +111,7 @@ describe("branch commands", () => {
       },
       warnings: [],
       nextSteps: ["prisma-cli app deploy --app <name>"],
+      nextActions: [],
     });
   });
 
@@ -145,6 +147,7 @@ describe("branch commands", () => {
       },
       warnings: [],
       nextSteps: ["prisma-cli app deploy --app <name>"],
+      nextActions: [],
     });
   });
 
@@ -265,6 +268,7 @@ describe("branch commands", () => {
       },
       warnings: [],
       nextSteps: [],
+      nextActions: [],
     });
   });
 
@@ -309,6 +313,7 @@ describe("branch commands", () => {
       },
       warnings: [],
       nextSteps: [],
+      nextActions: [],
     });
   });
 
@@ -346,6 +351,7 @@ describe("branch commands", () => {
       },
       warnings: ["Production is protected and durable. Use with care."],
       nextSteps: ["prisma-cli branch show"],
+      nextActions: [],
     });
   });
 
@@ -410,6 +416,7 @@ describe("branch commands", () => {
       },
       warnings: [],
       nextSteps: ["prisma-cli branch list"],
+      nextActions: [],
     });
   });
 
@@ -442,6 +449,7 @@ describe("branch commands", () => {
       },
       warnings: [],
       nextSteps: ["prisma-cli branch list"],
+      nextActions: [],
     });
   });
 
@@ -474,6 +482,7 @@ describe("branch commands", () => {
       },
       warnings: [],
       nextSteps: ["prisma-cli branch list"],
+      nextActions: [],
     });
   });
 

--- a/packages/cli/tests/project-controller.test.ts
+++ b/packages/cli/tests/project-controller.test.ts
@@ -39,12 +39,21 @@ describe("project controller", () => {
       resolution: {
         projectSource: "unbound",
       },
+      localBinding: {
+        status: "not-linked",
+      },
       candidates: [],
       recoveryCommands: [
         "prisma-cli project link <id-or-name>",
         "prisma-cli project show --project <id-or-name>",
       ],
     });
+    expect(result.nextActions).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: "user-choice",
+        journey: "project-setup",
+      }),
+    ]));
   });
 
   it("links an existing project and writes the local pin", async () => {

--- a/packages/cli/tests/project-real-mode.test.ts
+++ b/packages/cli/tests/project-real-mode.test.ts
@@ -147,7 +147,16 @@ describe("real project mode", () => {
         { id: "proj_123", name: "Acme Dashboard" },
         { id: "proj_456", name: "Billing API" },
       ],
+      localBinding: {
+        status: "not-linked",
+      },
     });
+    expect(result.nextActions).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: "user-choice",
+        journey: "project-setup",
+      }),
+    ]));
   });
 
   it("resolves an explicit project in real mode", async () => {

--- a/packages/cli/tests/project.test.ts
+++ b/packages/cli/tests/project.test.ts
@@ -44,6 +44,23 @@ async function createAmbiguousFixture(cwd: string): Promise<string> {
   return nextPath;
 }
 
+async function createAppleFixture(cwd: string): Promise<string> {
+  const raw = JSON.parse(await readFile(fixturePath, "utf8")) as {
+    projects: Array<{ id: string; name: string; slug: string; workspaceId: string }>;
+  };
+  raw.projects = [
+    {
+      id: "proj_apple",
+      name: "apple",
+      slug: "apple",
+      workspaceId: "ws_123",
+    },
+  ];
+  const nextPath = path.join(cwd, "apple-fixture.json");
+  await writeFile(nextPath, `${JSON.stringify(raw, null, 2)}\n`, "utf8");
+  return nextPath;
+}
+
 describe("project commands", () => {
   it("lists projects without resolving the current directory", async () => {
     const cwd = await createTempCwd();
@@ -60,8 +77,44 @@ describe("project commands", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toBe("");
     expect(result.stderr).toBe(
-      "project list → Listing projects for the authenticated workspace.\n\n│  workspace:  Acme Inc\n│  ⚬ project:  Acme Dashboard\n│  ⚬ project:  Billing API\n",
+      "project list → Listing projects for the authenticated workspace.\n\n│  workspace:  Acme Inc\n│  ⚬ project:  Acme Dashboard\n│  ⚬ project:  Billing API\n\nNext step:\n- Link the chosen Project: prisma-cli project link <id-or-name>\n",
     );
+  });
+
+  it("adds a Project setup next action to project list JSON when unlinked", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    await login(cwd, stateDir);
+
+    const result = await executeCli({
+      argv: ["project", "list", "--json"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+
+    const payload = JSON.parse(result.stdout);
+
+    expect(result.exitCode).toBe(0);
+    expect(payload.result).toMatchObject({
+      localBinding: {
+        status: "not-linked",
+      },
+      items: expect.arrayContaining([
+        expect.objectContaining({ name: "Acme Dashboard", status: null }),
+      ]),
+    });
+    expect(payload.nextActions).toEqual([
+      expect.objectContaining({
+        kind: "user-choice",
+        journey: "project-setup",
+        label: "Ask the user which Prisma Project this directory should use",
+      }),
+      expect.objectContaining({
+        kind: "run-command",
+        command: "prisma-cli project link <id-or-name>",
+      }),
+    ]);
   });
 
   it("shows unbound suggestions from package.json in JSON mode", async () => {
@@ -79,7 +132,7 @@ describe("project commands", () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(JSON.parse(result.stdout)).toEqual({
+    expect(JSON.parse(result.stdout)).toMatchObject({
       ok: true,
       command: "project.show",
       result: {
@@ -88,6 +141,9 @@ describe("project commands", () => {
           name: "Acme Inc",
         },
         project: null,
+        localBinding: {
+          status: "not-linked",
+        },
         resolution: {
           projectSource: "unbound",
         },
@@ -106,6 +162,29 @@ describe("project commands", () => {
       },
       warnings: [],
       nextSteps: [],
+      nextActions: [
+        expect.objectContaining({
+          kind: "user-choice",
+          journey: "project-setup",
+          commands: [
+            "prisma-cli project list",
+            "prisma-cli project link <id-or-name>",
+            "prisma-cli project show --project <id-or-name>",
+          ],
+        }),
+        expect.objectContaining({
+          kind: "run-command",
+          command: "prisma-cli project link <id-or-name>",
+        }),
+        expect.objectContaining({
+          kind: "run-command",
+          command: "prisma-cli project create billing-api",
+        }),
+        expect.objectContaining({
+          kind: "run-command",
+          command: "prisma-cli project show --project <id-or-name>",
+        }),
+      ],
     });
   });
 
@@ -191,6 +270,9 @@ describe("project commands", () => {
     expect(result.exitCode).toBe(0);
     expect(payload.result).toMatchObject({
       project: null,
+      localBinding: {
+        status: "not-linked",
+      },
       resolution: {
         projectSource: "unbound",
       },
@@ -198,6 +280,12 @@ describe("project commands", () => {
       suggestedProjectNameSource: "directory-name",
       candidates: [],
     });
+    expect(payload.nextActions).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: "user-choice",
+        journey: "project-setup",
+      }),
+    ]));
   });
 
   it("uses the directory name as the suggestion when package metadata is unusable", async () => {
@@ -239,9 +327,47 @@ describe("project commands", () => {
     const stderr = stripAnsi(result.stderr);
 
     expect(result.exitCode).toBe(0);
-    expect(stderr).toContain("No Project linked to this directory.");
-    expect(stderr).toContain("project:    unbound");
+    expect(stderr).toContain("This directory is not linked to a Prisma Project.");
+    expect(stderr).toContain("project:    Not linked");
+    expect(stderr).toContain("Link an existing Project: prisma-cli project link <id-or-name>");
+    expect(stderr).not.toContain("match:");
     expect(stderr).not.toContain("Select a project");
+  });
+
+  it("does not suggest linking a nearby-looking Project in human output", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const appleFixturePath = await createAppleFixture(cwd);
+    await writePackageJson(cwd, "pear");
+    await login(cwd, stateDir, appleFixturePath);
+
+    const result = await executeCli({
+      argv: ["project", "show"],
+      cwd,
+      stateDir,
+      fixturePath: appleFixturePath,
+    });
+    const stderr = stripAnsi(result.stderr);
+
+    expect(result.exitCode).toBe(0);
+    expect(stderr).toContain("project:    Not linked");
+    expect(stderr).not.toContain("apple");
+    expect(stderr).not.toContain("match:");
+    expect(stderr).toContain("Create a new Project: prisma-cli project create pear");
+
+    const jsonResult = await executeCli({
+      argv: ["project", "show", "--json"],
+      cwd,
+      stateDir,
+      fixturePath: appleFixturePath,
+    });
+    const payload = JSON.parse(jsonResult.stdout);
+
+    expect(payload.result.candidates).toEqual([]);
+    expect(payload.nextActions[0]).toMatchObject({
+      kind: "user-choice",
+      journey: "project-setup",
+    });
   });
 
   it("shows all matching candidates when package inference matches multiple projects", async () => {
@@ -263,6 +389,9 @@ describe("project commands", () => {
     expect(result.exitCode).toBe(0);
     expect(payload.result).toMatchObject({
       project: null,
+      localBinding: {
+        status: "not-linked",
+      },
       resolution: {
         projectSource: "unbound",
       },
@@ -329,6 +458,7 @@ describe("project commands", () => {
       },
       warnings: [],
       nextSteps: [],
+      nextActions: [],
     });
     expect(state.project.repositoryConnectionsByProject.proj_123.repository.fullName).toBe("prisma/prisma-cli");
   });

--- a/packages/cli/tests/shell.test.ts
+++ b/packages/cli/tests/shell.test.ts
@@ -2,11 +2,20 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import stripAnsi from "strip-ansi";
 
+import { formatCommandArgument } from "../src/shell/command-arguments";
 import { createTempCwd, executeCli } from "./helpers";
 
 const fixturePath = path.resolve("fixtures/mock-api.json");
 
 describe("shell behavior", () => {
+  it("formats command arguments for shell-safe next steps", () => {
+    expect(formatCommandArgument("billing-api")).toBe("billing-api");
+    expect(formatCommandArgument("-rf")).toBe("'-rf'");
+    expect(formatCommandArgument("my app")).toBe("'my app'");
+    expect(formatCommandArgument("owner's app")).toBe("'owner'\\''s app'");
+    expect(formatCommandArgument("$(rm -rf /)")).toBe("'$(rm -rf /)'");
+  });
+
   it("renders root help with workflow groups", async () => {
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");

--- a/packages/cli/tests/version.test.ts
+++ b/packages/cli/tests/version.test.ts
@@ -47,6 +47,7 @@ describe("version", () => {
       },
       warnings: [],
       nextSteps: [],
+      nextActions: [],
     });
   });
 
@@ -101,6 +102,7 @@ describe("version", () => {
       },
       warnings: [],
       nextSteps: [],
+      nextActions: [],
     });
     expect(["bunx", "npx", "global", "dev", "unknown"]).toContain(payload.result.invocation);
   });


### PR DESCRIPTION
## Summary

- add structured nextActions to JSON success and error envelopes while preserving nextSteps
- keep human project setup output calm with Not linked plus explicit link/create commands
- expose agent-legible Project setup choice guidance for project show/list and PROJECT_SETUP_REQUIRED
- add concrete Next.js standalone-output recovery actions for deploy build failures
- encode the human-vs-agent rendering principle in product docs

## Review

- Ran local thermonuclear review against origin/main...HEAD
- Verdict: pass after extracting command-argument formatting into a shared shell helper

## Validation

- corepack pnpm --filter @prisma/cli build
- corepack pnpm --filter @prisma/cli test
- git diff --check
- targeted grep for removed human-output stop-gate language