### PR TITLE
Add interactive Project setup to project link

### DIFF
--- a/docs/product/cli-style-guide.md
+++ b/docs/product/cli-style-guide.md
@@ -70,7 +70,7 @@ project show → This directory is not linked to a Prisma Project.
 │  project:    Not linked
 
 Next steps:
-- Link an existing Project: prisma-cli project link <id-or-name>
+- Link an existing Project you choose: prisma-cli project link <id-or-name>
 - Create a new Project: prisma-cli project create billing-api
 ```
 

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -365,9 +365,10 @@ Behavior:
 - lists projects visible to the active workspace
 - does not resolve the current directory
 - does not mutate local state
-- when the current directory is not linked, human output adds one setup hint after the list
+- when the current directory is not linked, human output adds setup hints after the list
 - in JSON, unlinked directories include a `user-choice` `nextActions` entry for Project setup
 - listed Projects are not marked selected unless durable local binding actually selects one
+- listed Projects are candidates only; the user must choose one before `project link <id-or-name>` runs
 
 Examples:
 
@@ -425,24 +426,30 @@ prisma-cli project create my-app
 prisma-cli project create my-app --json
 ```
 
-## `prisma-cli project link <id-or-name>`
+## `prisma-cli project link [id-or-name]`
 
 Purpose:
 
-- bind the current directory to an existing Prisma Project
+- bind the current directory to a Prisma Project
 
 Behavior:
 
 - requires auth
-- resolves exactly one Project by id or name in the authenticated workspace
+- with `[id-or-name]`, resolves exactly one existing Project by id or name in the authenticated workspace
+- without `[id-or-name]` in interactive mode, prompts the user to choose an existing Project, create a new Project, or cancel
+- choosing an existing Project writes the local binding and does not create remote resources
+- choosing "Create a new Project" prompts for a Project name, creates the Project, and writes the local binding
+- without `[id-or-name]` in `--json`, `--no-interactive`, non-TTY, CI, or `--yes` mode, fails with `PROJECT_LINK_TARGET_REQUIRED`
+- `--yes` does not choose Project scope
 - writes `.prisma/local.json` with Workspace and Project IDs
 - ensures `.prisma/` is ignored by Git
-- does not create remote resources
+- does not create Branch, App, Deployment, database, or Git repository connection state
 - fails with `PROJECT_NOT_FOUND` or `PROJECT_AMBIGUOUS` when the Project cannot be selected safely
 
 Examples:
 
 ```bash
+prisma-cli project link
 prisma-cli project link proj_123
 prisma-cli project link "Acme Dashboard" --json
 ```

--- a/docs/product/error-conventions.md
+++ b/docs/product/error-conventions.md
@@ -161,6 +161,7 @@ These codes are the minimum stable set for the MVP:
 - `USAGE_ERROR`
 - `AUTH_REQUIRED`
 - `PROJECT_SETUP_REQUIRED`
+- `PROJECT_LINK_TARGET_REQUIRED`
 - `PROJECT_CREATE_FAILED`
 - `PROJECT_NOT_FOUND`
 - `PROJECT_AMBIGUOUS`
@@ -200,6 +201,7 @@ Recommended meanings:
 - `USAGE_ERROR`: invalid arguments or invalid command combination
 - `AUTH_REQUIRED`: command needs an authenticated session
 - `PROJECT_SETUP_REQUIRED`: command needs explicit or durable Project context before it can continue
+- `PROJECT_LINK_TARGET_REQUIRED`: `project link` needs the user to choose an existing Project or create a new one
 - `PROJECT_CREATE_FAILED`: Project creation failed before deployment or linking could continue
 - `PROJECT_NOT_FOUND`: requested project does not exist or is not accessible
 - `PROJECT_AMBIGUOUS`: multiple safe project candidates matched

--- a/docs/product/output-conventions.md
+++ b/docs/product/output-conventions.md
@@ -226,7 +226,7 @@ project show → This directory is not linked to a Prisma Project.
 │  project:    Not linked
 
 Next steps:
