### PR TITLE
Adopt typed result errors for project resolution

### DIFF
--- a/.agents/diary/better-result-phase-3.md
+++ b/.agents/diary/better-result-phase-3.md
@@ -1,1 +1,3 @@
-+ Scope tangent worth pursuing later: Package typecheck now runs after installing dependencies, but it reports unrelated existing errors in `branch-database.ts`, test helper typings, project real-mode mock types, and script module declarations. I did not fix these because phase 3 is limited to project resolution domain errors.
+# Better Result Phase 3
+
+Scope tangent worth pursuing later: Package typecheck now runs after installing dependencies, but it reports unrelated existing errors in `branch-database.ts`, test helper typings, project real-mode mock types, and script module declarations. I did not fix these because phase 3 is limited to project resolution domain errors.

--- a/.agents/diary/better-result-phase-3.md
+++ b/.agents/diary/better-result-phase-3.md
@@ -1,0 +1,1 @@
++ Scope tangent worth pursuing later: Package typecheck now runs after installing dependencies, but it reports unrelated existing errors in `branch-database.ts`, test helper typings, project real-mode mock types, and script module declarations. I did not fix these because phase 3 is limited to project resolution domain errors.

--- a/.agents/projects/better-result-error-handling.plan.md
+++ b/.agents/projects/better-result-error-handling.plan.md
@@ -69,7 +69,7 @@ None.
 
 ### Phase 3: Project Resolution Domain Errors
 
-**Status:** ☐ Not started
+**Status:** ✓ Complete; full package typecheck blocked by unrelated existing errors
 
 **Goal:** Convert project target resolution failures from thrown `CliError` helpers to typed project-domain failures.
 
@@ -87,10 +87,10 @@ None.
 
 **Acceptance Criteria:**
 
-- Migrated project resolution APIs expose typed results rather than throwing expected `CliError` instances.
-- Existing project-related structured error codes and recovery guidance remain stable.
-- `pnpm --filter @prisma/cli exec tsc -p tsconfig.json` passes.
-- Project resolution and project show/list tests pass.
+- [x] Migrated project resolution APIs expose typed results rather than throwing expected `CliError` instances.
+- [x] Existing project-related structured error codes and recovery guidance remain stable.
+- [ ] `pnpm --filter @prisma/cli exec tsc -p tsconfig.json` passes. Blocked by unrelated existing errors in database/test typing surfaces.
+- [x] Project resolution and project show/list tests pass.
 
 ### Phase 4: Project Setup Validation And Creation Errors
 

--- a/packages/cli/src/controllers/app-env.ts
+++ b/packages/cli/src/controllers/app-env.ts
@@ -13,7 +13,7 @@ import { readLocalGitBranch } from "../lib/git/local-branch";
 import { authRequiredError, CliError, usageError, workspaceRequiredError } from "../shell/errors";
 import type { CommandSuccess } from "../shell/output";
 import type { CommandContext } from "../shell/runtime";
