### PR TITLE
Add preview environment variable pull command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ pnpm prisma-cli auth login
 pnpm prisma-cli app deploy --env DATABASE_URL=postgresql://example
 pnpm prisma-cli project env add --file .env --role preview
 pnpm prisma-cli project env list --role preview
+pnpm prisma-cli project env pull
 ```
 
 If you want local project scripts that look like the future command shape, add:

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -862,8 +862,9 @@ prisma-cli app deploy --entry src/server.ts --http-port 3000
 Manage durable, platform-stored environment variables for the resolved
 project. The `env` namespace operates on the
 platform-managed `/v1/environment-variables` API; values are stored
-encrypted at rest and **never returned** by the platform — read-back
-is not supported in Beta.
+encrypted at rest. Production values are never returned. Preview values are
+returned only by the explicit local-development pull flow, which writes to a
+local dotenv file and never prints values to terminal or JSON output.
 
 ### Scope flags
 
@@ -976,6 +977,46 @@ Examples:
 prisma-cli project env list
 prisma-cli project env list --role preview
 prisma-cli project env list --branch feature/foo
+```
+
+### `prisma-cli project env pull [output-file] [--role preview | --branch <git-name>]`
+
+Purpose:
+
+- pull preview environment variable values into a local dotenv file for
+  development.
+
+Behavior:
+
+- requires auth and a resolved project; accepts `--project <id-or-name>` as an explicit fallback
+- defaults the output file to `.env.local`
+- optional `output-file` overrides the destination, e.g. `.env`
+- explicit `--role preview` pulls the Project preview map
+- explicit `--branch` pulls the effective preview Branch snapshot: preview
+  defaults plus Branch overrides
+- with no scope and an active local preview Git branch, pulls the matching
+  Platform Branch snapshot when the Branch exists; otherwise pulls the preview
+  map and marks the local branch target as not created yet
+- with no scope on `main`, `production`, or outside a Git branch, pulls the
+  Project preview map
+- `--role production` and production Branch targets fail with
+  `PRODUCTION_ENV_PULL_UNSUPPORTED`
+- refuses to write outside the current project directory
+- refuses to write to a Git-tracked file
+- existing files require interactive confirmation or `--yes`
+- values are written to the local file only; human output and JSON output carry
+  keys, sources, target metadata, and file metadata, never values
+- first CLI implementation depends on the Management API exposing
+  `POST /v1/environment-variables/pull`; missing support returns
+  `FEATURE_UNAVAILABLE`
+
+Examples:
+
+```bash
+prisma-cli project env pull
+prisma-cli project env pull .env
+prisma-cli project env pull --role preview
+prisma-cli project env pull --branch feature/foo
 ```
 
 ### `prisma-cli project env remove KEY (--role <production|preview> | --branch <git-name>)`

--- a/docs/product/resource-model.md
+++ b/docs/product/resource-model.md
@@ -145,6 +145,8 @@ Rules:
   creates a new deployment
 - command output must not print secret values
 - listing variables should show names only
+- pulling preview variables writes values to a local dotenv file only; production
+  values remain write-only
 
 The `env` word is reserved for environment-variable ergonomics. The current
 top-level target-context group is `branch`, not `env`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -60,6 +60,7 @@ npx prisma-cli project env add DATABASE_URL=postgresql://example --role preview
 npx prisma-cli project env add --file .env --role preview
 npx prisma-cli project env list
 npx prisma-cli project env list --role preview