-- Link an existing Project: prisma-cli project link <id-or-name>
+- Link an existing Project you choose: prisma-cli project link <id-or-name>
 - Create a new Project: prisma-cli project create billing-api
 ```
 

--- a/packages/cli/src/commands/project/index.ts
+++ b/packages/cli/src/commands/project/index.ts
@@ -55,7 +55,7 @@ function createProjectCreateCommand(runtime: CliRuntime): Command {
 function createProjectLinkCommand(runtime: CliRuntime): Command {
   const command = attachCommandDescriptor(configureRuntimeCommand(new Command("link"), runtime), "project.link");
 
-  command.argument("<id-or-name>", "Project id or name");
+  command.argument("[id-or-name]", "Project id or name");
   addGlobalFlags(command);
 
   command.action(async (projectRef, options) => {
@@ -63,7 +63,7 @@ function createProjectLinkCommand(runtime: CliRuntime): Command {
       runtime,
       "project.link",
       options as Record<string, unknown>,
-      (context) => runProjectLink(context, String(projectRef)),
+      (context) => runProjectLink(context, typeof projectRef === "string" ? projectRef : undefined),
       {
         renderHuman: (context, descriptor, result) => renderProjectSetup(context, descriptor, result),
         renderJson: (result) => serializeProjectSetup(result),

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -56,6 +56,7 @@ import {
   type ProjectCandidate,
   sortProjects,
 } from "../lib/project/resolution";
+import { promptForProjectSetupChoice } from "../lib/project/interactive-setup";
 import {
   bindProjectToDirectory,
   formatCommandArgument,
@@ -2369,75 +2370,32 @@ async function resolveDeployProjectContext(
   throw projectSetupRequiredError(projects, suggestedName);
 }
 
-type DeployProjectSetupChoice =
-  | { kind: "project"; project: ProjectCandidate }
-  | { kind: "create" }
-  | { kind: "cancel" };
-
 async function resolveInteractiveDeployProjectSetup(
   context: CommandContext,
   provider: ReturnType<typeof createPreviewAppProvider>,
   workspace: AuthWorkspace,
   projects: ProjectCandidate[],
 ): Promise<Omit<ResolvedAppProjectContext, "branch">> {
-  const sortedProjects = sortProjects(projects);
-  const choice = await selectPrompt<DeployProjectSetupChoice>({
-    input: context.runtime.stdin,
-    output: context.runtime.stderr,
-    message: "Which Project should this directory use?",
-    choices: [
-      ...sortedProjects.map((project) => ({
-        label: project.name,
-        value: { kind: "project" as const, project },
-      })),
-      { label: "Create a new Project", value: { kind: "create" as const } },
-      { label: "Cancel", value: { kind: "cancel" as const } },
-    ],
+  const setup = await promptForProjectSetupChoice({
+    context,
+    projects,
+    createProject: (projectName) => createProjectForDeploySetup(provider, projectName, workspace),
+    cancel: {
+      why: "Deploy needs a Project before it can continue.",
+      fix: "Choose an existing Project or create a new one, then rerun deploy.",
+      nextSteps: ["prisma-cli app deploy --project <id-or-name>", "prisma-cli app deploy --create-project <name>"],
+    },
   });
-
-  if (choice.kind === "cancel") {
-    throw usageError(
-      "Project setup canceled",
-      "Deploy needs a Project before it can continue.",
-      "Choose an existing Project or create a new one, then rerun deploy.",
-      ["prisma-cli app deploy --project <id-or-name>", "prisma-cli app deploy --create-project <name>"],
-      "project",
-    );
-  }
-
-  if (choice.kind === "project") {
-    return {
-      workspace,
-      project: toProjectSummary(choice.project),
-      resolution: {
-        projectSource: "prompt",
-        targetName: choice.project.name,
-        targetNameSource: "prompt",
-      },
-      localPinAction: "linked",
-    };
-  }
-
-  const suggestedName = await inferTargetName(context.runtime.cwd);
-  const rawName = await textPrompt({
-    input: context.runtime.stdin,
-    output: context.runtime.stderr,
-    message: "Project name",
-    placeholder: suggestedName.name,
-    validate: (value) => validateProjectSetupNameText(value, suggestedName.name),
-  });
-  const projectName = rawName.trim() || suggestedName.name;
-  const created = await createProjectForDeploySetup(provider, projectName, workspace);
 
   return {
     workspace,
-    project: toProjectSummary(created),
+    project: setup.project,
     resolution: {
-      projectSource: "created",
-      targetName: projectName,
-      targetNameSource: rawName.trim() ? "prompt" : suggestedName.source,
+      projectSource: setup.action === "created" ? "created" : "prompt",
+      targetName: setup.targetName,
+      targetNameSource: setup.targetNameSource,
     },
-    localPinAction: "created",
+    localPinAction: setup.action,
   };
 }
 
@@ -2508,14 +2466,6 @@ function assertExclusiveDeployProjectInputs(options: {
     ],
     "project",
   );
-}
-
-function validateProjectSetupNameText(value: string | undefined, fallback: string): string | undefined {
-  if ((value?.trim() || fallback).trim().length > 0) {
-    return undefined;
-  }
-
-  return "Enter a Project name.";
 }
 
 interface ResolvedDeployBranch {

--- a/packages/cli/src/controllers/project.ts
+++ b/packages/cli/src/controllers/project.ts
@@ -9,15 +9,18 @@ import {
 import { requireComputeAuth } from "../lib/auth/guard";
 import {
   buildProjectSetupNextActions,
+  inferTargetName,
   inspectProjectBinding,
   resolveProjectTarget,
   sortProjects,
   type ProjectCandidate,
   type ResolvedProjectTarget,
 } from "../lib/project/resolution";
+import { promptForProjectSetupChoice } from "../lib/project/interactive-setup";
 import { readLocalResolutionPin } from "../lib/project/local-pin";
 import {
   bindProjectToDirectory,
+  formatCommandArgument,
   isValidProjectSetupName,
   projectCreateFailedError,
   projectSetupNameRequiredError,
@@ -123,6 +126,7 @@ function buildProjectListNextActions(localBinding: ProjectListResult["localBindi
   return localBinding?.status === "linked"
     ? []
     : buildProjectSetupNextActions({
+        createCommand: "prisma-cli project create <name>",
         reason: localBinding?.status === "invalid"
           ? "This directory has an invalid local Project binding. Ask the user which Prisma Project to link before running Project-scoped commands."
           : "This directory is not linked to a Prisma Project. Project list shows available Projects, but none is selected for this directory.",
@@ -211,7 +215,7 @@ export async function runProjectCreate(
 
 export async function runProjectLink(
   context: CommandContext,
-  projectRef: string,
+  projectRef: string | undefined,
 ): Promise<CommandSuccess<ProjectSetupResult>> {
   const authState = await requireAuthenticatedAuthState(context);
   const workspace = authState.workspace;
@@ -219,21 +223,33 @@ export async function runProjectLink(
     throw workspaceRequiredError();
   }
 
-  if (!projectRef || !projectRef.trim()) {
-    throw usageError(
-      "Project link requires a Project id or name",
-      "The command cannot choose a Project without an explicit id or name.",
-      "Pass the Project id or name as the first argument.",
-      ["prisma-cli project link proj_123"],
-      "project",
-    );
+  let provider: ReturnType<typeof createPreviewAppProvider> | null = null;
+  let projects: ProjectCandidate[];
+  if (isRealMode(context)) {
+    const client = await requireComputeAuth(context.runtime.env);
+    if (!client) {
+      throw authRequiredError();
+    }
+    provider = createPreviewAppProvider(client);
+    projects = await listRealWorkspaceProjects(client, workspace);
+  } else {
+    projects = listFixtureWorkspaceProjects(context, workspace);
   }
 
-  const projects = isRealMode(context)
-    ? await listRealProjectsForLink(context, workspace)
-    : listFixtureWorkspaceProjects(context, workspace);
-  const project = resolveProjectForSetup(projectRef.trim(), projects, workspace);
-  const result = await bindProjectToDirectory(context, workspace, toProjectSummary(project), "linked");
+  let result: ProjectSetupResult;
+  if (projectRef?.trim()) {
+    const project = resolveProjectForSetup(projectRef.trim(), projects, workspace);
+    result = await bindProjectToDirectory(context, workspace, toProjectSummary(project), "linked");
+  } else if (canPrompt(context) && !context.flags.yes) {
+    result = await resolveInteractiveProjectLinkSetup(
+      context,
+      workspace,
+      projects,
+      provider,
+    );
+  } else {
+    throw await projectLinkTargetRequiredError(context, projects);
+  }
 
   return {
     command: "project.link",
@@ -241,6 +257,94 @@ export async function runProjectLink(
     warnings: [],
     nextSteps: ["prisma-cli app deploy"],
   };
+}
+
+async function resolveInteractiveProjectLinkSetup(
+  context: CommandContext,
+  workspace: AuthWorkspace,
+  projects: ProjectCandidate[],
+  provider: ReturnType<typeof createPreviewAppProvider> | null,
+): Promise<ProjectSetupResult> {
+  const setup = await promptForProjectSetupChoice({
+    context,
+    projects,
+    createProject: (projectName) => {
+      if (!provider) {
+        throw featureUnavailableError(
+          "Project create is not available in fixture mode",
+          "Creating Projects requires live platform integration.",
+          "Rerun without fixture mode enabled to create a Project.",
+          ["prisma-cli auth login"],
+          "project",
+        );
+      }
+      return createProjectForLinkSetup(provider, projectName, workspace);
+    },
+    cancel: {
+      why: "Project link needs a Project before it can continue.",
+      fix: "Choose an existing Project or create a new one, then rerun project link.",
+      nextSteps: ["prisma-cli project link <id-or-name>", "prisma-cli project create <name>"],
+    },
+  });
+
+  return bindProjectToDirectory(context, workspace, setup.project, setup.action);
+}
+
+async function createProjectForLinkSetup(
+  provider: ReturnType<typeof createPreviewAppProvider>,
+  projectName: string,
+  workspace: AuthWorkspace,
+): Promise<ProjectCandidate> {
+  const created = await provider.createProject({ name: projectName }).catch((error) => {
+    throw projectCreateFailedError(error, projectName, workspace, {
+      nextSteps: [
+        "prisma-cli project list",
+        "prisma-cli project link <id-or-name>",
+        `prisma-cli project create ${formatCommandArgument(projectName)}`,
+      ],
+      permissionFix: "Grant the token permission to create Projects in this workspace, or link an existing Project.",
+      fallbackFix: "Retry the command, or choose an existing Project with prisma-cli project link <id-or-name>.",
+    });
+  });
+
+  return {
+    id: created.id,
+    name: created.name,
+    workspace,
+  };
+}
+
+async function projectLinkTargetRequiredError(
+  context: CommandContext,
+  projects: ProjectCandidate[],
+): Promise<CliError> {
+  const suggestedName = await inferTargetName(context.runtime.cwd);
+  const createCommand = `prisma-cli project create ${formatCommandArgument(suggestedName.name)}`;
+  const recoveryCommands = [
+    "prisma-cli project link <id-or-name>",
+    createCommand,
+  ];
+
+  return new CliError({
+    code: "PROJECT_LINK_TARGET_REQUIRED",
+    domain: "project",
+    summary: "Choose a Project to link this directory",
+    why: "This directory is not linked to a Prisma Project. Existing Projects are candidates until the user chooses one, and package or directory names are suggestions only.",
+    fix: "Run prisma-cli project link in a TTY to choose from the setup list, pass a Project id or name, or create a new Project.",
+    meta: {
+      suggestedProjectName: suggestedName.name,
+      suggestedProjectNameSource: suggestedName.source,
+      candidates: sortProjects(projects).map(toProjectSummary),
+      recoveryCommands,
+    },
+    exitCode: 2,
+    nextSteps: ["prisma-cli project list", ...recoveryCommands],
+    nextActions: buildProjectSetupNextActions({
+      suggestedProjectName: suggestedName.name,
+      createCommand,
+      reason: "Project link needs the user to choose an existing Project or create a new one. Existing Projects, package names, and directory names are candidates only, not selections.",
+    }),
+  });
 }
 
 export async function runGitConnect(
@@ -445,18 +549,6 @@ async function resolveRequiredProjectInRealMode(
     listProjects: () => listRealWorkspaceProjects(client, workspace),
     commandName,
   });
-}
-
-async function listRealProjectsForLink(
-  context: CommandContext,
-  workspace: AuthWorkspace,
-): Promise<ProjectCandidate[]> {
-  const client = await requireComputeAuth(context.runtime.env);
-  if (!client) {
-    throw authRequiredError();
-  }
-
-  return listRealWorkspaceProjects(client, workspace);
 }
 
 async function resolveProjectShowInFixtureMode(

--- a/packages/cli/src/lib/project/interactive-setup.ts
+++ b/packages/cli/src/lib/project/interactive-setup.ts
@@ -1,0 +1,81 @@
+import type { ProjectSetupSuggestion, ProjectSummary } from "../../types/project";
+import { usageError } from "../../shell/errors";
+import { selectPrompt, textPrompt } from "../../shell/prompt";
+import type { CommandContext } from "../../shell/runtime";
+import { inferTargetName, sortProjects, type ProjectCandidate } from "./resolution";
+import { toProjectSummary, validateProjectSetupNameText } from "./setup";
+
+type InteractiveProjectSetupChoice =
+  | { kind: "project"; project: ProjectCandidate }
+  | { kind: "create" }
+  | { kind: "cancel" };
+
+export interface InteractiveProjectSetupResult {
+  project: ProjectSummary;
+  action: "linked" | "created";
+  targetName: string;
+  targetNameSource: "prompt" | ProjectSetupSuggestion["suggestedProjectNameSource"];
+}
+
+export async function promptForProjectSetupChoice(options: {
+  context: CommandContext;
+  projects: ProjectCandidate[];
+  createProject: (projectName: string) => Promise<ProjectCandidate>;
+  cancel: {
+    why: string;
+    fix: string;
+    nextSteps: string[];
+  };
+}): Promise<InteractiveProjectSetupResult> {
+  const sortedProjects = sortProjects(options.projects);
+  const choice = await selectPrompt<InteractiveProjectSetupChoice>({
+    input: options.context.runtime.stdin,
+    output: options.context.runtime.stderr,
+    message: "Which Project should this directory use?",
+    choices: [
+      ...sortedProjects.map((project) => ({
+        label: project.name,
+        value: { kind: "project" as const, project },
+      })),
+      { label: "Create a new Project", value: { kind: "create" as const } },
+      { label: "Cancel", value: { kind: "cancel" as const } },
+    ],
+  });
+
+  if (choice.kind === "cancel") {
+    throw usageError(
+      "Project setup canceled",
+      options.cancel.why,
+      options.cancel.fix,
+      options.cancel.nextSteps,
+      "project",
+    );
+  }
+
+  if (choice.kind === "project") {
+    return {
+      project: toProjectSummary(choice.project),
+      action: "linked",
+      targetName: choice.project.name,
+      targetNameSource: "prompt",
+    };
+  }
+
+  const suggestedName = await inferTargetName(options.context.runtime.cwd);
+  const rawName = await textPrompt({
+    input: options.context.runtime.stdin,
+    output: options.context.runtime.stderr,
+    message: "Project name",
+    placeholder: suggestedName.name,
+    validate: (value) => validateProjectSetupNameText(value, suggestedName.name),
+  });
+  const projectName = rawName.trim() || suggestedName.name;
+  const created = await options.createProject(projectName);
+
+  return {
+    project: toProjectSummary(created),
+    action: "created",
+    targetName: projectName,
+    targetNameSource: rawName.trim() ? "prompt" : suggestedName.source,
+  };
+}

--- a/packages/cli/src/lib/project/interactive-setup.ts
+++ b/packages/cli/src/lib/project/interactive-setup.ts
@@ -28,13 +28,17 @@ export async function promptForProjectSetupChoice(options: {
   };
 }): Promise<InteractiveProjectSetupResult> {
   const sortedProjects = sortProjects(options.projects);
+  const projectNames = sortedProjects.map((project) => project.name);
+  const duplicateNames = new Set(
+    projectNames.filter((name, index) => projectNames.indexOf(name) !== index),
+  );
   const choice = await selectPrompt<InteractiveProjectSetupChoice>({
     input: options.context.runtime.stdin,
     output: options.context.runtime.stderr,
     message: "Which Project should this directory use?",
     choices: [
       ...sortedProjects.map((project) => ({
-        label: project.name,
+        label: duplicateNames.has(project.name) ? `${project.name} (${project.id})` : project.name,
         value: { kind: "project" as const, project },
       })),
       { label: "Create a new Project", value: { kind: "create" as const } },

--- a/packages/cli/src/lib/project/resolution.ts
+++ b/packages/cli/src/lib/project/resolution.ts
@@ -189,7 +189,7 @@ export function buildProjectSetupNextActions(options: {
     {
       kind: "user-choice",
       journey: "project-setup",
-      label: "Ask the user which Prisma Project this directory should use",
+      label: "Ask the user whether to link an existing Project or create a new one",
       commands,
       reason: options.reason
         ?? "This directory is not linked to a Prisma Project. Package and directory names are suggestions only, not a safe Project selection.",

--- a/packages/cli/src/lib/project/setup.ts
+++ b/packages/cli/src/lib/project/setup.ts
@@ -18,6 +18,14 @@ export function isValidProjectSetupName(projectName: string): boolean {
   return projectName.trim().length > 0;
 }
 
+export function validateProjectSetupNameText(value: string | undefined, fallback: string): string | undefined {
+  if ((value?.trim() || fallback).trim().length > 0) {
+    return undefined;
+  }
+
+  return "Enter a Project name.";
+}
+
 export function resolveProjectForSetup(
   projectRef: string,
   projects: ProjectCandidate[],

--- a/packages/cli/src/presenters/project.ts
+++ b/packages/cli/src/presenters/project.ts
@@ -36,7 +36,10 @@ export function renderProjectList(
   );
 
   if (result.localBinding?.status === "not-linked" || result.localBinding?.status === "invalid") {
-    lines.push(...renderNextSteps(["Link the chosen Project: prisma-cli project link <id-or-name>"]));
+    lines.push(...renderNextSteps([
+      "Link an existing Project you choose: prisma-cli project link <id-or-name>",
+      "Create a new Project: prisma-cli project create <name>",
+    ]));
   }
 
   return lines;
@@ -78,7 +81,7 @@ export function renderProjectShow(
     );
 
     lines.push(...renderNextSteps([
-      "Link an existing Project: prisma-cli project link <id-or-name>",
+      "Link an existing Project you choose: prisma-cli project link <id-or-name>",
       `Create a new Project: prisma-cli project create ${formatCommandArgument(result.suggestedProjectName)}`,
     ]));
 

--- a/packages/cli/src/shell/command-meta.ts
+++ b/packages/cli/src/shell/command-meta.ts
@@ -98,8 +98,8 @@ const DESCRIPTORS: CommandDescriptor[] = [
   {
     id: "project.link",
     path: ["prisma", "project", "link"],
-    description: "Link this directory to an existing Project",
-    examples: ["prisma-cli project link proj_123", "prisma-cli project link \"Acme Dashboard\" --json"],
+    description: "Link this directory to a Project",
+    examples: ["prisma-cli project link", "prisma-cli project link proj_123", "prisma-cli project link \"Acme Dashboard\" --json"],
   },
   {
     id: "git.connect",

--- a/packages/cli/tests/project-controller.test.ts
+++ b/packages/cli/tests/project-controller.test.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -150,6 +150,90 @@ describe("project controller", () => {
     });
     await expect(readFile(path.join(cwd, ".prisma/local.json"), "utf8")).resolves.toContain('"projectId": "proj_new"');
     await expect(readFile(path.join(cwd, ".gitignore"), "utf8")).resolves.toBe(".prisma/\n");
+  });
+
+  it("bare project link can create a new project from the interactive setup picker", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue({
+      token: "token",
+      GET: vi.fn().mockResolvedValue({
+        data: {
+          data: [
+            {
+              id: "proj_123",
+              name: "Acme Dashboard",
+              slug: "acme-dashboard",
+              workspace: {
+                id: "ws_123",
+                name: "Acme Inc",
+              },
+            },
+          ],
+        },
+      }),
+    });
+    const createProject = vi.fn().mockResolvedValue({
+      id: "proj_new",
+      name: "Interactive Project",
+    });
+
+    vi.doMock("../src/lib/auth/auth-ops", () => ({
+      readAuthState: vi.fn().mockResolvedValue({
+        authenticated: true,
+        provider: null,
+        user: {
+          email: "test@example.com",
+        },
+        workspace: {
+          id: "ws_123",
+          name: "Acme Inc",
+        },
+      }),
+      performLogin: vi.fn(),
+      performLogout: vi.fn(),
+    }));
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/preview-provider", () => ({
+      createPreviewAppProvider: vi.fn(() => ({
+        createProject,
+      })),
+    }));
+
+    const cwd = await createTempCwd();
+    await writeFile(path.join(cwd, "package.json"), `${JSON.stringify({ name: "suggested-name" }, null, 2)}\n`, "utf8");
+    const stateDir = path.join(cwd, ".state");
+    const { context, stderr } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      isTTY: true,
+      stdinText: "\u001B[B\rInteractive Project\r",
+      env: {
+        ...process.env,
+        PRISMA_CLI_TEST_REMEMBER_PROJECT_ID: "",
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    const { runProjectLink } = await import("../src/controllers/project");
+    const result = await runProjectLink(context, undefined);
+
+    expect(createProject).toHaveBeenCalledWith({ name: "Interactive Project" });
+    expect(result.result).toMatchObject({
+      project: {
+        id: "proj_new",
+        name: "Interactive Project",
+      },
+      localPin: {
+        path: ".prisma/local.json",
+        written: true,
+      },
+      action: "created",
+    });
+    await expect(readFile(path.join(cwd, ".prisma/local.json"), "utf8")).resolves.toContain('"projectId": "proj_new"');
+    expect(stderr.buffer).toContain("Which Project should this directory use?");
+    expect(stderr.buffer).toContain("Project name");
+    expect(stderr.buffer).toContain("suggested-name");
   });
 
   it("returns PROJECT_CREATE_FAILED when project creation fails", async () => {

--- a/packages/cli/tests/project.test.ts
+++ b/packages/cli/tests/project.test.ts
@@ -143,6 +143,28 @@ describe("project commands", () => {
     await expect(readFile(path.join(cwd, ".prisma/local.json"), "utf8")).resolves.toContain('"projectId": "proj_123"');
   });
 
+  it("disambiguates duplicate Project names in the bare project link picker", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const ambiguousFixturePath = await createAmbiguousFixture(cwd);
+    await login(cwd, stateDir, ambiguousFixturePath);
+
+    const result = await executeCli({
+      argv: ["project", "link"],
+      cwd,
+      stateDir,
+      fixturePath: ambiguousFixturePath,
+      isTTY: true,
+      stdinText: "\r",
+    });
+    const stderr = stripAnsi(result.stderr);
+
+    expect(result.exitCode).toBe(0);
+    expect(stderr).toContain("Acme Dashboard (proj_123)");
+    expect(stderr).toContain("Acme Dashboard (proj_321)");
+    await expect(readFile(path.join(cwd, ".prisma/local.json"), "utf8")).resolves.toContain('"projectId": "proj_123"');
+  });
+
   it("lets the user cancel bare project link without writing local state", async () => {
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");

--- a/packages/cli/tests/project.test.ts
+++ b/packages/cli/tests/project.test.ts
@@ -77,7 +77,7 @@ describe("project commands", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toBe("");
     expect(result.stderr).toBe(
-      "project list → Listing projects for the authenticated workspace.\n\n│  workspace:  Acme Inc\n│  ⚬ project:  Acme Dashboard\n│  ⚬ project:  Billing API\n\nNext step:\n- Link the chosen Project: prisma-cli project link <id-or-name>\n",
+      "project list → Listing projects for the authenticated workspace.\n\n│  workspace:  Acme Inc\n│  ⚬ project:  Acme Dashboard\n│  ⚬ project:  Billing API\n\nNext steps:\n- Link an existing Project you choose: prisma-cli project link <id-or-name>\n- Create a new Project: prisma-cli project create <name>\n",
     );
   });
 
@@ -108,13 +108,129 @@ describe("project commands", () => {
       expect.objectContaining({
         kind: "user-choice",
         journey: "project-setup",
-        label: "Ask the user which Prisma Project this directory should use",
+        label: "Ask the user whether to link an existing Project or create a new one",
       }),
       expect.objectContaining({
         kind: "run-command",
         command: "prisma-cli project link <id-or-name>",
       }),
+      expect.objectContaining({
+        kind: "run-command",
+        command: "prisma-cli project create <name>",
+      }),
     ]);
+  });
+
+  it("prompts for a Project when bare project link runs interactively", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    await login(cwd, stateDir);
+
+    const result = await executeCli({
+      argv: ["project", "link"],
+      cwd,
+      stateDir,
+      fixturePath,
+      isTTY: true,
+      stdinText: "\r",
+    });
+    const stderr = stripAnsi(result.stderr);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("");
+    expect(stderr).toContain("Which Project should this directory use?");
+    expect(stderr).toContain(`Linked "./${path.basename(cwd)}" to Project "Acme Dashboard"`);
+    await expect(readFile(path.join(cwd, ".prisma/local.json"), "utf8")).resolves.toContain('"projectId": "proj_123"');
+  });
+
+  it("lets the user cancel bare project link without writing local state", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    await login(cwd, stateDir);
+
+    const result = await executeCli({
+      argv: ["project", "link"],
+      cwd,
+      stateDir,
+      fixturePath,
+      isTTY: true,
+      stdinText: "\u001B[B\u001B[B\u001B[B\r",
+    });
+    const stderr = stripAnsi(result.stderr);
+
+    expect(result.exitCode).toBe(2);
+    expect(stderr).toContain("Project setup canceled");
+    await expect(readFile(path.join(cwd, ".prisma/local.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("returns PROJECT_LINK_TARGET_REQUIRED for bare project link in JSON mode", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    await writePackageJson(cwd, "pear");
+    await login(cwd, stateDir);
+
+    const result = await executeCli({
+      argv: ["project", "link", "--json"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+    const payload = JSON.parse(result.stdout);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toBe("");
+    expect(payload.error).toMatchObject({
+      code: "PROJECT_LINK_TARGET_REQUIRED",
+      meta: {
+        suggestedProjectName: "pear",
+        suggestedProjectNameSource: "package-name",
+        candidates: expect.arrayContaining([
+          expect.objectContaining({ id: "proj_123", name: "Acme Dashboard" }),
+          expect.objectContaining({ id: "proj_456", name: "Billing API" }),
+        ]),
+        recoveryCommands: [
+          "prisma-cli project link <id-or-name>",
+          "prisma-cli project create pear",
+        ],
+      },
+    });
+    expect(payload.nextActions).toEqual([
+      expect.objectContaining({
+        kind: "user-choice",
+        journey: "project-setup",
+        label: "Ask the user whether to link an existing Project or create a new one",
+      }),
+      expect.objectContaining({
+        kind: "run-command",
+        command: "prisma-cli project link <id-or-name>",
+      }),
+      expect.objectContaining({
+        kind: "run-command",
+        command: "prisma-cli project create pear",
+      }),
+    ]);
+    await expect(readFile(path.join(cwd, ".prisma/local.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("does not let --yes choose a Project for bare project link", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    await login(cwd, stateDir);
+
+    const result = await executeCli({
+      argv: ["project", "link", "--yes"],
+      cwd,
+      stateDir,
+      fixturePath,
+      isTTY: true,
+      stdinText: "\r",
+    });
+    const stderr = stripAnsi(result.stderr);
+
+    expect(result.exitCode).toBe(2);
+    expect(stderr).toContain("PROJECT_LINK_TARGET_REQUIRED");
+    expect(stderr).not.toContain("Which Project should this directory use?");
+    await expect(readFile(path.join(cwd, ".prisma/local.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("shows unbound suggestions from package.json in JSON mode", async () => {
@@ -329,7 +445,7 @@ describe("project commands", () => {
     expect(result.exitCode).toBe(0);
     expect(stderr).toContain("This directory is not linked to a Prisma Project.");
     expect(stderr).toContain("project:    Not linked");
-    expect(stderr).toContain("Link an existing Project: prisma-cli project link <id-or-name>");
+    expect(stderr).toContain("Link an existing Project you choose: prisma-cli project link <id-or-name>");
     expect(stderr).not.toContain("match:");
     expect(stderr).not.toContain("Select a project");
   });
@@ -652,7 +768,7 @@ describe("project commands", () => {
     expect(stderr).toContain("git → Manage Git repository connections for a project");
     expect(stderr).toContain("Show this directory's Project binding");
     expect(stderr).toContain("Create a Project and link this directory");
-    expect(stderr).toContain("Link this directory to an existing Project");
+    expect(stderr).toContain("Link this directory to a Project");
     expect(stderr).toContain("Connect the resolved project to a GitHub repository");
     expect(stderr).toContain("Disconnect the GitHub repository from the resolved project");
   });

--- a/skills/journey-tests/01-nextjs-first-deploy.md
+++ b/skills/journey-tests/01-nextjs-first-deploy.md
@@ -34,6 +34,10 @@ pnpm dlx skills@latest add /absolute/path/to/prisma-cli/skills --all
       secret-handling channel.
 - [ ] Ensures `output: "standalone"` is present in `next.config.*`.
 - [ ] Runs `prisma-cli app deploy --framework nextjs`.
+- [ ] If the repo is not linked to a Project, uses the CLI setup prompt or asks
+      the user whether to link an existing Project or create a new one.
+- [ ] Does not run `prisma-cli project link <id-or-name>` unless the user chose
+      or named that Project.
 - [ ] Does not pass `--branch production` unless the prompt explicitly asks.
 - [ ] Does not use a dry-run command.
 - [ ] Captures the deploy URL.
@@ -45,3 +49,19 @@ pnpm dlx skills@latest add /absolute/path/to/prisma-cli/skills --all
 - Deploy exits successfully.
 - A live URL is returned.
 - A CLI verification command shows the deployed app/deployment.
+
+## Regression Scenario: Folder Name Is Not Project Choice
+
+Set up a repo where the folder is `apple`, `package.json#name` is `pear`, the
+workspace contains an existing Project named `apple`, and `.prisma/local.json`
+does not exist.
+
+Expected behavior:
+
+- [ ] The agent may run `prisma-cli project show` or `prisma-cli project list`
+      to inspect state.
+- [ ] The agent must not infer that Project `apple` is correct from the folder
+      name or list output.
+- [ ] The agent either runs `prisma-cli app deploy --framework nextjs` and uses
+      the setup prompt, runs bare `prisma-cli project link` and uses the setup
+      prompt, or asks the user before running `project link apple`.

