### PR TITLE
fix(deploy) Preview deploy settings before prompting for customization

### DIFF
--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -635,7 +635,8 @@ Behavior:
 - resolves or creates app context inside the resolved branch from `--app`, `PRISMA_APP_ID`, `package.json#name`, or current directory name
 - does not prompt when there is no real choice; zero matching apps creates the inferred app
 - writes `.prisma/local.json` after Project binding succeeds and before build/deploy starts, so retries after a failed deploy do not repeat setup
-- asks `Customize settings? (y/N)` only while binding the directory for the first time, and only asks for Framework and HTTP port when the user opts in
+- before asking `Customize build settings? (y/N)`, previews the detected framework and runtime so the user can see the defaults they are accepting or changing
+- asks `Customize build settings? (y/N)` only while binding the directory for the first time, and only asks for Framework and HTTP port when the user opts in
 - after setup, deploy prints `Deploying to <Project> / <Branch> / <App>`; later deploys print a compact target header such as `Deploying ./j1 to j1 / main / j1`
 - deploy progress uses short stage copy (`Building locally...`, `Built <size>`, `Uploading...`, `Uploaded`, `Deploying...`, `Deployed`) and never prints `Status: running` or `Deployment is running at ...`
 - success human output prints `Live in <duration>`, the URL on its own line, and `Logs   prisma-cli app logs`

--- a/docs/product/output-conventions.md
+++ b/docs/product/output-conventions.md
@@ -290,6 +290,12 @@ After setup, keep the confirmation compact:
 Saved .prisma/local.json
 
 Deploying to Acme Dashboard / feat-login / my-app
