### PR TITLE
Fix npm trusted publishing workflows

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -36,7 +36,8 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version-file: .node-version
+          node-version: 24
+          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -55,7 +56,7 @@ jobs:
 
       - name: Publish dev package to npm
         working-directory: packages/cli
-        run: pnpm publish --access public --tag dev --provenance --no-git-checks
+        run: npm publish --access public --tag dev --provenance
 
       - name: Summarize dev publish
         run: |
@@ -93,7 +94,8 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version-file: .node-version
+          node-version: 24
+          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -137,7 +139,7 @@ jobs:
       - name: Publish official package to npm
         if: ${{ !inputs.dry_run }}
         working-directory: packages/cli
-        run: pnpm publish --access public --tag latest --provenance --no-git-checks
+        run: npm publish --access public --tag latest --provenance
 
       - name: Create release tag
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/publish-compute.yml
+++ b/.github/workflows/publish-compute.yml
@@ -36,7 +36,8 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version-file: .node-version
+          node-version: 24
+          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -55,7 +56,7 @@ jobs:
 
       - name: Publish dev package to npm
         working-directory: packages/compute
-        run: pnpm publish --access public --tag dev --provenance --no-git-checks
+        run: npm publish --access public --tag dev --provenance
 
       - name: Summarize dev publish
         run: |
@@ -93,7 +94,8 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version-file: .node-version
+          node-version: 24
+          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -137,7 +139,7 @@ jobs:
       - name: Publish official package to npm
         if: ${{ !inputs.dry_run }}
         working-directory: packages/compute
-        run: pnpm publish --access public --tag latest --provenance --no-git-checks
+        run: npm publish --access public --tag latest --provenance
 
       - name: Create release tag
         if: ${{ !inputs.dry_run }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Use this file for repo-wide instructions. Use package-local `AGENTS.md` files fo
 ## Package Manager
 
 - Use `pnpm` for commands run inside this repo.
+- Exception: use `npm publish` for npm release workflow publish steps so npm trusted publishing can use its OIDC authentication flow.
 - Use `npm` or multiple package-manager examples in user-facing content.
 
 ## Pre-Commit Verification

--- a/docs/architecture/adrs/0001-preview-package-and-publishing.md
+++ b/docs/architecture/adrs/0001-preview-package-and-publishing.md
@@ -37,7 +37,7 @@ The publish workflow is prepared for npm trusted publishing with provenance.
 Official releases publish with:
 
 ```bash
-pnpm publish --access public --tag latest --provenance
+npm publish --access public --tag latest --provenance
 ```
 
 Local development should build and inspect the package, but should not publish it.


### PR DESCRIPTION
Restores the publish workflows to the npm CLI path required for npm trusted publishing while keeping pnpm for repo setup and package preparation.

## Changes

- **Publish workflows**: Use Node 24 and configure the npm registry through setup-node for the CLI and Compute publish jobs.
- **Release publishing**: Switch final package publication back to npm publish so npm can perform the trusted-publisher OIDC authentication flow.
- **Documentation**: Record the npm publish exception in AGENTS.md and update the publishing ADR command example.

## Why

npm trusted publishing is implemented by the npm CLI OIDC exchange. Keeping pnpm for install, versioning, and pack validation is fine, but the final publish step needs npm publish to avoid falling back to unauthenticated registry publishing.