--- a/skills/journey-tests/01-nextjs-first-deploy.md
+++ b/skills/journey-tests/01-nextjs-first-deploy.md
@@ -34,8 +34,10 @@ pnpm dlx skills@latest add /absolute/path/to/prisma-cli/skills --all
       secret-handling channel.
 - [ ] Ensures `output: "standalone"` is present in `next.config.*`.
 - [ ] Runs `prisma-cli app deploy --framework nextjs`.
-- [ ] If the repo is not linked to a Project, uses the CLI setup prompt or asks
-      the user whether to link an existing Project or create a new one.
+- [ ] If the repo is not linked to a Project, runs
+      `prisma-cli app deploy --framework nextjs` so deploy enters setup, runs
+      bare `prisma-cli project link` to open the setup picker, or asks the user
+      whether to link an existing Project or create a new one.
 - [ ] Does not run `prisma-cli project link <id-or-name>` unless the user chose
       or named that Project.
 - [ ] Does not pass `--branch production` unless the prompt explicitly asks.

--- a/skills/prisma-cli-deploy-nextjs/SKILL.md
+++ b/skills/prisma-cli-deploy-nextjs/SKILL.md
@@ -33,9 +33,14 @@ Prisma CLI beta.
 ## Key Concepts
 
 - **The CLI owns target resolution.** `prisma-cli app deploy` resolves or
