### PR TITLE
chore(deps): Bump CLI Node engine floor to 22.12

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ is unclear, update the relevant product doc before changing the command surface.
 
 Requirements:
 
-- Node.js 20 or newer
+- Node.js 22.12 or newer
 - pnpm 10
 
 Install dependencies:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ pnpm prisma app deploy
 
 Requirements:
 
-- Node.js 20+
+- Node.js 22.12 or newer
 - pnpm 10+
 
 Install dependencies:

--- a/docs/onboarding/getting-started.md
+++ b/docs/onboarding/getting-started.md
@@ -4,7 +4,7 @@ This guide gets a local checkout ready for CLI development.
 
 ## Requirements
 
-- Node.js 20 or newer
+- Node.js 22.12 or newer
 - pnpm 10
 
 ## Install

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -113,7 +113,7 @@ the result, and route CLI / Compute feedback to the right Prisma channel.
 
 ## Beta notes
 
-- Requires Node.js 20 or newer.
+- Requires Node.js 22.12 or newer.
 - This is a beta package and may change quickly.
 - Official beta releases publish as `@prisma/cli`.
 - The package binary is `prisma-cli`, not `prisma`, during beta.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22.12.0"
   },
   "keywords": [
     "prisma",


### PR DESCRIPTION
## What changed

- Bumps `@prisma/cli`'s published Node engine floor from `>=20` to `>=22.12.0`.
- Updates the root README, contributor guide, onboarding guide, and package README to match.

## Why

Node 20 reached end of life on 2026-04-30, and newer dependencies increasingly declare Node 22.12+ engine requirements. Using `>=22.12.0` keeps the CLI on a supported runtime floor and avoids dependency update blockers caused by the old Node 20 allowance.

## Validation

- `pnpm test` passed: 32 test files, 291 tests.
- Note: the first sandboxed run failed only because `auth-login` tests could not bind `127.0.0.1` in the sandbox (`listen EPERM`). The same suite passed outside the sandbox.