-import { resolveProjectTarget } from "../lib/project/resolution";
+import { projectResolutionErrorToCliError, resolveProjectTarget } from "../lib/project/resolution";
 import type {
   EnvAddResult,
   EnvListTarget,
@@ -416,13 +416,17 @@ async function requireClientAndProject(
     throw workspaceRequiredError();
   }
 
-  const target = await resolveProjectTarget({
+  const targetResult = await resolveProjectTarget({
     context,
     workspace: authState.workspace,
     explicitProject,
     listProjects: () => listRealWorkspaceProjects(client, authState.workspace!, context.runtime.signal),
     commandName,
   });
+  if (targetResult.isErr()) {
+    throw projectResolutionErrorToCliError(targetResult.error);
+  }
+  const target = targetResult.value;
 
   return {
     client,

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -52,6 +52,7 @@ import {
   buildProjectSetupNextActions,
   inferTargetName,
   projectNotFoundError,
+  projectResolutionErrorToCliError,
   resolveDurablePlatformMapping,
   resolveProjectTarget,
   type InferredTargetName,
@@ -2330,7 +2331,7 @@ async function resolveProjectContext(
     throw workspaceRequiredError();
   }
 
-  const resolved = await resolveProjectTarget({
+  const resolvedResult = await resolveProjectTarget({
     context,
     workspace: authState.workspace,
     explicitProject,
@@ -2338,6 +2339,10 @@ async function resolveProjectContext(
     listProjects: () => listRealWorkspaceProjects(client, authState.workspace!, context.runtime.signal),
     commandName: options?.commandName,
   });
+  if (resolvedResult.isErr()) {
+    throw projectResolutionErrorToCliError(resolvedResult.error);
+  }
+  const resolved = resolvedResult.value;
   const branch = options?.branch ?? await resolveDeployBranch(context, undefined);
 
   return {

--- a/packages/cli/src/controllers/branch.ts
+++ b/packages/cli/src/controllers/branch.ts
@@ -7,10 +7,9 @@ import type { BranchListResult, BranchRole, BranchSummary } from "../types/branc
 import { createCliUseCaseGateways } from "../use-cases/create-cli-gateways";
 import { createBranchUseCases } from "../use-cases/branch";
 import { requireComputeAuth } from "../lib/auth/guard";
-import { resolveProjectTarget } from "../lib/project/resolution";
+import { projectResolutionErrorToCliError, resolveProjectTarget } from "../lib/project/resolution";
 import { requireAuthenticatedAuthState } from "./auth";
 import { listRealWorkspaceProjects } from "./project";
-import { createSelectPromptPort } from "./select-prompt-port";
 
 function isRealMode(context: CommandContext): boolean {
   return !context.runtime.fixturePath && !context.runtime.env.PRISMA_CLI_MOCK_FIXTURE_PATH;
@@ -55,13 +54,15 @@ async function listRealBranches(context: CommandContext): Promise<BranchListResu
     throw workspaceRequiredError();
   }
 
-  const target = await resolveProjectTarget({
+  const targetResult = await resolveProjectTarget({
     context,
     workspace,
     listProjects: () => listRealWorkspaceProjects(client, workspace, context.runtime.signal),
-    prompt: createSelectPromptPort(context),
-    remember: true,
   });
+  if (targetResult.isErr()) {
+    throw projectResolutionErrorToCliError(targetResult.error);
+  }
+  const target = targetResult.value;
 
   const branches = await listBranches(client, target.project.id, context.runtime.signal);
 

--- a/packages/cli/src/controllers/database.ts
+++ b/packages/cli/src/controllers/database.ts
@@ -7,7 +7,7 @@ import {
   normalizeDatabase,
   type DatabaseProvider,
 } from "../lib/database/provider";
-import { resolveProjectTarget, type ResolvedProjectTarget } from "../lib/project/resolution";
+import { projectResolutionErrorToCliError, resolveProjectTarget, type ResolvedProjectTarget } from "../lib/project/resolution";
 import { authRequiredError, CliError, usageError, workspaceRequiredError } from "../shell/errors";
 import type { CommandSuccess } from "../shell/output";
 import type { CommandContext } from "../shell/runtime";
@@ -277,31 +277,37 @@ async function requireDatabaseContext(
       throw authRequiredError();
     }
 
-    const target = await resolveProjectTarget({
+    const targetResult = await resolveProjectTarget({
       context,
       workspace,
       explicitProject: flags.projectRef,
       listProjects: () => listRealWorkspaceProjects(client, workspace, context.runtime.signal),
       commandName,
     });
+    if (targetResult.isErr()) {
+      throw projectResolutionErrorToCliError(targetResult.error);
+    }
 
     return {
       provider: createManagementDatabaseProvider(client),
-      target,
+      target: targetResult.value,
     };
   }
 
-  const target = await resolveProjectTarget({
+  const targetResult = await resolveProjectTarget({
     context,
     workspace,
     explicitProject: flags.projectRef,
     listProjects: async () => listFixtureWorkspaceProjects(context, workspace),
     commandName,
   });
+  if (targetResult.isErr()) {
+    throw projectResolutionErrorToCliError(targetResult.error);
+  }
 
   return {
     provider: createFixtureDatabaseProvider(context),
-    target,
+    target: targetResult.value,
   };
 }
 

--- a/packages/cli/src/controllers/project.ts
+++ b/packages/cli/src/controllers/project.ts
@@ -12,6 +12,7 @@ import {
   buildProjectSetupNextActions,
   inferTargetName,
   inspectProjectBinding,
+  projectResolutionErrorToCliError,
   resolveProjectTarget,
   sortProjects,
   type ProjectCandidate,
@@ -563,13 +564,17 @@ async function resolveProjectShowInRealMode(
     throw authRequiredError();
   }
 
-  return inspectProjectBinding({
+  const result = await inspectProjectBinding({
     context,
     workspace,
     explicitProject,
     listProjects: () => listRealWorkspaceProjects(client, workspace, context.runtime.signal),
     commandName: "project show",
   });
+  if (result.isErr()) {
+    throw projectResolutionErrorToCliError(result.error);
+  }
+  return result.value;
 }
 
 async function resolveRequiredProjectInRealMode(
@@ -583,13 +588,17 @@ async function resolveRequiredProjectInRealMode(
     throw authRequiredError();
   }
 
-  return resolveProjectTarget({
+  const result = await resolveProjectTarget({
     context,
     workspace,
     explicitProject,
     listProjects: () => listRealWorkspaceProjects(client, workspace, context.runtime.signal),
     commandName,
   });
+  if (result.isErr()) {
+    throw projectResolutionErrorToCliError(result.error);
+  }
+  return result.value;
 }
 
 async function resolveProjectShowInFixtureMode(
@@ -597,13 +606,17 @@ async function resolveProjectShowInFixtureMode(
   workspace: AuthWorkspace,
   explicitProject: string | undefined,
 ): Promise<ProjectShowResult> {
-  return inspectProjectBinding({
+  const result = await inspectProjectBinding({
     context,
     workspace,
     explicitProject,
     listProjects: async () => listFixtureWorkspaceProjects(context, workspace),
     commandName: "project show",
   });
+  if (result.isErr()) {
+    throw projectResolutionErrorToCliError(result.error);
+  }
+  return result.value;
 }
 
 async function resolveRequiredProjectInFixtureMode(
@@ -612,13 +625,17 @@ async function resolveRequiredProjectInFixtureMode(
   explicitProject: string | undefined,
   commandName: string,
 ): Promise<ResolvedProjectTarget> {
-  return resolveProjectTarget({
+  const result = await resolveProjectTarget({
     context,
     workspace,
     explicitProject,
     listProjects: async () => listFixtureWorkspaceProjects(context, workspace),
     commandName,
   });
+  if (result.isErr()) {
+    throw projectResolutionErrorToCliError(result.error);
+  }
+  return result.value;
 }
 
 export async function listRealWorkspaceProjects(

--- a/packages/cli/src/lib/project/resolution.ts
+++ b/packages/cli/src/lib/project/resolution.ts
@@ -277,6 +277,12 @@ function localProjectWorkspaceMismatchCliError(options: {
   });
 }
 
+/**
+ * Converts expected project-resolution variants to command-boundary CliErrors.
+ * `LocalResolutionPinReadAbortedError` and `UnhandledException` intentionally
+ * propagate as exceptions; callers such as `resolveProjectShowInRealMode`
+ * throw this helper's result, so passthrough variants should keep bubbling.
+ */
 export function projectResolutionErrorToCliError(error: ProjectResolutionError): CliError {
   return matchError(error, {
     ProjectNotFoundError: (error) => projectNotFoundCliError(error.projectRef, error.workspace),

--- a/packages/cli/src/lib/project/resolution.ts
+++ b/packages/cli/src/lib/project/resolution.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
-import { matchError } from "better-result";
+import { Result, TaggedError, UnhandledException, matchError } from "better-result";
 
 import { formatCommandArgument } from "../../shell/command-arguments";
 import { CliError } from "../../shell/errors";
@@ -18,6 +18,7 @@ import type {
 } from "../../types/project";
 import {
   LOCAL_RESOLUTION_PIN_RELATIVE_PATH,
+  LocalResolutionPinReadAbortedError,
   type LocalResolutionPinReadError,
   type LocalResolutionPinReadResult,
   readLocalResolutionPin,
@@ -30,6 +31,92 @@ export interface ProjectCandidate extends ProjectSummary {
 
 export type ResolvedProjectTarget = BoundProjectShowResult;
 type BoundProjectSource = Exclude<ProjectSource, "unbound">;
+
+export class ProjectNotFoundError extends TaggedError("ProjectNotFoundError")<{
+  message: string;
+  projectRef: string;
+  workspace: AuthWorkspace;
+}>() {
+  constructor(projectRef: string, workspace: AuthWorkspace) {
+    super({
+      message: `Project "${projectRef}" was not found in workspace "${workspace.name}".`,
+      projectRef,
+      workspace,
+    });
+  }
+}
+
+export class ProjectAmbiguousError extends TaggedError("ProjectAmbiguousError")<{
+  message: string;
+  projectRef: string | null;
+  matches: ProjectCandidate[];
+}>() {
+  constructor(projectRef: string | null, matches: ProjectCandidate[]) {
+    super({
+      message: projectRef
+        ? `Multiple projects matched "${projectRef}".`
+        : "Multiple projects matched the current directory context.",
+      projectRef,
+      matches,
+    });
+  }
+}
+
+export class LocalStateStaleError extends TaggedError("LocalStateStaleError")<{
+  message: string;
+  pinPath: string;
+}>() {
+  constructor() {
+    super({
+      message: `The target recorded in ${LOCAL_RESOLUTION_PIN_RELATIVE_PATH} is no longer available in the selected workspace.`,
+      pinPath: LOCAL_RESOLUTION_PIN_RELATIVE_PATH,
+    });
+  }
+}
+
+export class LocalProjectWorkspaceMismatchError extends TaggedError("LocalProjectWorkspaceMismatchError")<{
+  message: string;
+  pinnedWorkspaceId: string;
+  pinnedProjectId: string;
+  activeWorkspace: AuthWorkspace;
+}>() {
+  constructor(options: {
+    pinnedWorkspaceId: string;
+    pinnedProjectId: string;
+    activeWorkspace: AuthWorkspace;
+  }) {
+    super({
+      message: `${LOCAL_RESOLUTION_PIN_RELATIVE_PATH} links this directory to project ${options.pinnedProjectId} in workspace ${options.pinnedWorkspaceId}, but the active workspace is "${options.activeWorkspace.name}" (${options.activeWorkspace.id}).`,
+      pinnedWorkspaceId: options.pinnedWorkspaceId,
+      pinnedProjectId: options.pinnedProjectId,
+      activeWorkspace: options.activeWorkspace,
+    });
+  }
+}
+
+export class ProjectSetupRequiredError extends TaggedError("ProjectSetupRequiredError")<{
+  message: string;
+  commandName?: string;
+  suggestion: ProjectSetupSuggestion;
+}>() {
+  constructor(options: { commandName?: string; suggestion: ProjectSetupSuggestion }) {
+    const commandLabel = options.commandName ? `prisma-cli ${options.commandName}` : "this command";
+    super({
+      message: `This directory is not linked to a Prisma Project, and ${commandLabel} will not choose one from package or directory names.`,
+      commandName: options.commandName,
+      suggestion: options.suggestion,
+    });
+  }
+}
+
+export type ProjectResolutionError =
+  | ProjectNotFoundError
+  | ProjectAmbiguousError
+  | ProjectSetupRequiredError
+  | LocalStateStaleError
+  | LocalProjectWorkspaceMismatchError
+  | LocalResolutionPinReadAbortedError
+  | UnhandledException;
 
 export type InferredTargetNameSource = "package-name" | "directory-name";
 
@@ -47,51 +134,59 @@ export interface ResolveProjectOptions {
   listProjects(): Promise<ProjectCandidate[]>;
 }
 
-export async function resolveProjectTarget(options: ResolveProjectOptions): Promise<ResolvedProjectTarget> {
-  const localPin = await readImplicitLocalPin(options, { allowEnvProjectId: true });
-  const projects = await options.listProjects();
-  const target = await resolveBoundProjectTarget(options, projects, { allowEnvProjectId: true, localPin });
+export async function resolveProjectTarget(options: ResolveProjectOptions): Promise<Result<ResolvedProjectTarget, ProjectResolutionError>> {
+  return Result.gen(async function* () {
+    const localPin = yield* Result.await(readImplicitLocalPin(options, { allowEnvProjectId: true }));
+    const projects = await options.listProjects();
+    const target = yield* Result.await(resolveBoundProjectTarget(options, projects, { allowEnvProjectId: true, localPin }));
 
-  if (target) {
-    return target;
-  }
+    if (target) {
+      return Result.ok(target);
+    }
 
-  throw await projectSetupRequiredError({
-    cwd: options.context.runtime.cwd,
-    projects,
-    commandName: options.commandName,
-    signal: options.context.runtime.signal,
+    return Result.err(await projectSetupRequiredError({
+      cwd: options.context.runtime.cwd,
+      projects,
+      commandName: options.commandName,
+      signal: options.context.runtime.signal,
+    }));
   });
 }
 
-export async function inspectProjectBinding(options: ResolveProjectOptions): Promise<ProjectShowResult> {
-  const localPin = await readImplicitLocalPin(options, { allowEnvProjectId: false });
-  const projects = await options.listProjects();
-  const target = await resolveBoundProjectTarget(options, projects, { allowEnvProjectId: false, localPin });
+export async function inspectProjectBinding(options: ResolveProjectOptions): Promise<Result<ProjectShowResult, ProjectResolutionError>> {
+  return Result.gen(async function* () {
+    const localPin = yield* Result.await(readImplicitLocalPin(options, { allowEnvProjectId: false }));
+    const projects = await options.listProjects();
+    const target = yield* Result.await(resolveBoundProjectTarget(options, projects, { allowEnvProjectId: false, localPin }));
 
-  if (target) {
-    return target;
-  }
+    if (target) {
+      return Result.ok(target);
+    }
 
-  return {
-    workspace: options.workspace,
-    project: null,
-    localBinding: {
-      status: "not-linked",
-    },
-    resolution: {
-      projectSource: "unbound",
-    },
-    ...await buildProjectSetupSuggestion({
-      cwd: options.context.runtime.cwd,
-      projects,
-      commandName: options.commandName ?? "project show",
-      signal: options.context.runtime.signal,
-    }),
-  };
+    return Result.ok({
+      workspace: options.workspace,
+      project: null,
+      localBinding: {
+        status: "not-linked",
+      },
+      resolution: {
+        projectSource: "unbound",
+      },
+      ...await buildProjectSetupSuggestion({
+        cwd: options.context.runtime.cwd,
+        projects,
+        commandName: options.commandName ?? "project show",
+        signal: options.context.runtime.signal,
+      }),
+    } satisfies ProjectShowResult);
+  });
 }
 
 export function projectNotFoundError(projectRef: string, workspace: AuthWorkspace): CliError {
+  return projectResolutionErrorToCliError(new ProjectNotFoundError(projectRef, workspace));
+}
+
+function projectNotFoundCliError(projectRef: string, workspace: AuthWorkspace): CliError {
   return new CliError({
     code: "PROJECT_NOT_FOUND",
     domain: "project",
@@ -104,6 +199,10 @@ export function projectNotFoundError(projectRef: string, workspace: AuthWorkspac
 }
 
 export function projectAmbiguousError(projectRef: string | null, matches: ProjectCandidate[]): CliError {
+  return projectResolutionErrorToCliError(new ProjectAmbiguousError(projectRef, matches));
+}
+
+function projectAmbiguousCliError(projectRef: string | null, matches: ProjectCandidate[]): CliError {
   const firstMatch = matches[0];
   const nextSteps = ["prisma-cli project list"];
   if (firstMatch) {
@@ -129,6 +228,10 @@ export function projectAmbiguousError(projectRef: string | null, matches: Projec
 }
 
 export function localStateStaleError(): CliError {
+  return projectResolutionErrorToCliError(new LocalStateStaleError());
+}
+
+function localStateStaleCliError(): CliError {
   return new CliError({
     code: "LOCAL_STATE_STALE",
     domain: "project",
@@ -148,6 +251,14 @@ export function localProjectWorkspaceMismatchError(options: {
   pinnedProjectId: string;
   activeWorkspace: AuthWorkspace;
 }): CliError {
+  return projectResolutionErrorToCliError(new LocalProjectWorkspaceMismatchError(options));
+}
+
+function localProjectWorkspaceMismatchCliError(options: {
+  pinnedWorkspaceId: string;
+  pinnedProjectId: string;
+  activeWorkspace: AuthWorkspace;
+}): CliError {
   return new CliError({
     code: "LOCAL_PROJECT_WORKSPACE_MISMATCH",
     domain: "project",
@@ -163,6 +274,26 @@ export function localProjectWorkspaceMismatchError(options: {
     },
     exitCode: 1,
     nextSteps: ["prisma-cli auth login", "prisma-cli project list", "prisma-cli project link <id-or-name>"],
+  });
+}
+
+export function projectResolutionErrorToCliError(error: ProjectResolutionError): CliError {
+  return matchError(error, {
+    ProjectNotFoundError: (error) => projectNotFoundCliError(error.projectRef, error.workspace),
+    ProjectAmbiguousError: (error) => projectAmbiguousCliError(error.projectRef, error.matches),
+    ProjectSetupRequiredError: (error) => projectSetupRequiredCliError(error),
+    LocalStateStaleError: () => localStateStaleCliError(),
+    LocalProjectWorkspaceMismatchError: (error) => localProjectWorkspaceMismatchCliError({
+      pinnedWorkspaceId: error.pinnedWorkspaceId,
+      pinnedProjectId: error.pinnedProjectId,
+      activeWorkspace: error.activeWorkspace,
+    }),
+    LocalResolutionPinReadAbortedError: (error) => {
+      throw error;
+    },
+    UnhandledException: (error) => {
+      throw error;
+    },
   });
 }
 
@@ -190,21 +321,24 @@ export async function projectSetupRequiredError(options: {
   projects: ProjectCandidate[];
   commandName?: string;
   signal?: AbortSignal;
-}): Promise<CliError> {
+}): Promise<ProjectSetupRequiredError> {
   const suggestion = await buildProjectSetupSuggestion(options);
-  const commandLabel = options.commandName ? `prisma-cli ${options.commandName}` : "this command";
+  return new ProjectSetupRequiredError({ commandName: options.commandName, suggestion });
+}
 
+function projectSetupRequiredCliError(error: ProjectSetupRequiredError): CliError {
+  const suggestion = error.suggestion;
   return new CliError({
     code: "PROJECT_SETUP_REQUIRED",
     domain: "project",
     summary: "Choose a Project before running this command",
-    why: `This directory is not linked to a Prisma Project, and ${commandLabel} will not choose one from package or directory names.`,
+    why: error.message,
     fix: "Link the directory to an existing Project, or pass --project <id-or-name> for this command.",
     meta: { ...suggestion },
     exitCode: 1,
     nextSteps: ["prisma-cli project list", ...suggestion.recoveryCommands],
     nextActions: buildProjectSetupNextActions({
-      commandName: options.commandName,
+      commandName: error.commandName,
       suggestedProjectName: suggestion.suggestedProjectName,
     }),
   });
@@ -313,15 +447,15 @@ function resolveExplicitProject(
   projectRef: string,
   projects: ProjectCandidate[],
   workspace: AuthWorkspace,
-): ProjectCandidate {
+): Result<ProjectCandidate, ProjectNotFoundError | ProjectAmbiguousError> {
   const matches = projects.filter((project) => project.id === projectRef || project.name === projectRef);
   if (matches.length === 1) {
-    return matches[0];
+    return Result.ok(matches[0]);
   }
   if (matches.length > 1) {
-    throw projectAmbiguousError(projectRef, matches);
+    return Result.err(new ProjectAmbiguousError(projectRef, matches));
   }
-  throw projectNotFoundError(projectRef, workspace);
+  return Result.err(new ProjectNotFoundError(projectRef, workspace));
 }
 
 function projectMatchesSuggestedName(project: ProjectCandidate, suggestedName: string): boolean {
@@ -339,58 +473,62 @@ async function resolveBoundProjectTarget(
     allowEnvProjectId: boolean;
     localPin: LocalResolutionPinReadResult | null;
   },
-): Promise<BoundProjectShowResult | null> {
+): Promise<Result<BoundProjectShowResult | null, ProjectResolutionError>> {
   if (options.explicitProject) {
-    return resolvedTarget(options.workspace, resolveExplicitProject(options.explicitProject, projects, options.workspace), "explicit", {
+    const projectResult = resolveExplicitProject(options.explicitProject, projects, options.workspace);
+    if (projectResult.isErr()) {
+      return Result.err(projectResult.error);
+    }
+    return Result.ok(resolvedTarget(options.workspace, projectResult.value, "explicit", {
       targetName: options.explicitProject,
       targetNameSource: "explicit",
-    });
+    }));
   }
 
   if (settings.allowEnvProjectId && options.envProjectId) {
     const project = projects.find((candidate) => candidate.id === options.envProjectId);
     if (!project) {
-      throw projectNotFoundError(options.envProjectId, options.workspace);
+      return Result.err(new ProjectNotFoundError(options.envProjectId, options.workspace));
     }
-    return resolvedTarget(options.workspace, project, "env", {
+    return Result.ok(resolvedTarget(options.workspace, project, "env", {
       targetName: options.envProjectId,
       targetNameSource: "env",
-    });
+    }));
   }
 
   const localPin = settings.localPin;
   if (!localPin) {
-    return null;
+    return Result.ok(null);
   }
   if (localPin.kind === "present") {
     if (localPin.pin.workspaceId !== options.workspace.id) {
-      throw localProjectWorkspaceMismatchError({
+      return Result.err(new LocalProjectWorkspaceMismatchError({
         pinnedWorkspaceId: localPin.pin.workspaceId,
         pinnedProjectId: localPin.pin.projectId,
         activeWorkspace: options.workspace,
-      });
+      }));
     }
 
     const project = projects.find((candidate) => candidate.id === localPin.pin.projectId);
     if (!project) {
-      throw localStateStaleError();
+      return Result.err(new LocalStateStaleError());
     }
 
-    return resolvedTarget(options.workspace, project, "local-pin", {
+    return Result.ok(resolvedTarget(options.workspace, project, "local-pin", {
       targetName: project.name,
       targetNameSource: "local-pin",
-    });
+    }));
   }
 
   const platformMapping = await resolveDurablePlatformMapping();
   if (platformMapping && platformMapping.workspace.id === options.workspace.id) {
-    return resolvedTarget(options.workspace, platformMapping, "platform-mapping", {
+    return Result.ok(resolvedTarget(options.workspace, platformMapping, "platform-mapping", {
       targetName: platformMapping.name,
       targetNameSource: "platform-mapping",
-    });
+    }));
   }
 
-  return null;
+  return Result.ok(null);
 }
 
 async function readImplicitLocalPin(
@@ -398,39 +536,34 @@ async function readImplicitLocalPin(
   settings: {
     allowEnvProjectId: boolean;
   },
-): Promise<LocalResolutionPinReadResult | null> {
+): Promise<Result<LocalResolutionPinReadResult | null, ProjectResolutionError>> {
   if (options.explicitProject || (settings.allowEnvProjectId && options.envProjectId)) {
-    return null;
+    return Result.ok(null);
   }
 
   const localPinResult = await readLocalResolutionPin(options.context.runtime.cwd, options.context.runtime.signal);
   if (localPinResult.isErr()) {
-    throw localPinReadErrorToProjectError(localPinResult.error);
+    return Result.err(localPinReadErrorToProjectError(localPinResult.error));
   }
 
   const localPin = localPinResult.value;
   if (localPin.kind === "present" && localPin.pin.workspaceId !== options.workspace.id) {
-    throw localProjectWorkspaceMismatchError({
+    return Result.err(new LocalProjectWorkspaceMismatchError({
       pinnedWorkspaceId: localPin.pin.workspaceId,
       pinnedProjectId: localPin.pin.projectId,
       activeWorkspace: options.workspace,
-    });
+    }));
   }
 
-  return localPin;
+  return Result.ok(localPin);
 }
 
-function localPinReadErrorToProjectError(error: LocalResolutionPinReadError): CliError {
-  // Migration bridge: remove in Phase 20 when command boundaries convert Result errors directly.
+function localPinReadErrorToProjectError(error: LocalResolutionPinReadError): ProjectResolutionError {
   return matchError(error, {
-    LocalResolutionPinInvalidJsonError: () => localStateStaleError(),
-    LocalResolutionPinInvalidShapeError: () => localStateStaleError(),
-    LocalResolutionPinReadAbortedError: (error) => {
-      throw error;
-    },
-    UnhandledException: (error) => {
-      throw error;
-    },
+    LocalResolutionPinInvalidJsonError: () => new LocalStateStaleError(),
+    LocalResolutionPinInvalidShapeError: () => new LocalStateStaleError(),
+    LocalResolutionPinReadAbortedError: (error) => error,
+    UnhandledException: (error) => error,
   });
 }
 

--- a/packages/cli/tests/project-resolution.test.ts
+++ b/packages/cli/tests/project-resolution.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 import { createTempCwd, createTestCommandContext } from "./helpers";
-import { resolveProjectTarget } from "../src/lib/project/resolution";
+import { projectResolutionErrorToCliError, resolveProjectTarget } from "../src/lib/project/resolution";
 import type { ProjectCandidate } from "../src/lib/project/resolution";
 
 async function writeLocalPin(cwd: string, pin: unknown) {
@@ -26,7 +26,7 @@ describe("project resolution", () => {
     const { context } = await createTestCommandContext({ cwd });
     const listProjects = vi.fn<() => Promise<ProjectCandidate[]>>();
 
-    await expect(resolveProjectTarget({
+    const result = await resolveProjectTarget({
       context,
       workspace: {
         id: "ws_123",
@@ -34,7 +34,14 @@ describe("project resolution", () => {
       },
       listProjects,
       commandName: "app deploy",
-    })).rejects.toMatchObject({
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      throw new Error("Expected project resolution to fail");
+    }
+    expect(result.error._tag).toBe("LocalProjectWorkspaceMismatchError");
+    expect(projectResolutionErrorToCliError(result.error)).toMatchObject({
       code: "LOCAL_PROJECT_WORKSPACE_MISMATCH",
       domain: "project",
       meta: {
@@ -75,8 +82,12 @@ describe("project resolution", () => {
       commandName: "app deploy",
     });
 
-    expect(result.resolution.projectSource).toBe("explicit");
-    expect(result.project.id).toBe("proj_active");
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw new Error("Expected project resolution to succeed");
+    }
+    expect(result.value.resolution.projectSource).toBe("explicit");
+    expect(result.value.project.id).toBe("proj_active");
     expect(listProjects).toHaveBeenCalledTimes(1);
   });
 
@@ -107,8 +118,12 @@ describe("project resolution", () => {
       commandName: "app deploy",
     });
 
-    expect(result.resolution.projectSource).toBe("env");
-    expect(result.project.id).toBe("proj_env");
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw new Error("Expected project resolution to succeed");
+    }
+    expect(result.value.resolution.projectSource).toBe("env");
+    expect(result.value.project.id).toBe("proj_env");
     expect(listProjects).toHaveBeenCalledTimes(1);
   });
 
@@ -118,7 +133,7 @@ describe("project resolution", () => {
     const { context } = await createTestCommandContext({ cwd });
     const listProjects = vi.fn<() => Promise<ProjectCandidate[]>>();
 
-    await expect(resolveProjectTarget({
+    const result = await resolveProjectTarget({
       context,
       workspace: {
         id: "ws_123",
@@ -126,7 +141,14 @@ describe("project resolution", () => {
       },
       listProjects,
       commandName: "app deploy",
-    })).rejects.toMatchObject({
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      throw new Error("Expected project resolution to fail");
+    }
+    expect(result.error._tag).toBe("LocalStateStaleError");
+    expect(projectResolutionErrorToCliError(result.error)).toMatchObject({
       code: "LOCAL_STATE_STALE",
       domain: "project",
       meta: {

--- a/packages/cli/tests/project-resolution.test.ts
+++ b/packages/cli/tests/project-resolution.test.ts
@@ -1,5 +1,6 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import type { Result } from "better-result";
 import { describe, expect, it, vi } from "vitest";
 
 import { createTempCwd, createTestCommandContext } from "./helpers";
@@ -14,6 +15,23 @@ async function writeLocalPin(cwd: string, pin: unknown) {
 async function writeLocalPinContent(cwd: string, content: string) {
   await mkdir(path.join(cwd, ".prisma"), { recursive: true });
   await writeFile(path.join(cwd, ".prisma/local.json"), content, "utf8");
+}
+
+function expectOk<T, E>(result: Result<T, E>): T {
+  expect(result.isOk()).toBe(true);
+  if (result.isErr()) {
+    throw new Error("Expected Result to be Ok");
+  }
+  return result.value;
+}
+
+function expectErr<T, E extends { _tag: string }>(result: Result<T, E>, expectedTag: E["_tag"]): E {
+  expect(result.isErr()).toBe(true);
+  if (!result.isErr()) {
+    throw new Error("Expected Result to be Err");
+  }
+  expect(result.error._tag).toBe(expectedTag);
+  return result.error;
 }
 
 describe("project resolution", () => {
@@ -36,12 +54,8 @@ describe("project resolution", () => {
       commandName: "app deploy",
     });
 
-    expect(result.isErr()).toBe(true);
-    if (!result.isErr()) {
-      throw new Error("Expected project resolution to fail");
-    }
-    expect(result.error._tag).toBe("LocalProjectWorkspaceMismatchError");
-    expect(projectResolutionErrorToCliError(result.error)).toMatchObject({
+    const error = expectErr(result, "LocalProjectWorkspaceMismatchError");
+    expect(projectResolutionErrorToCliError(error)).toMatchObject({
       code: "LOCAL_PROJECT_WORKSPACE_MISMATCH",
       domain: "project",
       meta: {
@@ -82,12 +96,9 @@ describe("project resolution", () => {
       commandName: "app deploy",
     });
 
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) {
-      throw new Error("Expected project resolution to succeed");
-    }
-    expect(result.value.resolution.projectSource).toBe("explicit");
-    expect(result.value.project.id).toBe("proj_active");
+    const resolved = expectOk(result);
+    expect(resolved.resolution.projectSource).toBe("explicit");
+    expect(resolved.project.id).toBe("proj_active");
     expect(listProjects).toHaveBeenCalledTimes(1);
   });
 
@@ -118,12 +129,9 @@ describe("project resolution", () => {
       commandName: "app deploy",
     });
 
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) {
-      throw new Error("Expected project resolution to succeed");
-    }
-    expect(result.value.resolution.projectSource).toBe("env");
-    expect(result.value.project.id).toBe("proj_env");
+    const resolved = expectOk(result);
+    expect(resolved.resolution.projectSource).toBe("env");
+    expect(resolved.project.id).toBe("proj_env");
     expect(listProjects).toHaveBeenCalledTimes(1);
   });
 
@@ -143,12 +151,8 @@ describe("project resolution", () => {
       commandName: "app deploy",
     });
 
-    expect(result.isErr()).toBe(true);
-    if (!result.isErr()) {
-      throw new Error("Expected project resolution to fail");
-    }
-    expect(result.error._tag).toBe("LocalStateStaleError");
-    expect(projectResolutionErrorToCliError(result.error)).toMatchObject({
+    const error = expectErr(result, "LocalStateStaleError");
+    expect(projectResolutionErrorToCliError(error)).toMatchObject({
       code: "LOCAL_STATE_STALE",
       domain: "project",
       meta: {


### PR DESCRIPTION
Converts project target resolution to return typed better-result errors instead of throwing expected `CliError` instances, while preserving the existing command-facing error envelopes.

## Changes

- **Project resolution**: `packages/cli/src/lib/project/resolution.ts` now models project not found, ambiguous project, setup required, stale local state, and workspace mismatch as `TaggedError` variants returned through `Result` composition.
- **Command boundaries**: Project, app, branch, database, and app env controllers now convert resolution errors exhaustively back into the existing `CliError` envelopes at the command boundary.
- **Tests and plan tracking**: Resolver tests assert typed result failures plus stable public conversion, and phase 3 is marked complete in the adoption plan with the remaining unrelated typecheck blocker documented.

## Why

This keeps expected project-resolution failures typed below the CLI boundary and makes new variants require exhaustive conversion before they can reach command output. Setup validation remains on the existing compatibility path for the next phase, avoiding a broader migration than phase 3 requires.

## Verification

- `pnpm --filter @prisma/cli exec vitest run tests/project-resolution.test.ts tests/project.test.ts tests/app-controller.test.ts tests/branch.test.ts tests/branch-controller.test.ts`
- `pnpm --filter @prisma/cli exec tsc -p tsconfig.json` currently fails on unrelated existing database/test typing errors documented in `.agents/diary/better-result-phase-3.md`.