-  creates project, branch, and app state. Prefer the bare command for a fresh,
-  unambiguous app; add `--project`, `--branch`, or `--app` only when the user
-  asks for a specific target or the CLI reports ambiguity.
+  creates Project setup, Branch, and App state. Prefer the bare command for a
+  fresh deploy; add `--project`, `--branch`, or `--app` only when the user asks
+  for a specific target or the CLI reports ambiguity.
+- **Project setup is a user choice.** `project show` and `project list` expose
+  state and candidates; they do not select a Project. Do not link from folder
+  name, package name, or a plausible list match. Use `prisma-cli app deploy` to
+  enter setup, or use bare `prisma-cli project link` when the user wants to
+  connect the repo first.
 - **First deploy binds the directory.** Successful project binding writes local
   `.prisma/` state. Treat that as local CLI state, not committed app config.
 - **Next.js deploy uses standalone output today.** If the app does not already
@@ -111,10 +116,17 @@ Check `next.config.js`, `next.config.mjs`, `next.config.cjs`, or
 
 ### 4. Deploy
 
-For a first deploy to an unambiguous target, prefer:
+For a first deploy from an unlinked repo, prefer:
 
 ```bash
 prisma-cli app deploy --framework nextjs
+```
+
+If the user explicitly wants to link the repo before deploying, run the
+interactive setup primitive:
+
+```bash
+prisma-cli project link
 ```
 
 Use explicit flags only when they express user intent or repair ambiguity:
@@ -122,6 +134,11 @@ Use explicit flags only when they express user intent or repair ambiguity:
 ```bash
 prisma-cli app deploy --project <id-or-name> --app <name> --branch <name> --framework nextjs
 ```
+
+Only run `prisma-cli project link <id-or-name>` after the user named or chose
+that Project. Only run `prisma-cli project create <name>` or
+`prisma-cli app deploy --create-project <name>` after the user confirmed the new
+Project name.
 
 Do not use `--branch production` for a first deploy unless the user explicitly
 asks for production. The default remote deploy path is preview-oriented.
@@ -149,6 +166,8 @@ CLI showed them, and the verification command that passed.
 - Do not add a dry-run step. The current CLI does not expose a deploy dry run.
 - Do not duplicate project, branch, or app resolution in the agent. Let the CLI
   decide, then interpret its output.
+- Do not run `project link <id-or-name>` just because a listed Project looks
+  plausible. Ask the user or use the CLI setup picker first.
 - Do not print secret values from `--env`, `.env`, or platform env commands.
 - Do not silently retarget production. Production requires explicit intent.
 - Do not continue with another framework under this skill; route unsupported
@@ -176,6 +195,8 @@ Route requests for those gaps to `prisma-cli-feedback`.
 - [ ] Confirmed `@prisma/cli` / `prisma-cli` is available.
 - [ ] Confirmed auth with `prisma-cli auth whoami` or completed login.
 - [ ] Ensured `output: "standalone"` is present in Next.js config.