+
+Detected Next.js
+│  framework:  Next.js
+│  runtime:    HTTP 3000
+
+? Customize build settings? No
 ```
 
 Deploy progress should describe phases without claiming runtime success before

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -39,7 +39,7 @@ import { requireComputeAuth } from "../lib/auth/guard";
 import { readAuthState } from "../lib/auth/auth-ops";
 import { getApiBaseUrl, SERVICE_TOKEN_ENV_VAR } from "../lib/auth/client";
 import { parseEnvAssignments } from "../lib/app/env-vars";
-import { renderDeployOutputRows } from "../lib/app/deploy-output";
+import { renderDeployOutputRows, renderDeploySettingsPreview } from "../lib/app/deploy-output";
 import {
   DEFAULT_LOCAL_DEV_PORT,
   resolveLocalBuildType,
@@ -2842,10 +2842,15 @@ async function maybeCustomizeDeploySettings(
     };
   }
 
+  maybeRenderDeploySettingsPreview(context, {
+    framework: options.framework,
+    runtime: options.runtime,
+  });
+
   const shouldCustomize = await confirmPrompt({
     input: context.runtime.stdin,
     output: context.runtime.stderr,
-    message: "Customize settings?",
+    message: "Customize build settings?",
     initialValue: false,
   });
 
@@ -2898,6 +2903,26 @@ async function maybeCustomizeDeploySettings(
     framework,
     runtime,
   };
+}
+
+function maybeRenderDeploySettingsPreview(
+  context: CommandContext,
+  options: {
+    framework: ResolvedDeployFramework;
+    runtime: ResolvedDeployRuntime;
+  },
+): void {
+  if (context.flags.quiet || context.flags.json) {
+    return;
+  }
+
+  context.output.stderr.write(
+    `Detected ${options.framework.displayName}\n`
+      + `${renderDeploySettingsPreview(context.ui, [
+        { key: "framework", value: options.framework.displayName },
+        { key: "runtime", value: `HTTP ${options.runtime.port}` },
+      ]).join("\n")}\n\n`,
+  );
 }
 
 function frameworkDisplayName(framework: DeployFramework): string {

--- a/packages/cli/src/lib/app/deploy-output.ts
+++ b/packages/cli/src/lib/app/deploy-output.ts
@@ -6,8 +6,14 @@ export interface DeployOutputRow {
   origin?: string;
 }
 
+export interface DeploySettingsPreviewRow {
+  key: string;
+  value: string;
+}
+
 const DEPLOY_OUTPUT_MIN_LABEL_WIDTH = "Framework".length;
 const DEPLOY_OUTPUT_MIN_VALUE_WIDTH = "HTTP 3000".length;
+const DEPLOY_SETTINGS_MIN_KEY_WIDTH = "framework:".length;
 
 export function renderDeployOutputRows(ui: ShellUi, rows: DeployOutputRow[]): string[] {
   if (rows.length === 0) {
@@ -26,5 +32,19 @@ export function renderDeployOutputRows(ui: ShellUi, rows: DeployOutputRow[]): st
     const value = padDisplay(ui.strong(row.value), valueWidth);
     const origin = row.origin ? `  ${ui.dim(`· ${row.origin}`)}` : "";
     return `  ${label}  ${value}${origin}`.trimEnd();
+  });
+}
+
+export function renderDeploySettingsPreview(ui: ShellUi, rows: DeploySettingsPreviewRow[]): string[] {
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const keyWidth = Math.max(DEPLOY_SETTINGS_MIN_KEY_WIDTH, ...rows.map((row) => `${row.key}:`.length));
+  const rail = ui.dim("│");
+
+  return rows.map((row) => {
+    const key = ui.accent(padDisplay(`${row.key}:`, keyWidth));
+    return `${rail}  ${key}  ${ui.strong(row.value)}`;
   });
 }

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -1733,6 +1733,84 @@ describe("app controller", () => {
     expect(stderr.buffer).toContain(`Linked "./${path.basename(cwd)}" to Project "Acme Dashboard"`);
   });
 
+  it("interactive first deploy previews detected framework and runtime before the customization prompt", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+    const createProject = vi.fn();
+    const listApps = vi.fn().mockResolvedValue([]);
+    const deployApp = vi.fn().mockResolvedValue({
+      projectId: "proj_123",
+      app: {
+        id: "app_new",
+        name: "hello-world",
+        region: "eu-central-1",
+        liveDeploymentId: "dep_123",
+      },
+      deployment: {
+        id: "dep_123",
+        status: "running",
+        url: "https://hello-world.prisma.app",
+      },
+    });
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/preview-provider", () => ({
+      createPreviewAppProvider: vi.fn(() => ({
+        createProject,
+        listApps,
+        deployApp,
+        listDeployments: vi.fn(),
+        showDeployment: vi.fn(),
+      })),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import("./helpers");
+    const { runAppDeploy } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    await writePackageJson(cwd, {
+      name: "hello-world",
+      dependencies: {
+        next: "15.0.0",
+      },
+    });
+    const stateDir = path.join(cwd, ".state");
+    const { context, stderr } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      isTTY: true,
+      stdinText: "\r\r",
+      env: {
+        ...process.env,
+        PRISMA_CLI_TEST_REMEMBER_PROJECT_ID: "",
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await runAppDeploy(context, "hello-world");
+
+    expect(deployApp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        buildType: "nextjs",
+        portMapping: { http: 3000 },
+      }),
+    );
+
+    const targetIndex = stderr.buffer.indexOf("Deploying to Acme Dashboard / main / hello-world");
+    const detectedIndex = stderr.buffer.indexOf("Detected Next.js");
+    const promptIndex = stderr.buffer.indexOf("Customize build settings?");
+
+    expect(targetIndex).toBeGreaterThanOrEqual(0);
+    expect(detectedIndex).toBeGreaterThan(targetIndex);
+    expect(stderr.buffer).toContain("framework:");
+    expect(stderr.buffer).toContain("runtime:");
+    expect(stderr.buffer).toContain("Next.js");
+    expect(stderr.buffer).toContain("HTTP 3000");
+    expect(stderr.buffer).not.toContain("Using deploy settings:");
+    expect(stderr.buffer).not.toContain("build:");
+    expect(promptIndex).toBeGreaterThan(detectedIndex);
+  });
+
   it("interactive first deploy can create a new Project from an editable suggested name", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
     const createProject = vi.fn().mockResolvedValue({


### PR DESCRIPTION
## What changed

- Shows a concise detected deploy settings preview before the first-run customization prompt.
- Compresses the preview to `Detected <framework>` plus framework/runtime rows.
- Renames the prompt to `Customize build settings?` and removes the build command row for now.
- Updates product docs and adds controller coverage for the prompt ordering.

## Why

After Project setup, `app deploy` asked whether users wanted to customize settings before showing what defaults had been detected. The new preview makes the prompt less of a black box while keeping the setup path compact.

## Local review

- Thermonuclear review: pass after aligning prompt copy to the requested UX.
- File-size gate: pass. No changed file crossed 1000 lines; existing large controller/test files grew only in the narrow deploy path and its test.

## Validation

- `pnpm --filter @prisma/cli exec vitest run tests/app-controller.test.ts`
- `pnpm --filter @prisma/cli build`
- `pnpm --filter @prisma/cli test`