### PR TITLE
fix: update compute sdk to 0.22.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.5.0",
-    "@prisma/compute-sdk": "^0.21.0",
+    "@prisma/compute-sdk": "^0.22.0",
     "@prisma/credentials-store": "^7.8.0",
     "@prisma/management-api-sdk": "^1.37.0",
     "c12": "4.0.0-beta.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
       '@prisma/compute-sdk':
-        specifier: ^0.21.0
-        version: 0.21.0(@prisma/management-api-sdk@1.37.0)
+        specifier: ^0.22.0
+        version: 0.22.0(@prisma/management-api-sdk@1.37.0)
       '@prisma/credentials-store':
         specifier: ^7.8.0
         version: 7.8.0
@@ -470,11 +470,11 @@ packages:
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
-  '@prisma/compute-sdk@0.21.0':
-    resolution: {integrity: sha512-l9nmeY7xvwF3UZuGgZpA1CNa0RKPqhNmiM7jGH6IYP5j6/GmOJAaFfs2kGmMcN0TuBnV4z0k9exYcOpuLbjj8Q==}
+  '@prisma/compute-sdk@0.22.0':
+    resolution: {integrity: sha512-kP5DjbCuL+HyEOsLCnrbodtTxwPvcBWADzGHfrL+LFa1DdpbM8Uit7rGH8mN311icD4PgCssyg42W4XWVQ6O0g==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@prisma/management-api-sdk': '>=1.23.0'
+      '@prisma/management-api-sdk': '>=1.36.0'
 
   '@prisma/credentials-store@7.8.0':
     resolution: {integrity: sha512-T9yp5uYSowV2ZRkBeCZrqWFP4REUlxd5WEYgOFJDjZBRRV+zx3VFCBf0zJI7Z3/PYFF9o3+ZzLwokQ9nY5EbqA==}
@@ -1641,7 +1641,7 @@ snapshots:
 
   '@oxc-project/types@0.127.0': {}
 
-  '@prisma/compute-sdk@0.21.0(@prisma/management-api-sdk@1.37.0)':
+  '@prisma/compute-sdk@0.22.0(@prisma/management-api-sdk@1.37.0)':
     dependencies:
       '@prisma/management-api-sdk': 1.37.0
       better-result: 2.9.2


### PR DESCRIPTION
## Summary
- bump `@prisma/compute-sdk` from `^0.21.0` to `^0.22.0`
- update `pnpm-lock.yaml` so the CLI installs SDK `0.22.0`
- fixes the released CLI still sending unsupported `envVars` in deploy version creation payloads

## Verification
- `pnpm --filter @prisma/cli test`
- `pnpm --filter @prisma/cli build`
- live smoke with local built CLI: `app deploy --env DATABASE_URL=... --create-project ... --framework hono --http-port 8080` returned `ok: true`
- smoke deployment root returned `{"message":"hello from create-prisma + hono"}`