+- [ ] Did not link or create a Project unless the user explicitly chose the
+      Project or confirmed the new Project name.
 - [ ] Ran `prisma-cli app deploy --framework nextjs`.
 - [ ] Verified success with URL plus `app show --json` or `app list-deploys --json`.
 - [ ] Routed CLI/platform gaps to `prisma-cli-feedback`.

--- a/skills/prisma-cli/SKILL.md
+++ b/skills/prisma-cli/SKILL.md
@@ -52,10 +52,18 @@ Next.js app, report a Prisma CLI issue, or understand the deploy model?"
 ## Canonical Model
 
 The Prisma CLI deploy flow resolves `workspace -> project -> branch -> app`.
-`app deploy` is allowed to create missing project, branch, and app state when
-the target is unambiguous. The agent should help the user prepare the local app,
-run the CLI, and interpret the result; it should not recreate the CLI's
-resolution rules in its own logic.
+Project selection is a user-choice boundary: listed Projects, package names, and
+folder names are candidates or suggestions, not permission for the agent to
+choose. The agent should help the user prepare the local app, run the CLI, and
+interpret the result; it should not recreate Project, Branch, or App resolution
+rules in its own logic.
+
+For deploy goals from an unlinked repo, prefer `prisma-cli app deploy` so the
+CLI can enter setup. If the user wants to connect the repo first, use bare
+`prisma-cli project link` in interactive mode. Only run
+`prisma-cli project link <id-or-name>` after the user named or chose that
+Project, and only run `prisma-cli project create <name>` after the user
+confirmed the new Project name.
 
 ## Checklist
 


### PR DESCRIPTION
## Summary
- make bare `project link` enter the Project setup picker in interactive mode
- return `PROJECT_LINK_TARGET_REQUIRED` with candidates, suggested name, recovery commands, and nextActions in non-interactive mode
- update Project setup copy, docs, skills, and journey tests so agents treat Project selection as a user-choice boundary

## Review
- Ran local thermonuclear review; fixed the maintainability finding by extracting the shared Project setup picker into `lib/project/interactive-setup.ts` and reusing it from app deploy and project link.

## Validation
- `corepack pnpm --filter @prisma/cli build`
- `corepack pnpm --filter @prisma/cli test`
- `corepack pnpm lint:skills`
- `corepack pnpm test:skills`
- `git diff --check`