+npx prisma-cli project env pull
 ```
 
 The beta package exposes `prisma-cli` so it can coexist with the existing
@@ -96,7 +97,8 @@ npx prisma-cli app promote <deployment-id>
 - `--no-interactive` and `--yes` for automation.
 - `PRISMA_SERVICE_TOKEN` for headless authenticated commands.
 - Stable command groups, flags, and error codes for scripts and agents.
-- Environment variable values are not printed back to the terminal.
+- Environment variable values are not printed back to the terminal. Preview
+  values can be pulled into a local dotenv file for development.
 
 ### Agent skills
 

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -1,13 +1,15 @@
 import { Command, Option } from "commander";
 
-import { runEnvAdd, runEnvList, runEnvRemove, runEnvUpdate } from "../controllers/app-env";
+import { runEnvAdd, runEnvList, runEnvPull, runEnvRemove, runEnvUpdate } from "../controllers/app-env";
 import {
   renderEnvAdd,
   renderEnvList,
+  renderEnvPull,
   renderEnvRm,
   renderEnvUpdate,
   serializeEnvAdd,
   serializeEnvList,
+  serializeEnvPull,
   serializeEnvRm,
   serializeEnvUpdate,
 } from "../presenters/app-env";
@@ -18,6 +20,7 @@ import { configureRuntimeCommand, type CliRuntime } from "../shell/runtime";
 import type {
   EnvAddResult,
   EnvListResult,
+  EnvPullResult,
   EnvRmResult,
   EnvUpdateResult,
 } from "../types/app-env";
@@ -32,6 +35,7 @@ export function createEnvCommand(runtime: CliRuntime): Command {
   env.addCommand(createEnvAddCommand(runtime));
   env.addCommand(createEnvUpdateCommand(runtime));
   env.addCommand(createEnvListCommand(runtime));
+  env.addCommand(createEnvPullCommand(runtime));
   env.addCommand(createEnvRemoveCommand(runtime));
 
   return env;
@@ -147,6 +151,44 @@ function createEnvListCommand(runtime: CliRuntime): Command {
       {
         renderHuman: (context, descriptor, result) => renderEnvList(context, descriptor, result),
         renderJson: (result) => serializeEnvList(result),
+      },
+    );
+  });
+
+  return command;
+}
+
+function createEnvPullCommand(runtime: CliRuntime): Command {
+  const command = attachCommandDescriptor(
+    configureRuntimeCommand(new Command("pull"), runtime),
+    "project.env.pull",
+  );
+
+  command
+    .argument("[output-file]", "Local dotenv file to write", ".env.local")
+    .addOption(
+      new Option(
+        "--role <role>",
+        "Project template scope",
+      ).choices(["production", "preview"]),
+    )
+    .addOption(new Option("--branch <git-name>", "Preview branch resolved scope"))
+    .addOption(new Option("--project <id-or-name>", "Project id or name"));
+  addGlobalFlags(command);
+
+  command.action(async (outputFile: string, options) => {
+    const roleName = (options as { role?: string }).role;
+    const branchName = (options as { branch?: string }).branch;
+    const projectRef = (options as { project?: string }).project;
+
+    await runCommand<EnvPullResult>(
+      runtime,
+      "project.env.pull",
+      options as Record<string, unknown>,
+      (context) => runEnvPull(context, outputFile, { roleName, branchName, projectRef }),
+      {
+        renderHuman: (context, descriptor, result) => renderEnvPull(context, descriptor, result),
+        renderJson: (result) => serializeEnvPull(result),
       },
     );
   });

--- a/packages/cli/src/controllers/app-env-api.ts
+++ b/packages/cli/src/controllers/app-env-api.ts
@@ -1,7 +1,7 @@
 import type { ManagementApiClient } from "@prisma/management-api-sdk";
 
 import type { EnvVarRole } from "../lib/app/env-config";
-import { authRequiredError, CliError } from "../shell/errors";
+import { authRequiredError, CliError, featureUnavailableError } from "../shell/errors";
 import type { EnvScopeDescriptor, EnvVariableMetadata } from "../types/app-env";
 
 export interface ResolvedEnvApiScope {
@@ -18,12 +18,73 @@ export interface RawEnvironmentVariable {
   updatedAt: string;
 }
 
+export interface RawPulledEnvironmentVariable {
+  key: string;
+  value: string;
+  source: string;
+  isManagedBySystem?: boolean;
+}
+
 interface ApiErrorBody {
   error?: {
     code?: string;
     message?: string;
     hint?: string;
   };
+}
+
+type PullEnvPost = (
+  path: "/v1/environment-variables/pull",
+  options: {
+    body: {
+      projectId: string;
+      class: "preview";
+      branchId?: string;
+    };
+    signal: AbortSignal;
+  },
+) => Promise<{
+  data?: {
+    data?: {
+      variables?: RawPulledEnvironmentVariable[];
+    };
+  };
+  error?: ApiErrorBody;
+  response?: Response;
+}>;
+
+export async function pullPreviewEnvironmentVariables(
+  client: ManagementApiClient,
+  options: {
+    projectId: string;
+    branchId: string | null;
+    signal: AbortSignal;
+  },
+): Promise<RawPulledEnvironmentVariable[]> {
+  const post = client.POST as unknown as PullEnvPost;
+  const { data, error, response } = await post("/v1/environment-variables/pull", {
+    body: {
+      projectId: options.projectId,
+      class: "preview",
+      ...(options.branchId !== null ? { branchId: options.branchId } : {}),
+    },
+    signal: options.signal,
+  });
+
+  if (error || !data?.data?.variables) {
+    if (response?.status === 404 || response?.status === 405 || response?.status === 501) {
+      throw featureUnavailableError(
+        "Preview environment variable pull is not available yet",
+        "The CLI command is ready, but the platform endpoint for returning preview values is not available in this environment.",
+        "Retry after the Management API exposes POST /v1/environment-variables/pull.",
+        ["prisma-cli project env list --role preview"],
+        "app",
+      );
+    }
+    throw apiCallError("Failed to pull preview environment variables", response, error);
+  }
+
+  return [...data.data.variables].sort((left, right) => left.key.localeCompare(right.key));
 }
 
 export async function findVariableByNaturalKey(

--- a/packages/cli/src/controllers/app-env.ts
+++ b/packages/cli/src/controllers/app-env.ts
@@ -8,6 +8,7 @@ import {
   type EnvVarRole,
 } from "../lib/app/env-config";
 import { readEnvFileAssignments, type EnvFileAssignment } from "../lib/app/env-file";
+import { preparePulledEnvFile, writePulledEnvFile } from "../lib/app/env-pull-file";
 import { requireComputeAuth } from "../lib/auth/guard";
 import { readLocalGitBranch } from "../lib/git/local-branch";
 import { authRequiredError, CliError, usageError, workspaceRequiredError } from "../shell/errors";
@@ -18,6 +19,7 @@ import type {
   EnvAddResult,
   EnvListTarget,
   EnvListResult,
+  EnvPullResult,
   EnvRmResult,
   EnvResolvedContext,
   EnvScopeDescriptor,
@@ -26,6 +28,7 @@ import type {
 import {
   apiCallError,
   findVariableByNaturalKey,
+  pullPreviewEnvironmentVariables,
   type RawEnvironmentVariable,
   type ResolvedEnvApiScope,
   toMetadata,
@@ -52,6 +55,12 @@ type ResolvedListScope =
       target: EnvListTarget;
       addScope: EnvScope;
     };
+
+interface ResolvedPullScope {
+  descriptor: EnvScopeDescriptor;
+  target: EnvListTarget;
+  apiTarget: { class: "preview"; branchId: string | null };
+}
 
 interface EnvCommandFlags {
   roleName?: string;
@@ -332,6 +341,44 @@ export async function runEnvList(
   };
 }
 
+export async function runEnvPull(
+  context: CommandContext,
+  outputFile: string,
+  flags: EnvCommandFlags,
+): Promise<CommandSuccess<EnvPullResult>> {
+  const explicit = resolveEnvScope(flags, { requireExplicit: false, command: "pull" });
+  const { client, projectId, verboseContext } = await requireClientAndProject(context, flags.projectRef, "project env pull");
+  const resolved = await resolvePullScopeToApi(client, projectId, explicit ?? undefined, {
+    cwd: context.runtime.cwd,
+    signal: context.runtime.signal,
+  });
+  const fileTarget = await preparePulledEnvFile(context, outputFile);
+  const variables = await pullPreviewEnvironmentVariables(client, {
+    projectId,
+    branchId: resolved.apiTarget.branchId,
+    signal: context.runtime.signal,
+  });
+  const file = await writePulledEnvFile(fileTarget, variables);
+
+  return {
+    command: "project.env.pull",
+    result: {
+      projectId,
+      verboseContext,
+      scope: resolved.descriptor,
+      target: resolved.target,
+      file,
+      variables: variables.map((variable) => ({
+        key: variable.key,
+        source: variable.source,
+        isManagedBySystem: variable.isManagedBySystem === true,
+      })),
+    },
+    warnings: [],
+    nextSteps: [],
+  };
+}
+
 export async function runEnvRemove(
   context: CommandContext,
   key: string | undefined,
@@ -402,6 +449,95 @@ export async function runEnvRemove(
   };
 }
 
+async function resolvePullScopeToApi(
+  client: ManagementApiClient,
+  projectId: string,
+  explicit: EnvScope | undefined,
+  options: { cwd: string; signal: AbortSignal },
+): Promise<ResolvedPullScope> {
+  if (explicit?.kind === "role") {
+    if (explicit.role === "production") {
+      throw productionEnvPullUnsupportedError();
+    }
+    return {
+      descriptor: { kind: "role", role: "preview" },
+      target: {
+        source: "explicit",
+        envMap: "preview",
+      },
+      apiTarget: { class: "preview", branchId: null },
+    };
+  }
+
+  if (explicit?.kind === "branch") {
+    const branch = await resolveExistingBranch(client, projectId, explicit.branchName, options.signal);
+    if (branch.role === "production") {
+      throw productionEnvPullUnsupportedError();
+    }
+    return {
+      descriptor: {
+        kind: "branch",
+        branchName: branch.gitName,
+        branchId: branch.id,
+      },
+      target: {
+        source: "explicit",
+        branchName: branch.gitName,
+        branchId: branch.id,
+        branchRole: branch.role,
+        branchExists: true,
+        envMap: "preview",
+      },
+      apiTarget: { class: "preview", branchId: branch.id },
+    };
+  }
+
+  const gitBranch = await readLocalGitBranch(options.cwd, options.signal);
+  if (gitBranch && !isProductionBranchName(gitBranch)) {
+    const branch = (await listBranchesByName(client, projectId, gitBranch, options.signal))[0];
+    if (branch?.role === "preview") {
+      return {
+        descriptor: {
+          kind: "branch",
+          branchName: branch.gitName,
+          branchId: branch.id,
+        },
+        target: {
+          source: "local-git",
+          branchName: branch.gitName,
+          branchId: branch.id,
+          branchRole: branch.role,
+          branchExists: true,
+          envMap: "preview",
+        },
+        apiTarget: { class: "preview", branchId: branch.id },
+      };
+    }
+
+    return {
+      descriptor: { kind: "role", role: "preview" },
+      target: {
+        source: "local-git",
+        branchName: branch?.gitName ?? gitBranch,
+        branchId: branch?.id,
+        branchRole: branch?.role,
+        branchExists: branch ? true : false,
+        envMap: "preview",
+      },
+      apiTarget: { class: "preview", branchId: null },
+    };
+  }
+
+  return {
+    descriptor: { kind: "role", role: "preview" },
+    target: {
+      source: "overview",
+      envMap: "preview",
+    },
+    apiTarget: { class: "preview", branchId: null },
+  };
+}
+
 async function requireClientAndProject(
   context: CommandContext,
   explicitProject: string | undefined,
@@ -433,6 +569,25 @@ async function requireClientAndProject(
       resolution: target.resolution,
     },
   };
+}
+
+function isProductionBranchName(branchName: string): boolean {
+  return branchName === "main" || branchName === "production";
+}
+
+function productionEnvPullUnsupportedError(): CliError {
+  return new CliError({
+    code: "PRODUCTION_ENV_PULL_UNSUPPORTED",
+    domain: "app",
+    summary: "Production environment values cannot be pulled",
+    why: "Production values are write-only after creation. Only preview values are pullable for local development.",
+    fix: "Pull preview values or a preview Branch snapshot instead.",
+    exitCode: 1,
+    nextSteps: [
+      "prisma-cli project env pull --role preview",
+      "prisma-cli project env pull --branch feature/foo",
+    ],
+  });
 }
 
 async function resolveScopeToApi(

--- a/packages/cli/src/lib/app/env-config.ts
+++ b/packages/cli/src/lib/app/env-config.ts
@@ -13,7 +13,7 @@ export interface ScopeFlagInput {
 
 export interface ScopeOptions {
   requireExplicit: boolean;
-  command: "add" | "update" | "remove" | "list";
+  command: "add" | "update" | "remove" | "list" | "pull";
 }
 
 const VALID_ROLES: ReadonlySet<string> = new Set(["production", "preview"]);

--- a/packages/cli/src/lib/app/env-pull-file.ts
+++ b/packages/cli/src/lib/app/env-pull-file.ts
@@ -1,0 +1,296 @@
+import { execFile } from "node:child_process";
+import { chmod, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import type { RawPulledEnvironmentVariable } from "../../controllers/app-env-api";
+import { CliError, usageError } from "../../shell/errors";
+import { confirmPrompt } from "../../shell/prompt";
+import { canPrompt, type CommandContext } from "../../shell/runtime";
+import { validateKey } from "./env-config";
+
+const execFileAsync = promisify(execFile);
+
+export interface PulledEnvFileWrite {
+  path: string;
+  count: number;
+}
+
+export interface PulledEnvFileTarget {
+  absolutePath: string;
+  relativePath: string;
+}
+
+export async function preparePulledEnvFile(
+  context: CommandContext,
+  outputFile: string,
+): Promise<PulledEnvFileTarget> {
+  const target = resolveOutputFile(context.runtime.cwd, outputFile);
+  await rejectTrackedTarget(context.runtime.cwd, target.relativePath, context.runtime.signal);
+  await ensureParentDirectory(context.runtime.cwd, target.relativePath, target.absolutePath);
+  await confirmOverwriteIfNeeded(context, target.relativePath, target.absolutePath);
+  return target;
+}
+
+export async function writePulledEnvFile(
+  target: PulledEnvFileTarget,
+  variables: RawPulledEnvironmentVariable[],
+): Promise<PulledEnvFileWrite> {
+  await writeFile(target.absolutePath, serializePulledEnvVariables(variables), {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  await chmod(target.absolutePath, 0o600);
+
+  return {
+    path: target.relativePath,
+    count: variables.length,
+  };
+}
+
+export function serializePulledEnvVariables(variables: RawPulledEnvironmentVariable[]): string {
+  const seen = new Set<string>();
+  const lines: string[] = [];
+
+  for (const variable of variables) {
+    validatePulledKey(variable.key);
+    if (seen.has(variable.key)) {
+      throw new CliError({
+        code: "ENV_PULL_DUPLICATE_KEY",
+        domain: "app",
+        summary: `Pulled environment variable "${variable.key}" more than once`,
+        why: "The platform returned duplicate keys for one effective env snapshot.",
+        fix: "Retry after the platform returns one value per key.",
+        exitCode: 1,
+        nextSteps: ["prisma-cli project env list --role preview"],
+      });
+    }
+    seen.add(variable.key);
+    lines.push(`${variable.key}=${formatDotenvValue(variable.value)}`);
+  }
+
+  return `${lines.join("\n")}${lines.length > 0 ? "\n" : ""}`;
+}
+
+function resolveOutputFile(cwd: string, outputFile: string): {
+  absolutePath: string;
+  relativePath: string;
+} {
+  if (outputFile.length === 0) {
+    throw usageError(
+      "prisma-cli project env pull requires a non-empty output file",
+      "The output file positional argument was empty.",
+      "Pass a local dotenv file path, or omit it to use .env.local.",
+      ["prisma-cli project env pull", "prisma-cli project env pull .env"],
+      "app",
+    );
+  }
+
+  const absolutePath = path.resolve(cwd, outputFile);
+  const relativePath = path.relative(cwd, absolutePath) || ".";
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    throw usageError(
+      `Refusing to write env file outside the current project`,
+      `"${outputFile}" resolves outside the current working directory.`,
+      "Choose a path inside the current project.",
+      ["prisma-cli project env pull .env.local"],
+      "app",
+    );
+  }
+
+  return {
+    absolutePath,
+    relativePath,
+  };
+}
+
+async function rejectTrackedTarget(
+  cwd: string,
+  relativePath: string,
+  signal: AbortSignal,
+): Promise<void> {
+  try {
+    await execFileAsync("git", ["ls-files", "--error-unmatch", "--", relativePath], {
+      cwd,
+      signal,
+      timeout: 5_000,
+    });
+  } catch (error) {
+    if (signal.aborted || isAbortError(error)) {
+      throw error;
+    }
+    return;
+  }
+
+  throw new CliError({
+    code: "ENV_PULL_TARGET_TRACKED",
+    domain: "app",
+    summary: `Refusing to write pulled env values to tracked file "${relativePath}"`,
+    why: "Pulled preview values may include secrets, and this file is tracked by Git.",
+    fix: "Choose an ignored local file such as .env.local, or remove the target file from Git tracking first.",
+    exitCode: 1,
+    nextSteps: ["prisma-cli project env pull .env.local"],
+  });
+}
+
+async function ensureParentDirectory(
+  cwd: string,
+  relativePath: string,
+  absolutePath: string,
+): Promise<void> {
+  const parentAbsolutePath = path.dirname(absolutePath);
+  const parentRelativePath = path.relative(cwd, parentAbsolutePath) || ".";
+
+  try {
+    const stats = await stat(parentAbsolutePath);
+    if (!stats.isDirectory()) {
+      throw new CliError({
+        code: "ENV_PULL_PARENT_NOT_DIRECTORY",
+        domain: "app",
+        summary: `Env pull parent "${parentRelativePath}" is not a directory`,
+        why: `The output file "${relativePath}" cannot be created under a non-directory path.`,
+        fix: "Choose a file path inside an existing project directory.",
+        exitCode: 1,
+        nextSteps: ["prisma-cli project env pull .env.local"],
+      });
+    }
+  } catch (error) {
+    if (error instanceof CliError) {
+      throw error;
+    }
+    if (isNodeError(error) && error.code === "ENOENT") {
+      throw new CliError({
+        code: "ENV_PULL_PARENT_MISSING",
+        domain: "app",
+        summary: `Env pull parent "${parentRelativePath}" does not exist`,
+        why: `The output file "${relativePath}" cannot be created before its parent directory exists.`,
+        fix: "Create the parent directory first, or choose another output file.",
+        exitCode: 1,
+        nextSteps: ["prisma-cli project env pull .env.local"],
+      });
+    }
+    throw new CliError({
+      code: "ENV_PULL_PARENT_UNREADABLE",
+      domain: "app",
+      summary: `Could not inspect env pull parent "${parentRelativePath}"`,
+      why: error instanceof Error ? error.message : "The output directory could not be inspected.",
+      fix: "Choose a readable file path inside the current project.",
+      exitCode: 1,
+      nextSteps: ["prisma-cli project env pull .env.local"],
+    });
+  }
+}
+
+async function confirmOverwriteIfNeeded(
+  context: CommandContext,
+  relativePath: string,
+  absolutePath: string,
+): Promise<void> {
+  if (!(await targetFileExists(relativePath, absolutePath))) {
+    return;
+  }
+
+  if (context.flags.yes) {
+    return;
+  }
+
+  if (!canPrompt(context)) {
+    throw new CliError({
+      code: "CONFIRMATION_REQUIRED",
+      domain: "app",
+      summary: `Env pull requires confirmation to overwrite "${relativePath}"`,
+      why: "The target file already exists and the command cannot prompt in the current mode.",
+      fix: "Pass --yes to overwrite it, or choose a different output file.",
+      exitCode: 1,
+      nextSteps: [
+        `prisma-cli project env pull ${relativePath} --yes`,
+        "prisma-cli project env pull .env.local",
+      ],
+    });
+  }
+
+  const shouldOverwrite = await confirmPrompt({
+    input: context.runtime.stdin,
+    output: context.output.stderr,
+    message: `Overwrite ${relativePath}?`,
+    initialValue: false,
+  });
+
+  if (!shouldOverwrite) {
+    throw new CliError({
+      code: "ENV_PULL_CANCELED",
+      domain: "app",
+      summary: `Env pull canceled before overwriting "${relativePath}"`,
+      why: "The existing local env file was left unchanged.",
+      fix: "Choose another output file, or rerun with --yes to overwrite.",
+      exitCode: 1,
+      nextSteps: ["prisma-cli project env pull .env.local"],
+    });
+  }
+}
+
+async function targetFileExists(relativePath: string, absolutePath: string): Promise<boolean> {
+  try {
+    const stats = await stat(absolutePath);
+    if (!stats.isFile()) {
+      throw new CliError({
+        code: "ENV_PULL_TARGET_NOT_FILE",
+        domain: "app",
+        summary: `Env pull target "${relativePath}" is not a file`,
+        why: "The output path already exists but cannot be overwritten as a dotenv file.",
+        fix: "Choose a file path inside the current project.",
+        exitCode: 1,
+        nextSteps: ["prisma-cli project env pull .env.local"],
+      });
+    }
+    return true;
+  } catch (error) {
+    if (error instanceof CliError) {
+      throw error;
+    }
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return false;
+    }
+    throw new CliError({
+      code: "ENV_PULL_TARGET_UNREADABLE",
+      domain: "app",
+      summary: `Could not inspect env pull target "${relativePath}"`,
+      why: error instanceof Error ? error.message : "The output path could not be inspected.",
+      fix: "Choose a readable file path inside the current project.",
+      exitCode: 1,
+      nextSteps: ["prisma-cli project env pull .env.local"],
+    });
+  }
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+function validatePulledKey(key: string): void {
+  try {
+    validateKey(key, "add");
+  } catch {
+    throw new CliError({
+      code: "ENV_PULL_INVALID_KEY",
+      domain: "app",
+      summary: `Pulled environment variable "${key}" is not a valid env-var key`,
+      why: "The platform returned a key that cannot be written to a dotenv file safely.",
+      fix: "Retry after the platform returns POSIX-shaped environment variable keys.",
+      exitCode: 1,
+      nextSteps: [],
+    });
+  }
+}
+
+function formatDotenvValue(value: string): string {
+  if (/^[A-Za-z0-9_./:@+-]+$/.test(value)) {
+    return value;
+  }
+
+  return JSON.stringify(value);
+}

--- a/packages/cli/src/presenters/app-env.ts
+++ b/packages/cli/src/presenters/app-env.ts
@@ -3,6 +3,7 @@ import type { CommandContext } from "../shell/runtime";
 import type {
   EnvAddResult,
   EnvListResult,
+  EnvPullResult,
   EnvRmResult,
   EnvResolvedContext,
   EnvScopeDescriptor,
@@ -22,7 +23,7 @@ function scopeLabel(scope: EnvScopeDescriptor): string {
   return `branch:${scope.branchName ?? scope.branchId ?? "unknown"}`;
 }
 
-function listTargetLabel(result: EnvListResult): string {
+function listTargetLabel(result: EnvListResult | EnvPullResult): string {
   const target = result.target;
   if (target.source === "overview") {
     return "overview";
@@ -36,7 +37,7 @@ function listTargetLabel(result: EnvListResult): string {
   return scopeLabel(result.scope);
 }
 
-type EnvPresenterResult = EnvAddResult | EnvUpdateResult | EnvListResult | EnvRmResult;
+type EnvPresenterResult = EnvAddResult | EnvUpdateResult | EnvListResult | EnvPullResult | EnvRmResult;
 
 function renderEnvVerboseBlocks(
   context: CommandContext,
@@ -282,6 +283,38 @@ export function serializeEnvList(result: EnvListResult) {
     }),
     variables: serializable.variables,
   };
+}
+
+export function renderEnvPull(
+  context: CommandContext,
+  descriptor: CommandDescriptor,
+  result: EnvPullResult,
+): string[] {
+  const lines = renderList(
+    {
+      title: "Pulling preview environment variables into a local file.",
+      descriptor,
+      parentContext: {
+        key: "file",
+        value: `${result.file.path} (${listTargetLabel(result)})`,
+      },
+      items: result.variables.map((variable) => ({
+        noun: "variable",
+        label: `${variable.key} (${variable.source})`,
+        id: variable.key,
+        status: variable.isManagedBySystem ? "default" : null,
+      })),
+      emptyMessage: "No preview environment variables pulled.",
+    },
+    context.ui,
+  );
+  lines.push("Values were written locally and not printed.");
+  lines.push(...renderEnvVerboseBlocks(context, result));
+  return lines;
+}
+
+export function serializeEnvPull(result: EnvPullResult) {
+  return stripVerboseContext(result);
 }
 
 export function renderEnvRm(

--- a/packages/cli/src/shell/command-meta.ts
+++ b/packages/cli/src/shell/command-meta.ts
@@ -310,6 +310,7 @@ const DESCRIPTORS: CommandDescriptor[] = [
       "prisma-cli project env list",
       "prisma-cli project env add STRIPE_KEY=sk_test_xxx --role production",
       "prisma-cli project env add --file .env --role preview",
+      "prisma-cli project env pull",
       "prisma-cli project env add DATABASE_URL=postgresql://branch --branch feature/foo",
       "prisma-cli project env remove STRIPE_KEY --role preview",
     ],
@@ -347,6 +348,17 @@ const DESCRIPTORS: CommandDescriptor[] = [
       "prisma-cli project env list --role production",
       "prisma-cli project env list --role preview",
       "prisma-cli project env list --branch feature/foo",
+    ],
+  },
+  {
+    id: "project.env.pull",
+    path: ["prisma", "project", "env", "pull"],
+    description: "Pull preview environment variable values into a local file.",
+    examples: [
+      "prisma-cli project env pull",
+      "prisma-cli project env pull .env",
+      "prisma-cli project env pull --role preview",
+      "prisma-cli project env pull --branch feature/foo",
     ],
   },
   {

--- a/packages/cli/src/types/app-env.ts
+++ b/packages/cli/src/types/app-env.ts
@@ -30,6 +30,12 @@ export interface EnvVariableMetadata {
   updatedAt: string;
 }
 
+export interface EnvPulledVariableMetadata {
+  key: string;
+  source: string;
+  isManagedBySystem: boolean;
+}
+
 export interface EnvFileMetadata {
   path: string;
   count: number;
@@ -63,6 +69,15 @@ export interface EnvListResult {
   scope: EnvScopeDescriptor;
   target: EnvListTarget;
   variables: EnvVariableMetadata[];
+}
+
+export interface EnvPullResult {
+  projectId: string;
+  verboseContext?: EnvResolvedContext;
+  scope: EnvScopeDescriptor;
+  target: EnvListTarget;
+  file: EnvFileMetadata;
+  variables: EnvPulledVariableMetadata[];
 }
 
 export interface EnvRmResult {

--- a/packages/cli/tests/app-env.test.ts
+++ b/packages/cli/tests/app-env.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -163,6 +163,22 @@ function makeBranchRow(overrides: Partial<{
     role: "preview",
     isDefault: false,
     ...overrides,
+  };
+}
+
+function makePullResponse(variables: Array<{
+  key: string;
+  value: string;
+  source: string;
+  isManagedBySystem?: boolean;
+}>) {
+  return {
+    data: {
+      data: {
+        variables,
+      },
+    },
+    response: { status: 200 },
   };
 }
 
@@ -1397,6 +1413,282 @@ describe("env list", () => {
       { key: "API_URL", id: "envvar_api", source: "preview" },
       { key: "DATABASE_URL", id: "envvar_branch", source: "branch:feature/foo" },
     ]);
+  });
+});
+
+describe("env pull", () => {
+  it("pulls preview values into .env.local by default without returning values", async () => {
+    const client = createMockClient();
+    client.POST.mockResolvedValueOnce(makePullResponse([
+      {
+        key: "DATABASE_URL",
+        value: "postgresql://preview",
+        source: "preview",
+      },
+      {
+        key: "STRIPE_SECRET",
+        value: "sk test value",
+        source: "preview",
+      },
+    ]));
+
+    const { controllers, createTempCwd, createTestCommandContext } =
+      await loadControllers(client, "proj_123");
+    const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
+    const { context } = await createTestCommandContext({ cwd });
+
+    const result = await controllers.runEnvPull(context, ".env.local", {});
+
+    expect(client.POST).toHaveBeenCalledWith(
+      "/v1/environment-variables/pull",
+      expect.objectContaining({
+        body: {
+          projectId: "proj_123",
+          class: "preview",
+        },
+      }),
+    );
+    await expect(readFile(path.join(cwd, ".env.local"), "utf8")).resolves.toBe(
+      'DATABASE_URL=postgresql://preview\nSTRIPE_SECRET="sk test value"\n',
+    );
+    expect(result.result).toMatchObject({
+      projectId: "proj_123",
+      scope: { kind: "role", role: "preview" },
+      target: {
+        source: "overview",
+        envMap: "preview",
+      },
+      file: { path: ".env.local", count: 2 },
+      variables: [
+        { key: "DATABASE_URL", source: "preview", isManagedBySystem: false },
+        { key: "STRIPE_SECRET", source: "preview", isManagedBySystem: false },
+      ],
+    });
+    expect(JSON.stringify(result)).not.toContain("postgresql://preview");
+    expect(JSON.stringify(result)).not.toContain("sk test value");
+  });
+
+  it("pulls a resolved preview branch snapshot into an explicit output file", async () => {
+    const client = createMockClient();
+    client.envGET.mockResolvedValueOnce({
+      data: {
+        data: [makeBranchRow({ id: "br_feature", gitName: "feature/foo", role: "preview" })],
+        pagination: { hasMore: false, nextCursor: null },
+      },
+      response: { status: 200 },
+    });
+    client.POST.mockResolvedValueOnce(makePullResponse([
+      {
+        key: "API_URL",
+        value: "https://api.example",
+        source: "preview",
+      },
+      {
+        key: "DATABASE_URL",
+        value: "postgresql://branch",
+        source: "branch:feature/foo",
+        isManagedBySystem: true,
+      },
+    ]));
+
+    const { controllers, createTempCwd, createTestCommandContext } =
+      await loadControllers(client, "proj_123");
+    const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
+    const { context } = await createTestCommandContext({ cwd });
+
+    const result = await controllers.runEnvPull(context, ".env", {
+      branchName: "feature/foo",
+    });
+
+    expect(client.POST).toHaveBeenCalledWith(
+      "/v1/environment-variables/pull",
+      expect.objectContaining({
+        body: {
+          projectId: "proj_123",
+          class: "preview",
+          branchId: "br_feature",
+        },
+      }),
+    );
+    await expect(readFile(path.join(cwd, ".env"), "utf8")).resolves.toBe(
+      "API_URL=https://api.example\nDATABASE_URL=postgresql://branch\n",
+    );
+    expect(result.result).toMatchObject({
+      scope: {
+        kind: "branch",
+        branchName: "feature/foo",
+        branchId: "br_feature",
+      },
+      target: {
+        source: "explicit",
+        branchName: "feature/foo",
+        branchId: "br_feature",
+        branchRole: "preview",
+        branchExists: true,
+        envMap: "preview",
+      },
+      file: { path: ".env", count: 2 },
+      variables: [
+        { key: "API_URL", source: "preview", isManagedBySystem: false },
+        { key: "DATABASE_URL", source: "branch:feature/foo", isManagedBySystem: true },
+      ],
+    });
+  });
+
+  it("rejects production env pull", async () => {
+    const client = createMockClient();
+    const { controllers, createTempCwd, createTestCommandContext } =
+      await loadControllers(client, "proj_123");
+    const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
+    const { context } = await createTestCommandContext({ cwd });
+
+    await expect(
+      controllers.runEnvPull(context, ".env.local", { roleName: "production" }),
+    ).rejects.toMatchObject({
+      code: "PRODUCTION_ENV_PULL_UNSUPPORTED",
+      summary: "Production environment values cannot be pulled",
+    });
+    expect(client.POST).not.toHaveBeenCalled();
+  });
+
+  it("requires confirmation before overwriting an existing file", async () => {
+    const client = createMockClient();
+    const { controllers, createTempCwd, createTestCommandContext } =
+      await loadControllers(client, "proj_123");
+    const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
+    await writeFile(path.join(cwd, ".env.local"), "EXISTING=value\n", "utf8");
+    const { context } = await createTestCommandContext({ cwd });
+
+    await expect(
+      controllers.runEnvPull(context, ".env.local", {}),
+    ).rejects.toMatchObject({
+      code: "CONFIRMATION_REQUIRED",
+      summary: expect.stringContaining("requires confirmation"),
+    });
+    expect(client.POST).not.toHaveBeenCalled();
+    await expect(readFile(path.join(cwd, ".env.local"), "utf8")).resolves.toBe(
+      "EXISTING=value\n",
+    );
+  });
+
+  it("allows overwriting an existing file with --yes", async () => {
+    const client = createMockClient();
+    client.POST.mockResolvedValueOnce(makePullResponse([
+      { key: "API_URL", value: "https://api.example", source: "preview" },
+    ]));
+
+    const { controllers, createTempCwd, createTestCommandContext } =
+      await loadControllers(client, "proj_123");
+    const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
+    await writeFile(path.join(cwd, ".env.local"), "EXISTING=value\n", "utf8");
+    await chmod(path.join(cwd, ".env.local"), 0o644);
+    const { context } = await createTestCommandContext({
+      cwd,
+      flags: { yes: true },
+    });
+
+    await controllers.runEnvPull(context, ".env.local", {});
+
+    await expect(readFile(path.join(cwd, ".env.local"), "utf8")).resolves.toBe(
+      "API_URL=https://api.example\n",
+    );
+    expect((await stat(path.join(cwd, ".env.local"))).mode & 0o777).toBe(0o600);
+  });
+
+  it("refuses non-file output targets before pulling values", async () => {
+    const client = createMockClient();
+    const { controllers, createTempCwd, createTestCommandContext } =
+      await loadControllers(client, "proj_123");
+    const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
+    await mkdir(path.join(cwd, ".env.local"));
+    const { context } = await createTestCommandContext({
+      cwd,
+      flags: { yes: true },
+    });
+
+    await expect(
+      controllers.runEnvPull(context, ".env.local", {}),
+    ).rejects.toMatchObject({
+      code: "ENV_PULL_TARGET_NOT_FILE",
+      summary: expect.stringContaining("is not a file"),
+    });
+    expect(client.POST).not.toHaveBeenCalled();
+  });
+
+  it("refuses missing parent directories before pulling values", async () => {
+    const client = createMockClient();
+    const { controllers, createTempCwd, createTestCommandContext } =
+      await loadControllers(client, "proj_123");
+    const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
+    const { context } = await createTestCommandContext({
+      cwd,
+      flags: { yes: true },
+    });
+
+    await expect(
+      controllers.runEnvPull(context, "missing/.env.local", {}),
+    ).rejects.toMatchObject({
+      code: "ENV_PULL_PARENT_MISSING",
+      summary: expect.stringContaining("does not exist"),
+    });
+    expect(client.POST).not.toHaveBeenCalled();
+  });
+
+  it("refuses to write pulled values into a tracked git file", async () => {
+    const client = createMockClient();
+    const { controllers, createTempCwd, createTestCommandContext } =
+      await loadControllers(client, "proj_123");
+    const stateDir = path.join(await createTempCwd(), ".state");
+    const { context } = await createTestCommandContext({
+      cwd: process.cwd(),
+      stateDir,
+      flags: { yes: true },
+    });
+
+    await expect(
+      controllers.runEnvPull(context, "package.json", {
+        roleName: "preview",
+        projectRef: "proj_123",
+      }),
+    ).rejects.toMatchObject({
+      code: "ENV_PULL_TARGET_TRACKED",
+      summary: expect.stringContaining("tracked file"),
+    });
+    expect(client.POST).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a clear unavailable error when the pull endpoint is missing", async () => {
+    const client = createMockClient();
+    client.POST.mockResolvedValueOnce({
+      error: {
+        error: {
+          code: "NOT_FOUND",
+          message: "Route not found.",
+        },
+      },
+      response: { status: 404 },
+    });
+
+    const { controllers, createTempCwd, createTestCommandContext } =
+      await loadControllers(client, "proj_123");
+    const cwd = await createTempCwd();
+    await writeLocalPin(cwd);
+    const { context } = await createTestCommandContext({ cwd });
+
+    await expect(
+      controllers.runEnvPull(context, ".env.local", {}),
+    ).rejects.toMatchObject({
+      code: "FEATURE_UNAVAILABLE",
+      summary: "Preview environment variable pull is not available yet",
+    });
+    await expect(readFile(path.join(cwd, ".env.local"), "utf8")).rejects.toThrow();
   });
 });
 

--- a/packages/cli/tests/app.test.ts
+++ b/packages/cli/tests/app.test.ts
@@ -241,6 +241,35 @@ describe("app commands", () => {
     expect(listEnv.stderr).toContain("unknown command");
   });
 
+  it("shows the documented help text for project env pull", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+
+    const envHelp = await executeCli({
+      argv: ["project", "env", "--help"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+    const pullHelp = await executeCli({
+      argv: ["project", "env", "pull", "--help"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+
+    expect(envHelp.exitCode).toBe(0);
+    expect(envHelp.stderr).toContain("pull");
+    expect(envHelp.stderr).toContain("pull [output-file]");
+    expect(envHelp.stderr).toContain("$ prisma-cli project env pull");
+
+    expect(pullHelp.exitCode).toBe(0);
+    expect(pullHelp.stderr).toContain("Pull preview environment variable values into a local file");
+    expect(pullHelp.stderr).toContain("--role <role>");
+    expect(pullHelp.stderr).toContain("--branch <git-name>");
+    expect(pullHelp.stderr).toContain("$ prisma-cli project env pull .env");
+  });
+
   it("rejects mutually exclusive deploy database flags", async () => {
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");


### PR DESCRIPTION
## Overview
Adds a CLI-only first slice for pulling preview environment variables into a local dotenv file. This lets local development use platform preview values without printing secret values to terminal or JSON output.

## Changes
- Adds `project env pull [output-file]` with `--role preview`, `--branch`, `--project`, default `.env.local`, and command/help metadata.
- Wires the command to the future `POST /v1/environment-variables/pull` endpoint and returns `FEATURE_UNAVAILABLE` when that endpoint is not available.
- Adds file safety in `packages/cli/src/lib/app/env-pull-file.ts`: rejects tracked files, outside paths, non-file targets, and missing parents; requires confirmation or `--yes`; writes dotenv output with `0600` permissions.
- Updates product docs/readmes and tests role, branch, overwrite, tracked-file, missing-endpoint, and no-value-leak paths.

## Why
Preview values are local dev/test configuration, so the CLI can pull them only through an explicit file-writing command. Production values remain write-only. Keeping the API call behind a small wrapper lets this CLI-only PR land before backend support is available.

## Validation
- `pnpm --filter @prisma/cli exec vitest run tests/app-env.test.ts tests/app.test.ts --reporter=verbose`
- `pnpm build:cli`
- `pnpm --filter @prisma/cli test` outside the sandbox because auth tests bind `127.0.0.1`
- `git diff --check`
- Local review skills: `tmp-code-review`, `thermonuclear-review`