### PR TITLE
feat(cli): consume @prisma/compute-sdk build strategies, enable NestJS

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.5.0",
-    "@prisma/compute-sdk": "^0.23.0",
+    "@prisma/compute-sdk": "^0.28.0",
     "@prisma/credentials-store": "^7.8.0",
     "@prisma/management-api-sdk": "^1.37.0",
     "better-result": "^2.9.2",

--- a/packages/cli/src/commands/app/index.ts
+++ b/packages/cli/src/commands/app/index.ts
@@ -21,7 +21,7 @@ import {
   runAppShow,
   runAppShowDeploy,
 } from "../../controllers/app";
-import { PREVIEW_BUILD_TYPES } from "../../lib/app/preview-build";
+import { APP_BUILD_TYPES } from "../../lib/app/build";
 import {
   isAppDeployAllResult,
   renderAppBuild,
@@ -121,7 +121,7 @@ function createBuildCommand(runtime: CliRuntime): Command {
     )
     .addOption(
       new Option("--build-type <type>", "Local build type")
-        .choices([...PREVIEW_BUILD_TYPES])
+        .choices([...APP_BUILD_TYPES])
         .default("auto"),
     );
   addGlobalFlags(command);

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -17,10 +17,30 @@ import type { ManagementApiClient } from "@prisma/management-api-sdk";
 import { matchError, Result } from "better-result";
 import open from "open";
 import { FileTokenStorage } from "../adapters/token-storage";
+import { DEFAULT_REGION } from "../lib/app/app-interaction";
+import {
+  type AppRecord,
+  createAppProvider,
+  DomainApiError,
+  type DomainRecord,
+} from "../lib/app/app-provider";
 import {
   type BranchDatabaseDeployBranch,
   maybeSetupBranchDatabase,
 } from "../lib/app/branch-database-deploy";
+import {
+  APP_BUILD_TYPES,
+  type AppBuildSettings,
+  type AppBuildSettingsResolution,
+  type AppBuildType,
+  detectLegacyBuildSettings,
+  executeAppBuild,
+  PRISMA_APP_CONFIG_FILENAME,
+  RESOLVED_APP_BUILD_TYPES,
+  type ResolvedAppBuildType,
+  resolveConfiguredAppBuildSettings,
+  resolveInferredAppBuildSettings,
+} from "../lib/app/build";
 import {
   type BunPackageJsonLike,
   readBunPackageEntrypoint,
@@ -52,6 +72,12 @@ import {
   perAppInputsForDeployAll,
   planAppDeploy,
 } from "../lib/app/deploy-plan";
+import {
+  createDeployProgress,
+  createDeployProgressState,
+  createPromoteProgress,
+  type DeployProgressState,
+} from "../lib/app/deploy-progress";
 import { formatDomainFailureFix } from "../lib/app/domain-guidance";
 import { envVarNames, parseEnvInputs } from "../lib/app/env-vars";
 import {
@@ -59,32 +85,6 @@ import {
   type LocalBuildType,
   runLocalApp,
 } from "../lib/app/local-dev";
-import {
-  detectLegacyBuildSettings,
-  executePreviewBuild,
-  PREVIEW_BUILD_TYPES,
-  PRISMA_APP_CONFIG_FILENAME,
-  type PreviewBuildSettings,
-  type PreviewBuildSettingsResolution,
-  type PreviewBuildType,
-  RESOLVED_PREVIEW_BUILD_TYPES,
-  type ResolvedPreviewBuildType,
-  resolveConfiguredPreviewBuildSettings,
-  resolveInferredPreviewBuildSettings,
-} from "../lib/app/preview-build";
-import { PREVIEW_DEFAULT_REGION } from "../lib/app/preview-interaction";
-import {
-  createPreviewDeployProgress,
-  createPreviewDeployProgressState,
-  createPreviewPromoteProgress,
-  type PreviewDeployProgressState,
-} from "../lib/app/preview-progress";
-import {
-  createPreviewAppProvider,
-  type PreviewAppRecord,
-  PreviewDomainApiError,
-  type PreviewDomainRecord,
-} from "../lib/app/preview-provider";
 import { enforceProductionDeployGate } from "../lib/app/production-deploy-gate";
 import { readAuthState } from "../lib/auth/auth-ops";
 import { getApiBaseUrl, SERVICE_TOKEN_ENV_VAR } from "../lib/auth/client";
@@ -214,7 +214,7 @@ export async function runAppBuild(
     compute.target?.build &&
     isConfigBackedBuildType(buildType)
       ? (
-          await resolveConfiguredPreviewBuildSettings({
+          await resolveConfiguredAppBuildSettings({
             appPath: appDir,
             buildType,
             configured: compute.target.build,
@@ -225,7 +225,7 @@ export async function runAppBuild(
       : undefined;
 
   try {
-    const { artifact, buildType: actualBuildType } = await executePreviewBuild({
+    const { artifact, buildType: actualBuildType } = await executeAppBuild({
       appPath: appDir,
       entrypoint: merged.entrypoint,
       buildType,
@@ -247,7 +247,7 @@ export async function runAppBuild(
     if (buildType === "auto" && isAutoBuildDetectionError(error)) {
       throw usageError(
         "App build requires an explicit framework when detection is ambiguous",
-        `This preview auto-detects clear project shapes for ${RESOLVED_PREVIEW_BUILD_TYPES.map(formatBuildTypeName).join(", ")}.`,
+        `This preview auto-detects clear project shapes for ${RESOLVED_APP_BUILD_TYPES.map(formatBuildTypeName).join(", ")}.`,
         "Pass a supported --build-type value, or pass --entry <path> for a Bun app.",
         getBuildTypeExamples("build"),
         "app",
@@ -740,14 +740,14 @@ async function runSingleAppDeploy(
     computeConfig.config &&
     computeConfig.target?.build &&
     isConfigBackedBuildType(buildType)
-      ? await resolveConfiguredPreviewBuildSettings({
+      ? await resolveConfiguredAppBuildSettings({
           appPath: appDir,
           buildType,
           configured: computeConfig.target.build,
           configPath: computeConfig.config.configPath,
           signal: context.runtime.signal,
         })
-      : await resolveInferredPreviewBuildSettings({
+      : await resolveInferredAppBuildSettings({
           appPath: appDir,
           buildType,
           signal: context.runtime.signal,
@@ -772,7 +772,7 @@ async function runSingleAppDeploy(
     },
   );
 
-  const progressState = createPreviewDeployProgressState();
+  const progressState = createDeployProgressState();
   const deployStartedAt = Date.now();
   const deployResult = await provider
     .deployApp({
@@ -789,7 +789,7 @@ async function runSingleAppDeploy(
       envVars,
       interaction: undefined,
       signal: context.runtime.signal,
-      progress: createPreviewDeployProgress(
+      progress: createDeployProgress(
         context.output.stderr,
         context.ui,
         !context.flags.json && !context.flags.quiet,
@@ -1564,12 +1564,12 @@ export async function runAppLogs(
 
 async function resolveExplicitLogDeployment(
   context: CommandContext,
-  provider: ReturnType<typeof createPreviewAppProvider>,
+  provider: ReturnType<typeof createAppProvider>,
   projectId: string,
   branchName: string,
   appName: string | undefined,
   deploymentId: string,
-): Promise<{ app: PreviewAppRecord; deployment: AppDeploymentSummary }> {
+): Promise<{ app: AppRecord; deployment: AppDeploymentSummary }> {
   if (appName) {
     const apps = await listApps(context, provider, projectId, branchName);
     const selectedApp = await resolveExistingAppSelection(
@@ -1669,11 +1669,11 @@ async function resolveExplicitLogDeployment(
 
 async function resolveLiveLogDeployment(
   context: CommandContext,
-  provider: ReturnType<typeof createPreviewAppProvider>,
+  provider: ReturnType<typeof createAppProvider>,
   projectId: string,
   branchName: string,
   appName: string | undefined,
-): Promise<{ app: PreviewAppRecord; deployment: AppDeploymentSummary }> {
+): Promise<{ app: AppRecord; deployment: AppDeploymentSummary }> {
   const apps = await listApps(context, provider, projectId, branchName);
   const selectedApp = await resolveExistingAppSelection(
     context,
@@ -1808,7 +1808,7 @@ export async function runAppPromote(
         appId: selectedApp.id,
         deploymentId: targetDeployment.id,
         signal: context.runtime.signal,
-        progress: createPreviewPromoteProgress(
+        progress: createPromoteProgress(
           context.output.stderr,
           !context.flags.json && !context.flags.quiet,
         ),
@@ -1920,7 +1920,7 @@ export async function runAppRollback(
         appId: selectedApp.id,
         deploymentId: targetDeployment.id,
         signal: context.runtime.signal,
-        progress: createPreviewPromoteProgress(
+        progress: createPromoteProgress(
           context.output.stderr,
           !context.flags.json && !context.flags.quiet,
         ),
@@ -2026,8 +2026,8 @@ export async function runAppRemove(
 }
 
 interface ResolvedAppDomainTarget {
-  provider: ReturnType<typeof createPreviewAppProvider>;
-  app: PreviewAppRecord;
+  provider: ReturnType<typeof createAppProvider>;
+  app: AppRecord;
   resultTarget: AppDomainTarget;
 }
 
@@ -2117,12 +2117,12 @@ function resolveDomainBranch(
 async function resolveDomainAppSelection(
   context: CommandContext,
   projectId: string,
-  apps: PreviewAppRecord[],
+  apps: AppRecord[],
   options: {
     explicitAppName: string | undefined;
     explicitAppId: string | undefined;
   },
-): Promise<PreviewAppRecord> {
+): Promise<AppRecord> {
   if (options.explicitAppId) {
     const matched = apps.find((app) => app.id === options.explicitAppId);
     if (!matched) {
@@ -2157,12 +2157,12 @@ async function resolveDomainAppSelection(
 }
 
 async function resolveDomainByHostname(
-  provider: ReturnType<typeof createPreviewAppProvider>,
+  provider: ReturnType<typeof createAppProvider>,
   appId: string,
   hostname: string,
   command: AppDomainCommand,
   signal: AbortSignal,
-): Promise<PreviewDomainRecord> {
+): Promise<DomainRecord> {
   const domains = await provider
     .listDomains(appId, { signal })
     .catch((error) => {
@@ -2225,7 +2225,7 @@ function sameDomainHostname(left: string, right: string): boolean {
   );
 }
 
-function toAppDomainSummary(domain: PreviewDomainRecord): AppDomainSummary {
+function toAppDomainSummary(domain: DomainRecord): AppDomainSummary {
   return {
     id: domain.id,
     type: domain.type,
@@ -2244,7 +2244,7 @@ function toAppDomainSummary(domain: PreviewDomainRecord): AppDomainSummary {
 }
 
 function toAppDomainDnsRecords(
-  domain: Pick<PreviewDomainRecord, "dnsRecords">,
+  domain: Pick<DomainRecord, "dnsRecords">,
 ): AppDomainDnsRecord[] {
   return domain.dnsRecords.map((record) => ({
     type: record.type,
@@ -2254,7 +2254,7 @@ function toAppDomainDnsRecords(
   }));
 }
 
-function buildDomainShowNextSteps(domain: PreviewDomainRecord): string[] {
+function buildDomainShowNextSteps(domain: DomainRecord): string[] {
   if (domain.status === "active") {
     return [];
   }
@@ -2313,7 +2313,7 @@ function domainCommandError(
   error: unknown,
   hostname: string,
 ): CliError {
-  if (error instanceof PreviewDomainApiError) {
+  if (error instanceof DomainApiError) {
     if (
       command === "add" &&
       (error.status === 400 || error.status === 422) &&
@@ -2407,7 +2407,7 @@ function domainCommandError(
   });
 }
 
-function isDomainQuotaError(error: PreviewDomainApiError): boolean {
+function isDomainQuotaError(error: DomainApiError): boolean {
   if (error.status !== 409) {
     return false;
   }
@@ -2420,7 +2420,7 @@ function isDomainQuotaError(error: PreviewDomainApiError): boolean {
 
 function domainAlreadyRegisteredError(
   hostname: string,
-  error: PreviewDomainApiError,
+  error: DomainApiError,
 ): CliError {
   return new CliError({
     code: "DOMAIN_ALREADY_REGISTERED",
@@ -2437,7 +2437,7 @@ function domainAlreadyRegisteredError(
   });
 }
 
-function isDomainDnsError(error: PreviewDomainApiError): boolean {
+function isDomainDnsError(error: DomainApiError): boolean {
   const text = `${error.message} ${error.hint ?? ""}`.toLowerCase();
   return (
     text.includes("dns is not configured") ||
@@ -2451,7 +2451,7 @@ function isDomainDnsError(error: PreviewDomainApiError): boolean {
 
 function domainDnsNotConfiguredError(
   hostname: string,
-  error: PreviewDomainApiError,
+  error: DomainApiError,
 ): CliError {
   const target = extractDomainDnsTarget(error);
   const record = target ? `CNAME ${hostname} -> ${target}` : null;
@@ -2472,7 +2472,7 @@ function domainDnsNotConfiguredError(
   });
 }
 
-function extractDomainDnsTarget(error: PreviewDomainApiError): string | null {
+function extractDomainDnsTarget(error: DomainApiError): string | null {
   const text = `${error.hint ?? ""} ${error.message}`;
   const match = /\b((?:[a-z0-9-]+\.)+prisma\.build)\b/i.exec(text);
   return match?.[1]?.toLowerCase() ?? null;
@@ -2490,7 +2490,7 @@ function domainNotFoundError(hostname: string): CliError {
   });
 }
 
-function formatDomainFailureWhy(domain: PreviewDomainRecord): string {
+function formatDomainFailureWhy(domain: DomainRecord): string {
   if (domain.failureReason) {
     return domain.failureCategory
       ? `${domain.failureCategory}: ${domain.failureReason}`
@@ -2614,7 +2614,7 @@ async function sleep(milliseconds: number, signal: AbortSignal): Promise<void> {
 async function resolveDeployAppSelection(
   context: CommandContext,
   projectId: string,
-  apps: PreviewAppRecord[],
+  apps: AppRecord[],
   options: {
     explicitAppName: string | undefined;
     explicitAppId: string | undefined;
@@ -2652,7 +2652,7 @@ async function resolveDeployAppSelection(
 
     return {
       appName: options.explicitAppName,
-      region: PREVIEW_DEFAULT_REGION,
+      region: DEFAULT_REGION,
       displayName: options.explicitAppName,
       annotation: "set by --app",
       firstDeploy: options.firstDeploy,
@@ -2703,7 +2703,7 @@ async function resolveDeployAppSelection(
 
     return {
       appName: configName.value,
-      region: PREVIEW_DEFAULT_REGION,
+      region: DEFAULT_REGION,
       displayName: configName.value,
       annotation: configName.annotation,
       firstDeploy: options.firstDeploy,
@@ -2733,7 +2733,7 @@ async function resolveDeployAppSelection(
 
   return {
     appName: inferredName.name,
-    region: PREVIEW_DEFAULT_REGION,
+    region: DEFAULT_REGION,
     displayName: inferredName.name,
     annotation:
       inferredName.source === "package-name"
@@ -2745,7 +2745,7 @@ async function resolveDeployAppSelection(
 
 async function resolveAmbiguousDeployApp(
   context: CommandContext,
-  matches: PreviewAppRecord[],
+  matches: AppRecord[],
   targetName: string,
   firstDeploy: boolean,
 ): Promise<{
@@ -2760,7 +2760,7 @@ async function resolveAmbiguousDeployApp(
     const createNew = "__create_new_app__";
     const cancel = "__cancel__";
     const selected = await selectPrompt<
-      PreviewAppRecord | typeof createNew | typeof cancel
+      AppRecord | typeof createNew | typeof cancel
     >({
       input: context.runtime.stdin,
       output: context.runtime.stderr,
@@ -2794,7 +2794,7 @@ async function resolveAmbiguousDeployApp(
     if (selected === createNew) {
       return {
         appName: targetName,
-        region: PREVIEW_DEFAULT_REGION,
+        region: DEFAULT_REGION,
         displayName: targetName,
         annotation: "created from package.json",
         firstDeploy,
@@ -2826,9 +2826,9 @@ async function resolveAmbiguousDeployApp(
 async function resolveExistingAppSelection(
   context: CommandContext,
   projectId: string,
-  apps: PreviewAppRecord[],
+  apps: AppRecord[],
   explicitAppName: string | undefined,
-): Promise<PreviewAppRecord | null> {
+): Promise<AppRecord | null> {
   if (explicitAppName) {
     const matched = findAppByName(apps, explicitAppName);
     if (!matched) {
@@ -2893,10 +2893,10 @@ async function resolveExistingAppSelection(
 async function requireReleaseAppSelection(
   context: CommandContext,
   projectId: string,
-  apps: PreviewAppRecord[],
+  apps: AppRecord[],
   explicitAppName: string | undefined,
   commandName: "promote" | "rollback" | "remove",
-): Promise<PreviewAppRecord> {
+): Promise<AppRecord> {
   const selectedApp = await resolveExistingAppSelection(
     context,
     projectId,
@@ -2918,7 +2918,7 @@ async function requireReleaseAppSelection(
 
 async function confirmAppRemoval(
   context: CommandContext,
-  app: PreviewAppRecord,
+  app: AppRecord,
 ): Promise<void> {
   if (context.flags.yes) {
     return;
@@ -2994,7 +2994,7 @@ function requireDeploymentForApp(
 async function resolveCurrentLiveDeploymentId(
   context: CommandContext,
   projectId: string,
-  app: Pick<PreviewAppRecord, "id" | "liveDeploymentId">,
+  app: Pick<AppRecord, "id" | "liveDeploymentId">,
   deployments: AppDeploymentSummary[],
 ): Promise<string | null> {
   if (
@@ -3086,7 +3086,7 @@ function resolveRollbackTarget(
 
 async function listApps(
   context: CommandContext,
-  provider: ReturnType<typeof createPreviewAppProvider>,
+  provider: ReturnType<typeof createAppProvider>,
   projectId: string,
   branchName?: string,
 ) {
@@ -3124,7 +3124,7 @@ async function requirePreviewAppProviderWithClient(
   context: CommandContext,
 ): Promise<{
   client: ManagementApiClient;
-  provider: ReturnType<typeof createPreviewAppProvider>;
+  provider: ReturnType<typeof createAppProvider>;
 }> {
   const client = await requireComputeAuth(
     context.runtime.env,
@@ -3136,7 +3136,7 @@ async function requirePreviewAppProviderWithClient(
 
   return {
     client,
-    provider: createPreviewAppProvider(
+    provider: createAppProvider(
       client,
       createPreviewLogAuthOptions(context.runtime.env, context.runtime.signal),
     ),
@@ -3193,7 +3193,7 @@ async function requireProviderAndProjectContext(
   },
 ): Promise<{
   client: ManagementApiClient;
-  provider: ReturnType<typeof createPreviewAppProvider>;
+  provider: ReturnType<typeof createAppProvider>;
   target: ResolvedAppProjectContext;
   projectId: string;
 }> {
@@ -3224,7 +3224,7 @@ async function requireProviderAndDeployProjectContext(
   },
 ): Promise<{
   client: ManagementApiClient;
-  provider: ReturnType<typeof createPreviewAppProvider>;
+  provider: ReturnType<typeof createAppProvider>;
   target: ResolvedAppProjectContext;
   projectId: string;
 }> {
@@ -3295,7 +3295,7 @@ async function resolveProjectContext(
 async function resolveDeployProjectContext(
   context: CommandContext,
   client: ManagementApiClient,
-  provider: ReturnType<typeof createPreviewAppProvider>,
+  provider: ReturnType<typeof createAppProvider>,
   explicitProject: string | undefined,
   options: {
     branch?: ResolvedDeployBranch;
@@ -3464,7 +3464,7 @@ async function resolveDeployProjectContext(
 
 async function resolveInteractiveDeployProjectSetup(
   context: CommandContext,
-  provider: ReturnType<typeof createPreviewAppProvider>,
+  provider: ReturnType<typeof createAppProvider>,
   workspace: AuthWorkspace,
   projects: ProjectCandidate[],
 ): Promise<Omit<ResolvedAppProjectContext, "branch">> {
@@ -3501,7 +3501,7 @@ async function resolveInteractiveDeployProjectSetup(
 }
 
 async function createProjectForDeploySetup(
-  provider: ReturnType<typeof createPreviewAppProvider>,
+  provider: ReturnType<typeof createAppProvider>,
   projectName: string,
   workspace: AuthWorkspace,
   signal: AbortSignal,
@@ -3530,7 +3530,7 @@ async function createProjectForDeploySetup(
 }
 
 async function withRemoteDeployBranch(
-  provider: ReturnType<typeof createPreviewAppProvider>,
+  provider: ReturnType<typeof createAppProvider>,
   target: Omit<ResolvedAppProjectContext, "branch">,
   branch: ResolvedDeployBranch,
   signal: AbortSignal,
@@ -3796,7 +3796,7 @@ async function resolveComputeAppDir(
 async function handleLegacyBuildSettings(
   context: CommandContext,
   appDir: string,
-  effective: PreviewBuildSettings,
+  effective: AppBuildSettings,
 ): Promise<string[]> {
   const legacy = await detectLegacyBuildSettings({
     appPath: appDir,
@@ -4142,7 +4142,7 @@ async function maybeRenderDeploySetupBlock(
 
 function maybeRenderDeployBuildSettings(
   context: CommandContext,
-  resolution: PreviewBuildSettingsResolution,
+  resolution: AppBuildSettingsResolution,
 ): void {
   if (context.flags.json || context.flags.quiet) {
     return;
@@ -4365,7 +4365,7 @@ async function readCurrentWorkspaceId(
 
 function normalizeBuildType(
   requestedBuildType: string | undefined,
-): PreviewBuildType {
+): AppBuildType {
   if (!requestedBuildType) {
     return "auto";
   }
@@ -4376,26 +4376,26 @@ function normalizeBuildType(
 
   throw usageError(
     `Unsupported build type "${requestedBuildType}"`,
-    `Only ${PREVIEW_BUILD_TYPES.join(", ")} are supported in the current preview.`,
+    `Only ${APP_BUILD_TYPES.join(", ")} are supported in the current preview.`,
     "Pass a supported --build-type value.",
     getBuildTypeExamples("build"),
     "app",
   );
 }
 
-function isPreviewBuildType(value: string): value is PreviewBuildType {
-  return (PREVIEW_BUILD_TYPES as readonly string[]).includes(value);
+function isPreviewBuildType(value: string): value is AppBuildType {
+  return (APP_BUILD_TYPES as readonly string[]).includes(value);
 }
 
 function getBuildTypeExamples(commandName: "build"): string[] {
-  return RESOLVED_PREVIEW_BUILD_TYPES.map((buildType) => {
+  return RESOLVED_APP_BUILD_TYPES.map((buildType) => {
     const entrypoint = buildType === "bun" ? " --entry server.ts" : "";
     return `prisma-cli app ${commandName} --build-type ${buildType}${entrypoint}`;
   });
 }
 
 function assertSupportedEntrypoint(
-  buildType: PreviewBuildType,
+  buildType: AppBuildType,
   entrypoint: string | undefined,
   commandName: "build" | "run" | "deploy",
 ) {
@@ -4441,7 +4441,7 @@ function assertSupportedEntrypoint(
 async function resolveLocalRunFramework(
   context: CommandContext,
   options: {
-    requestedBuildType: PreviewBuildType;
+    requestedBuildType: AppBuildType;
     configFramework: ComputeFramework | null;
     appDir: string;
   },
@@ -4569,7 +4569,7 @@ function deployFailedError(
 
 function appDeployFailedError(
   error: unknown,
-  progress: PreviewDeployProgressState,
+  progress: DeployProgressState,
 ): CliError {
   const why = error instanceof Error ? error.message : String(error);
   const debug = formatDebugDetails(error);
@@ -4825,7 +4825,7 @@ function isAutoBuildDetectionError(error: unknown): boolean {
   );
 }
 
-function formatBuildTypeName(buildType: PreviewBuildType): string {
+function formatBuildTypeName(buildType: AppBuildType): string {
   switch (buildType) {
     case "nextjs":
       return "Next.js";
@@ -4878,21 +4878,15 @@ function isMissingProjectError(error: unknown): boolean {
   return error instanceof Error && error.message === "Resource Not Found";
 }
 
-function findAppByName(
-  apps: PreviewAppRecord[],
-  name: string,
-): PreviewAppRecord | undefined {
+function findAppByName(apps: AppRecord[], name: string): AppRecord | undefined {
   return apps.find((app) => app.name === name);
 }
 
-function findAppsByName(
-  apps: PreviewAppRecord[],
-  name: string,
-): PreviewAppRecord[] {
+function findAppsByName(apps: AppRecord[], name: string): AppRecord[] {
   return apps.filter((app) => app.name === name);
 }
 
-function sortApps(apps: PreviewAppRecord[]): PreviewAppRecord[] {
+function sortApps(apps: AppRecord[]): AppRecord[] {
   return apps
     .slice()
     .sort(

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -4833,6 +4833,8 @@ function formatBuildTypeName(buildType: PreviewBuildType): string {
       return "Nuxt";
     case "astro":
       return "Astro";
+    case "nestjs":
+      return "NestJS";
     case "tanstack-start":
       return "TanStack Start";
     case "bun":

--- a/packages/cli/src/controllers/project.ts
+++ b/packages/cli/src/controllers/project.ts
@@ -7,7 +7,7 @@ import {
   parseGitHubRepositoryUrl,
   readGitOriginRemote,
 } from "../adapters/git";
-import { createPreviewAppProvider } from "../lib/app/preview-provider";
+import { createAppProvider } from "../lib/app/app-provider";
 import { requireComputeAuth } from "../lib/auth/guard";
 import { promptForProjectSetupChoice } from "../lib/project/interactive-setup";
 import {
@@ -262,7 +262,7 @@ export async function runProjectCreate(
     throw authRequiredError();
   }
 
-  const provider = createPreviewAppProvider(client);
+  const provider = createAppProvider(client);
   const name = projectName.trim();
   const created = await provider
     .createProject({ name, signal: context.runtime.signal })
@@ -310,7 +310,7 @@ export async function runProjectLink(
     throw workspaceRequiredError();
   }
 
-  let provider: ReturnType<typeof createPreviewAppProvider> | null = null;
+  let provider: ReturnType<typeof createAppProvider> | null = null;
   let projects: ProjectCandidate[];
   if (isRealMode(context)) {
     const client = await requireComputeAuth(
@@ -320,7 +320,7 @@ export async function runProjectLink(
     if (!client) {
       throw authRequiredError();
     }
-    provider = createPreviewAppProvider(client);
+    provider = createAppProvider(client);
     projects = await listRealWorkspaceProjects(
       client,
       workspace,
@@ -366,7 +366,7 @@ async function resolveInteractiveProjectLinkSetup(
   context: CommandContext,
   workspace: AuthWorkspace,
   projects: ProjectCandidate[],
-  provider: ReturnType<typeof createPreviewAppProvider> | null,
+  provider: ReturnType<typeof createAppProvider> | null,
 ): Promise<ProjectSetupResult> {
   const setup = await promptForProjectSetupChoice({
     context,
@@ -426,7 +426,7 @@ async function requireProjectDirectoryBinding(
 }
 
 async function createProjectForLinkSetup(
-  provider: ReturnType<typeof createPreviewAppProvider>,
+  provider: ReturnType<typeof createAppProvider>,
   projectName: string,
   workspace: AuthWorkspace,
   signal: AbortSignal,

--- a/packages/cli/src/lib/app/app-interaction.ts
+++ b/packages/cli/src/lib/app/app-interaction.ts
@@ -8,9 +8,9 @@ import { selectPrompt, textPrompt } from "../../shell/prompt";
 import type { CommandContext } from "../../shell/runtime";
 
 const CREATE_NEW_APP = "__create_new_app__";
-export const PREVIEW_DEFAULT_REGION = "eu-central-1";
+export const DEFAULT_REGION = "eu-central-1";
 
-export function createPreviewDeployInteraction(
+export function createDeployInteraction(
   context: CommandContext,
 ): DeployInteraction {
   return {
@@ -51,7 +51,7 @@ export function createPreviewDeployInteraction(
       }).then((value) => value.trim());
     },
     async selectRegion(_regions: RegionInfo[]): Promise<string> {
-      return PREVIEW_DEFAULT_REGION;
+      return DEFAULT_REGION;
     },
   };
 }

--- a/packages/cli/src/lib/app/app-provider.ts
+++ b/packages/cli/src/lib/app/app-provider.ts
@@ -11,21 +11,21 @@ import {
 } from "@prisma/compute-sdk";
 import type { ManagementApiClient } from "@prisma/management-api-sdk";
 import type { BranchKind } from "../../types/branch";
-import { envVarNames } from "./env-vars";
 import {
+  type BranchDatabaseRecord,
   createBranchDatabase,
   createEnvironmentVariable,
   deleteBranchDatabase,
   deleteEnvironmentVariable,
+  type EnvironmentVariableRecord,
   listEnvironmentVariables,
-  type PreviewBranchDatabaseRecord,
-  type PreviewEnvironmentVariableRecord,
   updateEnvironmentVariable,
-} from "./preview-branch-database";
-import type { PreviewBuildSettings, PreviewBuildType } from "./preview-build";
-import { PreviewBuildStrategy } from "./preview-build";
+} from "./branch-database-api";
+import type { AppBuildSettings, AppBuildType } from "./build";
+import { AppBuildStrategy } from "./build";
+import { envVarNames } from "./env-vars";
 
-export interface PreviewAppRecord {
+export interface AppRecord {
   id: string;
   name: string;
   region: string | null;
@@ -34,23 +34,23 @@ export interface PreviewAppRecord {
   liveUrl: string | null;
 }
 
-export interface PreviewProjectRecord {
+export interface ProjectRecord {
   id: string;
   name: string;
 }
 
-export interface PreviewBranchRecord {
+export interface BranchRecord {
   id: string;
   name: string;
   role: BranchKind;
 }
 
 export type {
-  PreviewBranchDatabaseRecord,
-  PreviewEnvironmentVariableRecord,
-} from "./preview-branch-database";
+  BranchDatabaseRecord,
+  EnvironmentVariableRecord,
+} from "./branch-database-api";
 
-export interface PreviewDeploymentRecord {
+export interface DeploymentRecord {
   id: string;
   status: string;
   createdAt: string;
@@ -58,9 +58,9 @@ export interface PreviewDeploymentRecord {
   live: boolean | null;
 }
 
-export interface PreviewDeployRecord {
+export interface DeployRecord {
   projectId: string;
-  app: PreviewAppRecord;
+  app: AppRecord;
   deployment: {
     id: string;
     status: string;
@@ -68,24 +68,24 @@ export interface PreviewDeployRecord {
   };
 }
 
-export interface PreviewEnvRecord {
+export interface EnvRecord {
   projectId: string;
-  app: PreviewAppRecord;
-  deployment: PreviewDeploymentRecord;
+  app: AppRecord;
+  deployment: DeploymentRecord;
   variables: string[];
 }
 
-export interface PreviewShownDeploymentRecord {
-  app: PreviewAppRecord | null;
-  deployment: PreviewDeploymentRecord;
+export interface ShownDeploymentRecord {
+  app: AppRecord | null;
+  deployment: DeploymentRecord;
 }
 
-export interface PreviewRemovedAppRecord {
+export interface RemovedAppRecord {
   id: string;
   name: string;
 }
 
-export type PreviewDomainStatus =
+export type DomainStatus =
   | "pending_dns"
   | "verifying"
   | "verified_routing_blocked"
@@ -94,30 +94,30 @@ export type PreviewDomainStatus =
   | "failed"
   | "removing";
 
-export interface PreviewDomainDnsRecord {
+export interface DomainDnsRecord {
   type: string;
   name: string;
   value: string;
   ttl: number | null;
 }
 
-export interface PreviewDomainRecord {
+export interface DomainRecord {
   id: string;
   type: "custom-domain";
   url: string;
   hostname: string;
   computeServiceId: string;
-  status: PreviewDomainStatus;
+  status: DomainStatus;
   foundryStatus: string;
   failureReason: string | null;
   failureCategory: "dns" | "acme" | "storage" | "unknown" | null;
   certExpiresAt: string | null;
   createdAt: string;
   updatedAt: string;
-  dnsRecords: PreviewDomainDnsRecord[];
+  dnsRecords: DomainDnsRecord[];
 }
 
-export class PreviewDomainApiError extends Error {
+export class DomainApiError extends Error {
   readonly status: number;
   readonly code: string | null;
   readonly hint: string | null;
@@ -132,28 +132,28 @@ export class PreviewDomainApiError extends Error {
     super(
       `${options.summary}: ${options.message}${options.hint ? ` ${options.hint}` : ""}`,
     );
-    this.name = "PreviewDomainApiError";
+    this.name = "DomainApiError";
     this.status = options.status;
     this.code = options.code ?? null;
     this.hint = options.hint ?? null;
   }
 }
 
-export interface PreviewAppProvider {
+export interface AppProvider {
   createProject(options: {
     name: string;
     signal?: AbortSignal;
-  }): Promise<PreviewProjectRecord>;
+  }): Promise<ProjectRecord>;
   resolveBranch(
     projectId: string,
     options: { branchName: string; signal?: AbortSignal },
-  ): Promise<PreviewBranchRecord>;
+  ): Promise<BranchRecord>;
   createBranchDatabase(options: {
     projectId: string;
     branchId: string;
     branchName: string;
     signal?: AbortSignal;
-  }): Promise<PreviewBranchDatabaseRecord>;
+  }): Promise<BranchDatabaseRecord>;
   deleteBranchDatabase(options: {
     databaseId: string;
     signal?: AbortSignal;
@@ -164,7 +164,7 @@ export interface PreviewAppProvider {
     key?: string;
     branchId?: string;
     signal?: AbortSignal;
-  }): Promise<PreviewEnvironmentVariableRecord[]>;
+  }): Promise<EnvironmentVariableRecord[]>;
   createEnvironmentVariable(options: {
     projectId: string;
     branchId?: string;
@@ -172,12 +172,12 @@ export interface PreviewAppProvider {
     key: string;
     value: string;
     signal?: AbortSignal;
-  }): Promise<PreviewEnvironmentVariableRecord>;
+  }): Promise<EnvironmentVariableRecord>;
   updateEnvironmentVariable(options: {
     envVarId: string;
     value: string;
     signal?: AbortSignal;
-  }): Promise<PreviewEnvironmentVariableRecord>;
+  }): Promise<EnvironmentVariableRecord>;
   deleteEnvironmentVariable(options: {
     envVarId: string;
     signal?: AbortSignal;
@@ -185,24 +185,24 @@ export interface PreviewAppProvider {
   listApps(
     projectId: string,
     options?: { branchName?: string; signal?: AbortSignal },
-  ): Promise<PreviewAppRecord[]>;
+  ): Promise<AppRecord[]>;
   removeApp(
     appId: string,
     options?: { signal?: AbortSignal },
-  ): Promise<PreviewRemovedAppRecord>;
+  ): Promise<RemovedAppRecord>;
   listDomains(
     appId: string,
     options?: { signal?: AbortSignal },
-  ): Promise<PreviewDomainRecord[]>;
+  ): Promise<DomainRecord[]>;
   addDomain(options: {
     appId: string;
     hostname: string;
     signal?: AbortSignal;
-  }): Promise<{ domain: PreviewDomainRecord; existing: boolean }>;
+  }): Promise<{ domain: DomainRecord; existing: boolean }>;
   showDomain(
     domainId: string,
     options?: { signal?: AbortSignal },
-  ): Promise<PreviewDomainRecord>;
+  ): Promise<DomainRecord>;
   removeDomain(
     domainId: string,
     options?: { signal?: AbortSignal },
@@ -210,7 +210,7 @@ export interface PreviewAppProvider {
   retryDomain(
     domainId: string,
     options?: { signal?: AbortSignal },
-  ): Promise<PreviewDomainRecord>;
+  ): Promise<DomainRecord>;
   promoteDeployment(options: {
     appId: string;
     deploymentId: string;
@@ -225,37 +225,37 @@ export interface PreviewAppProvider {
     appName?: string;
     region?: string;
     entrypoint?: string;
-    buildType?: PreviewBuildType;
-    buildSettings?: PreviewBuildSettings;
+    buildType?: AppBuildType;
+    buildSettings?: AppBuildSettings;
     portMapping?: PortMapping;
     envVars?: Record<string, string>;
     interaction?: unknown;
     signal?: AbortSignal;
     progress?: unknown;
-  }): Promise<PreviewDeployRecord>;
+  }): Promise<DeployRecord>;
   updateAppEnv(options: {
     appId: string;
     envVars: Record<string, string>;
     signal?: AbortSignal;
     progress?: unknown;
     promoteProgress?: unknown;
-  }): Promise<PreviewEnvRecord>;
+  }): Promise<EnvRecord>;
   listAppEnvNames(options: {
     appId: string;
     deploymentId: string;
     signal?: AbortSignal;
-  }): Promise<PreviewEnvRecord>;
+  }): Promise<EnvRecord>;
   listDeployments(
     appId: string,
     options?: { signal?: AbortSignal },
   ): Promise<{
-    app: PreviewAppRecord;
-    deployments: PreviewDeploymentRecord[];
+    app: AppRecord;
+    deployments: DeploymentRecord[];
   }>;
   showDeployment(
     deploymentId: string,
     options?: { signal?: AbortSignal },
-  ): Promise<PreviewShownDeploymentRecord | null>;
+  ): Promise<ShownDeploymentRecord | null>;
   streamDeploymentLogs(options: {
     deploymentId: string;
     signal?: AbortSignal;
@@ -263,13 +263,13 @@ export interface PreviewAppProvider {
   }): Promise<void>;
 }
 
-export function createPreviewAppProvider(
+export function createAppProvider(
   client: ManagementApiClient,
   options?: {
     baseUrl?: string;
     getToken?: () => Promise<string>;
   },
-): PreviewAppProvider {
+): AppProvider {
   const sdk = new ComputeClient(client);
 
   return {
@@ -501,7 +501,7 @@ export function createPreviewAppProvider(
             };
 
       const deployResult = await sdk.deploy({
-        strategy: new PreviewBuildStrategy({
+        strategy: new AppBuildStrategy({
           appPath: path.resolve(options.cwd),
           entrypoint: options.entrypoint,
           buildType: options.buildType,
@@ -798,7 +798,7 @@ interface RawDomainRecord {
   url: string;
   hostname: string;
   computeServiceId: string;
-  status: PreviewDomainStatus;
+  status: DomainStatus;
   foundryStatus: string;
   failureReason: string | null;
   failureCategory: "dns" | "acme" | "storage" | "unknown" | null;
@@ -892,7 +892,7 @@ async function listComputeServices(
     branchGitName?: string;
     signal?: AbortSignal;
   },
-): Promise<PreviewAppRecord[]> {
+): Promise<AppRecord[]> {
   const services: RawComputeServiceRecord[] = [];
   let cursor: string | undefined;
 
@@ -934,7 +934,7 @@ async function listComputeServiceDomains(
   client: ManagementApiClient,
   computeServiceId: string,
   signal?: AbortSignal,
-): Promise<PreviewDomainRecord[]> {
+): Promise<DomainRecord[]> {
   const result = await client.GET(
     "/v1/compute-services/{computeServiceId}/domains",
     {
@@ -956,7 +956,7 @@ async function listComputeServiceDomains(
   return result.data.data.map((domain) => normalizeDomainRecord(domain));
 }
 
-function normalizeDomainRecord(domain: RawDomainRecord): PreviewDomainRecord {
+function normalizeDomainRecord(domain: RawDomainRecord): DomainRecord {
   return {
     id: domain.id,
     type: domain.type,
@@ -976,7 +976,7 @@ function normalizeDomainRecord(domain: RawDomainRecord): PreviewDomainRecord {
 
 function normalizeDomainDnsRecords(
   records: RawDomainDnsRecord[] | null | undefined,
-): PreviewDomainDnsRecord[] {
+): DomainDnsRecord[] {
   if (!Array.isArray(records)) {
     return [];
   }
@@ -998,7 +998,7 @@ function normalizeDomainDnsRecords(
         ttl: typeof record.ttl === "number" ? record.ttl : null,
       };
     })
-    .filter((record): record is PreviewDomainDnsRecord => Boolean(record));
+    .filter((record): record is DomainDnsRecord => Boolean(record));
 }
 
 function sameHostname(left: string, right: string): boolean {
@@ -1087,8 +1087,8 @@ function domainApiCallError(
   summary: string,
   response: Response,
   error: RawApiErrorBody,
-): PreviewDomainApiError {
-  return new PreviewDomainApiError({
+): DomainApiError {
+  return new DomainApiError({
     summary,
     status: response.status,
     code: error.error?.code ?? null,
@@ -1103,7 +1103,7 @@ async function findAppForDeployment(
   sdk: ComputeClient,
   deploymentId: string,
   signal?: AbortSignal,
-): Promise<PreviewAppRecord | null> {
+): Promise<AppRecord | null> {
   const projectsResult = await sdk.listProjects({ signal });
   if (projectsResult.isErr()) {
     throw new Error(projectsResult.error.message);
@@ -1139,7 +1139,7 @@ async function findServiceAppForDeployment(
   serviceId: string,
   deploymentId: string,
   signal?: AbortSignal,
-): Promise<PreviewAppRecord | null> {
+): Promise<AppRecord | null> {
   const detailResult = await sdk.showService({
     serviceId,
     signal,
@@ -1148,7 +1148,7 @@ async function findServiceAppForDeployment(
     throw new Error(detailResult.error.message);
   }
 
-  const app: PreviewAppRecord = {
+  const app: AppRecord = {
     id: detailResult.value.id,
     name: detailResult.value.name,
     region: detailResult.value.region ?? null,

--- a/packages/cli/src/lib/app/branch-database-api.ts
+++ b/packages/cli/src/lib/app/branch-database-api.ts
@@ -1,7 +1,7 @@
 // biome-ignore-all lint/performance/noAwaitInLoops: Environment variable pagination must run sequentially.
 import type { ManagementApiClient } from "@prisma/management-api-sdk";
 
-export interface PreviewEnvironmentVariableRecord {
+export interface EnvironmentVariableRecord {
   id: string;
   key: string;
   branchId: string | null;
@@ -9,7 +9,7 @@ export interface PreviewEnvironmentVariableRecord {
   isManagedBySystem: boolean;
 }
 
-export interface PreviewBranchDatabaseRecord {
+export interface BranchDatabaseRecord {
   id: string;
   name: string;
   branchId: string | null;
@@ -58,7 +58,7 @@ export async function createBranchDatabase(
     branchName: string;
     signal?: AbortSignal;
   },
-): Promise<PreviewBranchDatabaseRecord> {
+): Promise<BranchDatabaseRecord> {
   const result = await client.POST("/v1/databases", {
     body: {
       projectId: options.projectId,
@@ -89,7 +89,7 @@ export async function listEnvironmentVariables(
     branchId?: string;
     signal?: AbortSignal;
   },
-): Promise<PreviewEnvironmentVariableRecord[]> {
+): Promise<EnvironmentVariableRecord[]> {
   const variables: RawEnvironmentVariableRecord[] = [];
   let cursor: string | undefined;
 
@@ -136,7 +136,7 @@ export async function createEnvironmentVariable(
     value: string;
     signal?: AbortSignal;
   },
-): Promise<PreviewEnvironmentVariableRecord> {
+): Promise<EnvironmentVariableRecord> {
   const result = await client.POST("/v1/environment-variables", {
     body: {
       projectId: options.projectId,
@@ -191,7 +191,7 @@ export async function updateEnvironmentVariable(
     value: string;
     signal?: AbortSignal;
   },
-): Promise<PreviewEnvironmentVariableRecord> {
+): Promise<EnvironmentVariableRecord> {
   const result = await client.PATCH("/v1/environment-variables/{envVarId}", {
     params: {
       path: { envVarId: options.envVarId },
@@ -240,7 +240,7 @@ export async function deleteEnvironmentVariable(
 
 function normalizeEnvironmentVariable(
   variable: RawEnvironmentVariableRecord,
-): PreviewEnvironmentVariableRecord {
+): EnvironmentVariableRecord {
   return {
     id: variable.id,
     key: variable.key,
@@ -252,7 +252,7 @@ function normalizeEnvironmentVariable(
 
 function normalizeBranchDatabaseRecord(
   database: RawDatabaseRecord,
-): PreviewBranchDatabaseRecord {
+): BranchDatabaseRecord {
   const connection = database.connections?.[0];
   const databaseUrl = connection?.endpoints?.pooled?.connectionString;
   const directUrl = connection?.endpoints?.direct?.connectionString ?? null;

--- a/packages/cli/src/lib/app/branch-database-deploy.ts
+++ b/packages/cli/src/lib/app/branch-database-deploy.ts
@@ -6,6 +6,11 @@ import { canPrompt } from "../../shell/runtime";
 import { renderSummaryLine } from "../../shell/ui";
 import type { AppDeployResult } from "../../types/app";
 import { formatCommandArgument } from "../project/setup";
+import type {
+  AppProvider,
+  BranchDatabaseRecord,
+  EnvironmentVariableRecord,
+} from "./app-provider";
 import {
   type BranchDatabaseSchema,
   type BranchDatabaseSignal,
@@ -13,11 +18,6 @@ import {
   inspectBranchDatabaseSignal,
   type UnsupportedBranchDatabaseSchema,
 } from "./branch-database";
-import type {
-  PreviewAppProvider,
-  PreviewBranchDatabaseRecord,
-  PreviewEnvironmentVariableRecord,
-} from "./preview-provider";
 
 export interface BranchDatabaseDeployBranch {
   id: string;
@@ -31,14 +31,14 @@ export interface BranchDatabaseSetupOutcome {
 }
 
 interface BranchDatabaseEnvState {
-  targetDatabaseUrl: PreviewEnvironmentVariableRecord | null;
-  targetDirectUrl: PreviewEnvironmentVariableRecord | null;
-  inheritedPreviewDatabaseUrl: PreviewEnvironmentVariableRecord | null;
+  targetDatabaseUrl: EnvironmentVariableRecord | null;
+  targetDirectUrl: EnvironmentVariableRecord | null;
+  inheritedPreviewDatabaseUrl: EnvironmentVariableRecord | null;
 }
 
 export async function maybeSetupBranchDatabase(
   context: CommandContext,
-  provider: PreviewAppProvider,
+  provider: AppProvider,
   projectId: string,
   branch: BranchDatabaseDeployBranch,
   options: {
@@ -169,7 +169,7 @@ export async function maybeSetupBranchDatabase(
 
 async function setupBranchDatabase(
   context: CommandContext,
-  provider: PreviewAppProvider,
+  provider: AppProvider,
   projectId: string,
   branch: BranchDatabaseDeployBranch,
   signal: BranchDatabaseSignal,
@@ -241,10 +241,10 @@ async function setupBranchDatabase(
 
 async function upsertBranchDatabaseEnvVars(
   context: CommandContext,
-  provider: PreviewAppProvider,
+  provider: AppProvider,
   projectId: string,
   branch: BranchDatabaseDeployBranch,
-  database: PreviewBranchDatabaseRecord,
+  database: BranchDatabaseRecord,
   envState: BranchDatabaseEnvState,
 ): Promise<string[]> {
   const scope = envScopeForBranch(branch);
@@ -289,14 +289,14 @@ async function upsertBranchDatabaseEnvVars(
 
 async function upsertBranchDatabaseEnvVar(
   context: CommandContext,
-  provider: PreviewAppProvider,
+  provider: AppProvider,
   options: {
     projectId: string;
     branchId?: string;
     className: "production" | "preview";
     key: "DATABASE_URL" | "DIRECT_URL";
     value: string;
-    existing: PreviewEnvironmentVariableRecord | null;
+    existing: EnvironmentVariableRecord | null;
     branch: BranchDatabaseDeployBranch;
   },
 ): Promise<void> {
@@ -336,7 +336,7 @@ async function upsertBranchDatabaseEnvVar(
 }
 
 async function inspectBranchDatabaseEnv(
-  provider: PreviewAppProvider,
+  provider: AppProvider,
   projectId: string,
   branch: BranchDatabaseDeployBranch,
   signal: AbortSignal,
@@ -371,9 +371,9 @@ async function inspectBranchDatabaseEnv(
 }
 
 function findEnvVar(
-  rows: PreviewEnvironmentVariableRecord[],
+  rows: EnvironmentVariableRecord[],
   options: { branchId: string | null },
-): PreviewEnvironmentVariableRecord | null {
+): EnvironmentVariableRecord | null {
   return rows.find((row) => row.branchId === options.branchId) ?? null;
 }
 
@@ -402,7 +402,7 @@ function getTargetDatabaseEnvVarKeys(
   envState: BranchDatabaseEnvState,
 ): string[] {
   return [envState.targetDatabaseUrl, envState.targetDirectUrl]
-    .filter((variable): variable is PreviewEnvironmentVariableRecord =>
+    .filter((variable): variable is EnvironmentVariableRecord =>
       Boolean(variable),
     )
     .map((variable) => variable.key)
@@ -593,8 +593,8 @@ function branchDatabaseSetupFailedError(
 
 async function cleanupCreatedBranchDatabaseAfterFailure(
   context: CommandContext,
-  provider: PreviewAppProvider,
-  database: PreviewBranchDatabaseRecord,
+  provider: AppProvider,
+  database: BranchDatabaseRecord,
   branch: BranchDatabaseDeployBranch,
   error: unknown,
 ): Promise<CliError> {
@@ -633,7 +633,7 @@ async function cleanupCreatedBranchDatabaseAfterFailure(
 function branchDatabaseCleanupFailedError(
   setupError: CliError,
   cleanupError: unknown,
-  database: PreviewBranchDatabaseRecord,
+  database: BranchDatabaseRecord,
   branch: BranchDatabaseDeployBranch,
 ): CliError {
   const cleanupWhy =

--- a/packages/cli/src/lib/app/build-settings.ts
+++ b/packages/cli/src/lib/app/build-settings.ts
@@ -6,12 +6,11 @@ import {
   resolveConfiguredBuildSettings,
 } from "@prisma/compute-sdk";
 import type { ConfigBackedBuildType } from "@prisma/compute-sdk/config";
-
+import type { ResolvedAppBuildType } from "./build";
 import type { BunPackageJsonLike } from "./bun-project";
-import type { ResolvedPreviewBuildType } from "./preview-build";
 
-export type PreviewBuildSettingsBuildType = Extract<
-  ResolvedPreviewBuildType,
+export type AppBuildSettingsBuildType = Extract<
+  ResolvedAppBuildType,
   ConfigBackedBuildType
 >;
 
@@ -23,15 +22,15 @@ export const PRISMA_APP_CONFIG_FILENAME = "prisma.app.json";
  * CLI-facing alias so existing imports stay stable while the resolution logic
  * lives in `@prisma/compute-sdk`.
  */
-export type PreviewBuildSettings = BuildSettings;
+export type AppBuildSettings = BuildSettings;
 
-export interface PreviewBuildSettingsResolution {
+export interface AppBuildSettingsResolution {
   /** "config" when the compute config owns the settings, "inferred" otherwise. */
   status: "config" | "inferred";
   /** The compute config path when status is "config". */
   configPath: string | null;
   relativeConfigPath: string | null;
-  settings: PreviewBuildSettings;
+  settings: AppBuildSettings;
 }
 
 export type LegacyBuildSettingsDetection =
@@ -53,7 +52,7 @@ export type LegacyBuildSettingsDetection =
  */
 export async function detectLegacyBuildSettings(options: {
   appPath: string;
-  effective: PreviewBuildSettings;
+  effective: AppBuildSettings;
   signal?: AbortSignal;
 }): Promise<LegacyBuildSettingsDetection> {
   const configPath = path.join(options.appPath, PRISMA_APP_CONFIG_FILENAME);
@@ -99,11 +98,11 @@ export async function detectLegacyBuildSettings(options: {
 }
 
 /** Resolves build settings purely from framework inference; nothing is read or written. */
-export async function resolveInferredPreviewBuildSettings(options: {
+export async function resolveInferredAppBuildSettings(options: {
   appPath: string;
-  buildType: ResolvedPreviewBuildType;
+  buildType: ResolvedAppBuildType;
   signal?: AbortSignal;
-}): Promise<PreviewBuildSettingsResolution> {
+}): Promise<AppBuildSettingsResolution> {
   return {
     status: "inferred",
     configPath: null,
@@ -116,9 +115,9 @@ export async function resolveInferredPreviewBuildSettings(options: {
  * Resolves build settings when the compute config owns them: configured
  * fields win, omitted fields fall back to framework defaults.
  */
-export async function resolveConfiguredPreviewBuildSettings(options: {
+export async function resolveConfiguredAppBuildSettings(options: {
   appPath: string;
-  buildType: PreviewBuildSettingsBuildType;
+  buildType: AppBuildSettingsBuildType;
   configured: {
     command: string | null | undefined;
     outputDirectory: string | undefined;
@@ -126,7 +125,7 @@ export async function resolveConfiguredPreviewBuildSettings(options: {
   /** Absolute path of the compute config file owning these settings. */
   configPath: string;
   signal?: AbortSignal;
-}): Promise<PreviewBuildSettingsResolution> {
+}): Promise<AppBuildSettingsResolution> {
   const configFilename = path.basename(options.configPath);
   const settings = await resolveConfiguredBuildSettings({
     appPath: options.appPath,
@@ -145,7 +144,7 @@ export async function resolveConfiguredPreviewBuildSettings(options: {
 }
 
 /** Inferred build settings for a resolved framework. Delegates to the SDK. */
-export const resolvePreviewBuildSettings = resolveBuildSettings;
+export const resolveAppBuildSettings = resolveBuildSettings;
 
 export function hasPackageDependency(
   packageJson: BunPackageJsonLike | null,

--- a/packages/cli/src/lib/app/build.ts
+++ b/packages/cli/src/lib/app/build.ts
@@ -9,23 +9,23 @@ import {
   stageStandaloneArtifact,
 } from "@prisma/compute-sdk";
 
-import type { PreviewBuildSettings } from "./preview-build-settings";
+import type { AppBuildSettings } from "./build-settings";
 
 export {
+  type AppBuildSettings,
+  type AppBuildSettingsBuildType,
+  type AppBuildSettingsResolution,
   detectLegacyBuildSettings,
   hasAnyPackageDependency,
   hasPackageDependency,
   type LegacyBuildSettingsDetection,
   PRISMA_APP_CONFIG_FILENAME,
-  type PreviewBuildSettings,
-  type PreviewBuildSettingsBuildType,
-  type PreviewBuildSettingsResolution,
-  resolveConfiguredPreviewBuildSettings,
-  resolveInferredPreviewBuildSettings,
-  resolvePreviewBuildSettings,
-} from "./preview-build-settings";
+  resolveAppBuildSettings,
+  resolveConfiguredAppBuildSettings,
+  resolveInferredAppBuildSettings,
+} from "./build-settings";
 
-export const PREVIEW_BUILD_TYPES = [
+export const APP_BUILD_TYPES = [
   "auto",
   "bun",
   "nextjs",
@@ -35,26 +35,26 @@ export const PREVIEW_BUILD_TYPES = [
   "tanstack-start",
 ] as const;
 
-export type PreviewBuildType = (typeof PREVIEW_BUILD_TYPES)[number];
-export type ResolvedPreviewBuildType = Exclude<PreviewBuildType, "auto">;
+export type AppBuildType = (typeof APP_BUILD_TYPES)[number];
+export type ResolvedAppBuildType = Exclude<AppBuildType, "auto">;
 
-export const RESOLVED_PREVIEW_BUILD_TYPES = PREVIEW_BUILD_TYPES.filter(
-  (buildType): buildType is ResolvedPreviewBuildType => buildType !== "auto",
+export const RESOLVED_APP_BUILD_TYPES = APP_BUILD_TYPES.filter(
+  (buildType): buildType is ResolvedAppBuildType => buildType !== "auto",
 );
 
-export class PreviewBuildStrategy implements BuildStrategy {
+export class AppBuildStrategy implements BuildStrategy {
   readonly #appPath: string;
   readonly #entrypoint?: string;
-  readonly #buildType: PreviewBuildType;
+  readonly #buildType: AppBuildType;
   readonly #signal?: AbortSignal;
-  readonly #buildSettings?: PreviewBuildSettings;
+  readonly #buildSettings?: AppBuildSettings;
 
   constructor(options: {
     appPath: string;
     entrypoint?: string;
-    buildType?: PreviewBuildType;
+    buildType?: AppBuildType;
     signal?: AbortSignal;
-    buildSettings?: PreviewBuildSettings;
+    buildSettings?: AppBuildSettings;
   }) {
     this.#appPath = options.appPath;
     this.#entrypoint = options.entrypoint;
@@ -64,7 +64,7 @@ export class PreviewBuildStrategy implements BuildStrategy {
   }
 
   async canBuild(signal = this.#signal): Promise<boolean> {
-    const { strategy } = await resolvePreviewBuildStrategy({
+    const { strategy } = await resolveAppBuildStrategy({
       appPath: this.#appPath,
       entrypoint: this.#entrypoint,
       buildType: this.#buildType,
@@ -76,7 +76,7 @@ export class PreviewBuildStrategy implements BuildStrategy {
   }
 
   async execute(signal = this.#signal): Promise<BuildArtifact> {
-    const { artifact } = await executePreviewBuild({
+    const { artifact } = await executeAppBuild({
       appPath: this.#appPath,
       entrypoint: this.#entrypoint,
       buildType: this.#buildType,
@@ -88,17 +88,17 @@ export class PreviewBuildStrategy implements BuildStrategy {
   }
 }
 
-export async function executePreviewBuild(options: {
+export async function executeAppBuild(options: {
   appPath: string;
   entrypoint?: string;
-  buildType?: PreviewBuildType;
+  buildType?: AppBuildType;
   signal?: AbortSignal;
-  buildSettings?: PreviewBuildSettings;
+  buildSettings?: AppBuildSettings;
 }): Promise<{
   artifact: BuildArtifact;
-  buildType: ResolvedPreviewBuildType;
+  buildType: ResolvedAppBuildType;
 }> {
-  const { strategy, buildType } = await resolvePreviewBuildStrategy({
+  const { strategy, buildType } = await resolveAppBuildStrategy({
     appPath: options.appPath,
     entrypoint: options.entrypoint,
     buildType: options.buildType ?? "auto",
@@ -123,15 +123,15 @@ export async function executePreviewBuild(options: {
   }
 }
 
-export async function resolvePreviewBuildStrategy(options: {
+export async function resolveAppBuildStrategy(options: {
   appPath: string;
   entrypoint?: string;
-  buildType: PreviewBuildType;
+  buildType: AppBuildType;
   signal?: AbortSignal;
-  buildSettings?: PreviewBuildSettings;
+  buildSettings?: AppBuildSettings;
 }): Promise<{
   strategy: BuildStrategy;
-  buildType: ResolvedPreviewBuildType;
+  buildType: ResolvedAppBuildType;
 }> {
   // Detection, per-framework construction, and Bun entrypoint resolution
   // (package.json `main`) all live in the SDK now; the CLI forwards. The CLI's

--- a/packages/cli/src/lib/app/bun-project.ts
+++ b/packages/cli/src/lib/app/bun-project.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 
 export interface BunPackageJsonLike {
   main?: unknown;
-  module?: unknown;
   packageManager?: unknown;
   scripts?: unknown;
   dependencies?: unknown;
@@ -42,15 +41,7 @@ export async function readBunPackageJson(
 export function readBunPackageEntrypoint(
   packageJson: BunPackageJsonLike | null,
 ): string | undefined {
-  if (typeof packageJson?.main === "string") {
-    return packageJson.main;
-  }
-
-  if (typeof packageJson?.module === "string") {
-    return packageJson.module;
-  }
-
-  return undefined;
+  return typeof packageJson?.main === "string" ? packageJson.main : undefined;
 }
 
 export async function resolveBunEntrypoint(
@@ -63,7 +54,7 @@ export async function resolveBunEntrypoint(
 
   if (!candidate) {
     throw new Error(
-      "Entrypoint is required. Pass --entry or define package.json main or module.",
+      "Entrypoint is required. Pass --entry or define package.json main.",
     );
   }
 

--- a/packages/cli/src/lib/app/deploy-progress.ts
+++ b/packages/cli/src/lib/app/deploy-progress.ts
@@ -7,7 +7,7 @@ import type {
 import type { ShellUi } from "../../shell/ui";
 import { renderDeployOutputRows } from "./deploy-output";
 
-export interface PreviewDeployProgressState {
+export interface DeployProgressState {
   buildStarted: boolean;
   buildCompleted: boolean;
   archiveReady: boolean;
@@ -19,7 +19,7 @@ export interface PreviewDeployProgressState {
   promotedUrl: string | null;
 }
 
-export function createPreviewDeployProgressState(): PreviewDeployProgressState {
+export function createDeployProgressState(): DeployProgressState {
   return {
     buildStarted: false,
     buildCompleted: false,
@@ -33,11 +33,11 @@ export function createPreviewDeployProgressState(): PreviewDeployProgressState {
   };
 }
 
-export function createPreviewDeployProgress(
+export function createDeployProgress(
   output: Writable,
   ui: ShellUi,
   enabled: boolean,
-  state: PreviewDeployProgressState = createPreviewDeployProgressState(),
+  state: DeployProgressState = createDeployProgressState(),
 ): DeployProgress | undefined {
   const write = (line: string) => {
     if (!enabled) {
@@ -94,7 +94,7 @@ function formatArtifactSize(byteLength: number): string {
   return `${(byteLength / 1024 / 1024).toFixed(1)} MB`;
 }
 
-export function createPreviewPromoteProgress(
+export function createPromoteProgress(
   output: Writable,
   enabled: boolean,
 ): PromoteProgress | undefined {
@@ -136,7 +136,7 @@ export function createPreviewPromoteProgress(
   };
 }
 
-export function createPreviewUpdateEnvProgress(
+export function createUpdateEnvProgress(
   output: Writable,
   enabled: boolean,
 ): UpdateEnvProgress | undefined {

--- a/packages/cli/src/lib/app/local-dev.ts
+++ b/packages/cli/src/lib/app/local-dev.ts
@@ -3,20 +3,14 @@
 import { type SpawnOptions, spawn } from "node:child_process";
 import { access } from "node:fs/promises";
 import path from "node:path";
+import type { AppBuildType, ResolvedAppBuildType } from "./build";
 import {
   readBunPackageEntrypoint,
   readBunPackageJson,
   resolveBunEntrypoint,
 } from "./bun-project";
-import type {
-  PreviewBuildType,
-  ResolvedPreviewBuildType,
-} from "./preview-build";
 
-export type LocalBuildType = Extract<
-  ResolvedPreviewBuildType,
-  "bun" | "nextjs"
->;
+export type LocalBuildType = Extract<ResolvedAppBuildType, "bun" | "nextjs">;
 
 const NEXT_CONFIG_FILENAMES = [
   "next.config.js",
@@ -44,7 +38,7 @@ interface CommandCandidate {
 
 export async function resolveLocalBuildType(
   appPath: string,
-  buildType: PreviewBuildType,
+  buildType: AppBuildType,
   signal?: AbortSignal,
 ): Promise<LocalBuildType | null> {
   if (buildType === "bun" || buildType === "nextjs") {

--- a/packages/cli/src/lib/app/preview-build-settings.ts
+++ b/packages/cli/src/lib/app/preview-build-settings.ts
@@ -1,16 +1,15 @@
-import { exec } from "node:child_process";
-import { readdir, readFile, stat } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import {
-  type ConfigBackedBuildType,
-  sourceRootLineage,
-} from "@prisma/compute-sdk/config";
-import { type ASTNode, parseModule } from "magicast";
+  type BuildSettings,
+  resolveBuildSettings,
+  resolveConfiguredBuildSettings,
+} from "@prisma/compute-sdk";
+import type { ConfigBackedBuildType } from "@prisma/compute-sdk/config";
 
-import { type BunPackageJsonLike, readBunPackageJson } from "./bun-project";
+import type { BunPackageJsonLike } from "./bun-project";
 import type { ResolvedPreviewBuildType } from "./preview-build";
 
-type PackageManager = "bun" | "pnpm" | "yarn" | "npm";
 export type PreviewBuildSettingsBuildType = Extract<
   ResolvedPreviewBuildType,
   ConfigBackedBuildType
@@ -19,22 +18,12 @@ export type PreviewBuildSettingsBuildType = Extract<
 /** Legacy build-settings file: no longer read or written, only detected for migration. */
 export const PRISMA_APP_CONFIG_FILENAME = "prisma.app.json";
 
-interface ResolvedBuildCommand {
-  command: string | null;
-  source: string | null;
-}
-
-interface StaticNextConfig {
-  distDir?: string;
-  output?: "standalone" | "export";
-}
-
-export interface PreviewBuildSettings {
-  buildCommand: string | null;
-  buildCommandSource: string | null;
-  outputDirectory: string;
-  outputDirectorySource: string | null;
-}
+/**
+ * Build settings shape. Identical to the SDK's `BuildSettings`; kept as a
+ * CLI-facing alias so existing imports stay stable while the resolution logic
+ * lives in `@prisma/compute-sdk`.
+ */
+export type PreviewBuildSettings = BuildSettings;
 
 export interface PreviewBuildSettingsResolution {
   /** "config" when the compute config owns the settings, "inferred" otherwise. */
@@ -119,7 +108,7 @@ export async function resolveInferredPreviewBuildSettings(options: {
     status: "inferred",
     configPath: null,
     relativeConfigPath: null,
-    settings: await resolvePreviewBuildSettings(options),
+    settings: await resolveBuildSettings(options),
   };
 }
 
@@ -139,147 +128,24 @@ export async function resolveConfiguredPreviewBuildSettings(options: {
   signal?: AbortSignal;
 }): Promise<PreviewBuildSettingsResolution> {
   const configFilename = path.basename(options.configPath);
-  const source = `set by ${configFilename}`;
-  const needsFallback =
-    options.configured.command === undefined ||
-    options.configured.outputDirectory === undefined;
-  const fallback = needsFallback
-    ? await resolvePreviewBuildSettings(options)
-    : null;
+  const settings = await resolveConfiguredBuildSettings({
+    appPath: options.appPath,
+    buildType: options.buildType,
+    configured: options.configured,
+    source: `set by ${configFilename}`,
+    signal: options.signal,
+  });
 
   return {
     status: "config",
     configPath: options.configPath,
     relativeConfigPath: configFilename,
-    settings: {
-      buildCommand:
-        options.configured.command !== undefined
-          ? options.configured.command
-          : fallback!.buildCommand,
-      buildCommandSource:
-        options.configured.command !== undefined
-          ? source
-          : fallback!.buildCommandSource,
-      outputDirectory:
-        options.configured.outputDirectory ?? fallback!.outputDirectory,
-      outputDirectorySource:
-        options.configured.outputDirectory !== undefined
-          ? source
-          : fallback!.outputDirectorySource,
-    },
+    settings,
   };
 }
 
-export async function resolvePreviewBuildSettings(options: {
-  appPath: string;
-  buildType: ResolvedPreviewBuildType;
-  signal?: AbortSignal;
-}): Promise<PreviewBuildSettings> {
-  switch (options.buildType) {
-    // The nuxt and astro strategies invoke the framework CLI and stage fixed
-    // output themselves; these settings only describe that for display.
-    case "nuxt":
-      return {
-        buildCommand: "nuxt build",
-        buildCommandSource: "Nuxt default",
-        outputDirectory: ".output",
-        outputDirectorySource: "Nuxt output",
-      };
-    case "astro":
-      return {
-        buildCommand: "astro build",
-        buildCommandSource: "Astro default",
-        outputDirectory: "dist",
-        outputDirectorySource: "Astro output",
-      };
-    case "nextjs": {
-      const packageJson = await readBunPackageJson(
-        options.appPath,
-        options.signal,
-      );
-      const buildCommand = await resolveFrameworkBuildCommand(
-        options.appPath,
-        packageJson,
-        {
-          command: "next build",
-          source: "Next.js default",
-          signal: options.signal,
-        },
-      );
-      const outputRoot = await resolveNextOutputRoot(
-        options.appPath,
-        options.signal,
-      );
-      return {
-        buildCommand: buildCommand.command,
-        buildCommandSource: buildCommand.source,
-        outputDirectory: joinPosix(outputRoot, "standalone"),
-        outputDirectorySource:
-          outputRoot === ".next" ? "Next.js output" : "next.config distDir",
-      };
-    }
-    case "tanstack-start": {
-      const packageJson = await readBunPackageJson(
-        options.appPath,
-        options.signal,
-      );
-      const buildCommand = await resolveFrameworkBuildCommand(
-        options.appPath,
-        packageJson,
-        {
-          command: "vite build",
-          source: "TanStack Start default",
-          signal: options.signal,
-        },
-      );
-      return {
-        buildCommand: buildCommand.command,
-        buildCommandSource: buildCommand.source,
-        outputDirectory: ".output",
-        outputDirectorySource: "TanStack Start output",
-      };
-    }
-    case "bun": {
-      const packageJson = await readBunPackageJson(
-        options.appPath,
-        options.signal,
-      );
-      const buildCommand = await resolveFrameworkBuildCommand(
-        options.appPath,
-        packageJson,
-        {
-          command: null,
-          source: null,
-          signal: options.signal,
-        },
-      );
-      return {
-        buildCommand: buildCommand.command,
-        buildCommandSource: buildCommand.source,
-        outputDirectory: ".",
-        outputDirectorySource: "app root",
-      };
-    }
-  }
-}
-
-export async function hasRootFile(
-  appPath: string,
-  filenames: readonly string[],
-  signal?: AbortSignal,
-): Promise<boolean> {
-  let entries: string[];
-  try {
-    signal?.throwIfAborted();
-    entries = await readdir(appPath);
-    signal?.throwIfAborted();
-  } catch (error) {
-    if (signal?.aborted) throw error;
-    return false;
-  }
-
-  return entries.some((entry) => filenames.includes(entry));
-}
+/** Inferred build settings for a resolved framework. Delegates to the SDK. */
+export const resolvePreviewBuildSettings = resolveBuildSettings;
 
 export function hasPackageDependency(
   packageJson: BunPackageJsonLike | null,
@@ -309,429 +175,7 @@ export function hasAnyPackageDependency(
   });
 }
 
-async function resolveFrameworkBuildCommand(
-  appPath: string,
-  packageJson: BunPackageJsonLike | null,
-  fallback: {
-    command: string | null;
-    source: string | null;
-    signal?: AbortSignal;
-  },
-): Promise<ResolvedBuildCommand> {
-  const buildScript = readBuildScript(packageJson);
-  if (buildScript) {
-    const packageManager = await resolvePackageManager(
-      appPath,
-      packageJson,
-      fallback.signal,
-    );
-    if (!packageManager) {
-      return {
-        command: buildScript,
-        source: "package.json scripts.build",
-      };
-    }
-
-    return {
-      command: `${packageManager} run build`,
-      source: "package.json scripts.build",
-    };
-  }
-
-  return {
-    command: fallback.command,
-    source: fallback.source,
-  };
-}
-
-function readBuildScript(
-  packageJson: BunPackageJsonLike | null,
-): string | null {
-  if (!packageJson?.scripts || typeof packageJson.scripts !== "object") {
-    return null;
-  }
-
-  const scripts = packageJson.scripts as Record<string, unknown>;
-  if (typeof scripts.build !== "string") {
-    return null;
-  }
-
-  const buildScript = scripts.build.trim();
-  return buildScript.length > 0 ? buildScript : null;
-}
-
-async function resolvePackageManager(
-  appPath: string,
-  packageJson: BunPackageJsonLike | null,
-  signal?: AbortSignal,
-): Promise<PackageManager | undefined> {
-  // Workspace repos keep the lockfile and packageManager field at the
-  // workspace root, so check every level from the app up to the source root.
-  // The nearest level wins.
-  for (const directory of await sourceRootLineage(appPath, signal)) {
-    const levelPackageJson =
-      directory === path.resolve(appPath)
-        ? packageJson
-        : await readBunPackageJson(directory, signal);
-
-    const fromPackageManager = packageManagerFromPackageJson(
-      levelPackageJson?.packageManager,
-    );
-    if (fromPackageManager) {
-      return fromPackageManager;
-    }
-
-    if (
-      (await pathExists(path.join(directory, "bun.lock"), signal)) ||
-      (await pathExists(path.join(directory, "bun.lockb"), signal))
-    ) {
-      return "bun";
-    }
-
-    if (await pathExists(path.join(directory, "pnpm-lock.yaml"), signal)) {
-      return "pnpm";
-    }
-
-    if (await pathExists(path.join(directory, "yarn.lock"), signal)) {
-      return "yarn";
-    }
-
-    if (await pathExists(path.join(directory, "package-lock.json"), signal)) {
-      return "npm";
-    }
-  }
-}
-
-function packageManagerFromPackageJson(value: unknown): PackageManager | null {
-  if (typeof value !== "string") {
-    return null;
-  }
-
-  const name = value.split("@")[0];
-  return name === "bun" || name === "pnpm" || name === "yarn" || name === "npm"
-    ? name
-    : null;
-}
-
-export async function runResolvedBuildCommand(
-  appPath: string,
-  settings: PreviewBuildSettings,
-  failurePrefix: string,
-  signal?: AbortSignal,
-): Promise<void> {
-  if (!settings.buildCommand) {
-    return;
-  }
-
-  // Workspace repos may hoist binaries like `next` to the workspace root, so
-  // expose every node_modules/.bin between the app and its source root.
-  const binDirs = (await sourceRootLineage(appPath, signal)).map((directory) =>
-    path.join(directory, "node_modules", ".bin"),
-  );
-  await execBuildCommand(
-    settings.buildCommand,
-    appPath,
-    binDirs,
-    failurePrefix,
-    signal,
-  );
-}
-
-function execBuildCommand(
-  command: string,
-  cwd: string,
-  binDirs: string[],
-  failurePrefix: string,
-  signal?: AbortSignal,
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const child = exec(
-      command,
-      {
-        cwd,
-        env: {
-          ...process.env,
-          PATH: [...binDirs, process.env.PATH]
-            .filter(Boolean)
-            .join(path.delimiter),
-        },
-        maxBuffer: 10 * 1024 * 1024,
-        signal,
-      },
-      (error, stdout, stderr) => {
-        if (error) {
-          const output = [stderr.trim(), stdout.trim()]
-            .filter(Boolean)
-            .join("\n");
-          reject(
-            new Error(`${failurePrefix} failed:\n${output || error.message}`),
-          );
-          return;
-        }
-
-        resolve();
-      },
-    );
-
-    if (signal?.aborted) {
-      child.kill();
-    }
-  });
-}
-
-async function resolveNextOutputRoot(
-  appPath: string,
-  signal?: AbortSignal,
-): Promise<string> {
-  const config = await readNextConfig(appPath, signal);
-  return config.distDir ?? ".next";
-}
-
-async function readNextConfig(
-  appPath: string,
-  signal?: AbortSignal,
-): Promise<StaticNextConfig> {
-  for (const fileName of NEXT_CONFIG_FILENAMES) {
-    const filePath = path.join(appPath, fileName);
-    let content: string;
-    try {
-      content = await readFile(filePath, { encoding: "utf8", signal });
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-        continue;
-      }
-
-      throw error;
-    }
-
-    return readStaticNextConfig(content);
-  }
-
-  return {};
-}
-
-const NEXT_CONFIG_FILENAMES = [
-  "next.config.js",
-  "next.config.mjs",
-  "next.config.ts",
-  "next.config.mts",
-] as const;
-
-function readStaticNextConfig(content: string): StaticNextConfig {
-  try {
-    const module = parseModule(content);
-    const program = asAstNode(module.$ast);
-    const bindings = program
-      ? collectStaticBindings(program)
-      : new Map<string, AstNode>();
-    const configObject = program
-      ? findExportedConfigObject(program, bindings)
-      : null;
-    if (!configObject) {
-      return {};
-    }
-
-    const rawDistDir = readStaticStringProperty(configObject, "distDir");
-    const output = readStaticStringProperty(configObject, "output");
-    const distDir = rawDistDir ? normalizeRelativePath(rawDistDir) : undefined;
-
-    return {
-      distDir,
-      output:
-        output === "standalone" || output === "export" ? output : undefined,
-    };
-  } catch {
-    return {};
-  }
-}
-
-export function joinPosix(...parts: string[]): string {
-  return parts.join("/").replace(/\/+/g, "/");
-}
-
-export function nextOutputRootFromStandaloneDirectory(
-  outputDirectory: string,
-): string {
-  const normalized = outputDirectory.replace(/\/+$/g, "");
-  if (normalized === "standalone") {
-    return ".";
-  }
-
-  if (normalized.endsWith("/standalone")) {
-    const outputRoot = normalized.slice(0, -"/standalone".length);
-    return outputRoot.length > 0 ? outputRoot : ".";
-  }
-
-  const dirname = path.posix.dirname(normalized);
-  return dirname === "." ? "." : dirname;
-}
-
-type AstNode = ASTNode & { type: string; [key: string]: unknown };
-
-function asAstNode(value: unknown): AstNode | null {
-  if (!value || typeof value !== "object") {
-    return null;
-  }
-
-  const type = (value as { type?: unknown }).type;
-  return typeof type === "string" ? (value as AstNode) : null;
-}
-
-function astNodes(value: unknown): AstNode[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  return value.map(asAstNode).filter((node): node is AstNode => Boolean(node));
-}
-
-function collectStaticBindings(program: AstNode): Map<string, AstNode> {
-  const bindings = new Map<string, AstNode>();
-  for (const statement of astNodes(program.body)) {
-    if (statement.type !== "VariableDeclaration") {
-      continue;
-    }
-
-    for (const declaration of astNodes(statement.declarations)) {
-      const id = asAstNode(declaration.id);
-      const init = asAstNode(declaration.init);
-      if (id?.type === "Identifier" && typeof id.name === "string" && init) {
-        bindings.set(id.name, init);
-      }
-    }
-  }
-
-  return bindings;
-}
-
-function findExportedConfigObject(
-  program: AstNode,
-  bindings: Map<string, AstNode>,
-): AstNode | null {
-  for (const statement of astNodes(program.body)) {
-    if (statement.type === "ExportDefaultDeclaration") {
-      return resolveConfigObject(statement.declaration, bindings);
-    }
-
-    if (statement.type !== "ExpressionStatement") {
-      continue;
-    }
-
-    const expression = asAstNode(statement.expression);
-    if (
-      expression?.type !== "AssignmentExpression" ||
-      expression.operator !== "="
-    ) {
-      continue;
-    }
-
-    if (isModuleExports(expression.left)) {
-      return resolveConfigObject(expression.right, bindings);
-    }
-  }
-
-  return null;
-}
-
-function resolveConfigObject(
-  value: unknown,
-  bindings: Map<string, AstNode>,
-  depth = 0,
-): AstNode | null {
-  if (depth > 4) {
-    return null;
-  }
-
-  const node = unwrapStaticExpression(asAstNode(value));
-  if (!node) {
-    return null;
-  }
-
-  if (node.type === "ObjectExpression") {
-    return node;
-  }
-
-  if (node.type === "Identifier" && typeof node.name === "string") {
-    return resolveConfigObject(bindings.get(node.name), bindings, depth + 1);
-  }
-
-  if (node.type === "CallExpression") {
-    return resolveConfigObject(
-      astNodes(node.arguments)[0],
-      bindings,
-      depth + 1,
-    );
-  }
-
-  return null;
-}
-
-function unwrapStaticExpression(node: AstNode | null): AstNode | null {
-  let current = node;
-  while (
-    current?.type === "TSAsExpression" ||
-    current?.type === "TSSatisfiesExpression" ||
-    current?.type === "TSNonNullExpression"
-  ) {
-    current = asAstNode(current.expression);
-  }
-
-  return current;
-}
-
-function isModuleExports(value: unknown): boolean {
-  const node = asAstNode(value);
-  if (node?.type !== "MemberExpression" || node.computed === true) {
-    return false;
-  }
-
-  const object = asAstNode(node.object);
-  const property = asAstNode(node.property);
-  return (
-    object?.type === "Identifier" &&
-    object.name === "module" &&
-    property?.type === "Identifier" &&
-    property.name === "exports"
-  );
-}
-
-function readStaticStringProperty(
-  objectExpression: AstNode,
-  propertyName: string,
-): string | undefined {
-  for (const property of astNodes(objectExpression.properties)) {
-    if (property.type !== "ObjectProperty" || property.computed === true) {
-      continue;
-    }
-
-    if (propertyKeyName(property.key) !== propertyName) {
-      continue;
-    }
-
-    const value = unwrapStaticExpression(asAstNode(property.value));
-    if (value?.type === "StringLiteral" && typeof value.value === "string") {
-      const trimmed = value.value.trim();
-      return trimmed.length > 0 ? trimmed : undefined;
-    }
-  }
-
-  return undefined;
-}
-
-function propertyKeyName(value: unknown): string | undefined {
-  const key = asAstNode(value);
-  if (key?.type === "Identifier" && typeof key.name === "string") {
-    return key.name;
-  }
-
-  if (key?.type === "StringLiteral" && typeof key.value === "string") {
-    return key.value;
-  }
-
-  return undefined;
-}
-
-export function normalizeRelativePath(value: string): string | undefined {
+function normalizeRelativePath(value: string): string | undefined {
   const raw = value.trim().replace(/\\/g, "/");
   if (raw.length === 0 || raw.split("/").includes("..")) {
     return undefined;
@@ -753,19 +197,4 @@ export function normalizeRelativePath(value: string): string | undefined {
   }
 
   return normalized === "." ? "." : normalized;
-}
-
-async function pathExists(
-  targetPath: string,
-  signal?: AbortSignal,
-): Promise<boolean> {
-  try {
-    signal?.throwIfAborted();
-    await stat(targetPath);
-    signal?.throwIfAborted();
-    return true;
-  } catch (error) {
-    if (signal?.aborted) throw error;
-    return false;
-  }
 }

--- a/packages/cli/src/lib/app/preview-build.ts
+++ b/packages/cli/src/lib/app/preview-build.ts
@@ -2,19 +2,13 @@ import { cp, rm, stat } from "node:fs/promises";
 import path from "node:path";
 
 import {
-  AstroBuild,
   type BuildArtifact,
   type BuildStrategy,
-  BunBuild,
-  NestjsBuild,
-  NextjsBuild,
-  NuxtBuild,
   normalizeArtifactSymlinks,
+  resolveBuildStrategy,
   stageStandaloneArtifact,
-  TanstackStartBuild,
 } from "@prisma/compute-sdk";
 
-import { resolveBunEntrypoint } from "./bun-project";
 import type { PreviewBuildSettings } from "./preview-build-settings";
 
 export {
@@ -139,99 +133,16 @@ export async function resolvePreviewBuildStrategy(options: {
   strategy: BuildStrategy;
   buildType: ResolvedPreviewBuildType;
 }> {
-  if (options.buildType !== "auto") {
-    const strategy = await createPreviewBuildStrategy({
-      appPath: options.appPath,
-      entrypoint: options.entrypoint,
-      buildType: options.buildType,
-      signal: options.signal,
-      buildSettings: options.buildSettings,
-    });
-
-    return {
-      buildType: options.buildType,
-      strategy,
-    };
-  }
-
-  for (const buildType of RESOLVED_PREVIEW_BUILD_TYPES) {
-    // Bun is the fallback because it can build any valid Bun entrypoint.
-    if (buildType === "bun") continue;
-
-    const strategy = await createPreviewBuildStrategy({
-      appPath: options.appPath,
-      entrypoint: options.entrypoint,
-      buildType,
-      signal: options.signal,
-      buildSettings: options.buildSettings,
-    });
-
-    if (await strategy.canBuild(options.signal)) {
-      return {
-        buildType,
-        strategy,
-      };
-    }
-  }
-
-  return {
-    buildType: "bun",
-    strategy: await createPreviewBuildStrategy({
-      appPath: options.appPath,
-      entrypoint: options.entrypoint,
-      buildType: "bun",
-      signal: options.signal,
-      buildSettings: options.buildSettings,
-    }),
-  };
-}
-
-/**
- * Constructs the SDK build strategy for a resolved framework. The strategies
- * run the framework build (and any `package.json` build script) and stage a
- * deployable artifact themselves; the CLI only resolves the Bun entrypoint,
- * which supports the `module` field on top of `main`.
- */
-async function createPreviewBuildStrategy(options: {
-  appPath: string;
-  entrypoint?: string;
-  buildType: ResolvedPreviewBuildType;
-  signal?: AbortSignal;
-  buildSettings?: PreviewBuildSettings;
-}): Promise<BuildStrategy> {
-  switch (options.buildType) {
-    case "nextjs":
-      return new NextjsBuild({
-        appPath: options.appPath,
-        buildSettings: options.buildSettings,
-      });
-    case "nuxt":
-      return new NuxtBuild({ appPath: options.appPath });
-    case "astro":
-      return new AstroBuild({ appPath: options.appPath });
-    case "nestjs":
-      return new NestjsBuild({
-        appPath: options.appPath,
-        buildSettings: options.buildSettings,
-      });
-    case "tanstack-start":
-      return new TanstackStartBuild({
-        appPath: options.appPath,
-        buildSettings: options.buildSettings,
-      });
-    case "bun": {
-      const entrypoint = await resolveBunEntrypoint(
-        options.appPath,
-        options.entrypoint,
-        options.signal,
-      );
-      return new BunBuild({
-        appPath: options.appPath,
-        entrypoint,
-        buildSettings: options.buildSettings,
-      });
-    }
-  }
+  // Detection, per-framework construction, and Bun entrypoint resolution
+  // (package.json `main`) all live in the SDK now; the CLI forwards. The CLI's
+  // build types map 1:1 to the SDK's, and `auto` is the SDK default.
+  return resolveBuildStrategy({
+    appPath: options.appPath,
+    buildType: options.buildType,
+    entrypoint: options.entrypoint,
+    buildSettings: options.buildSettings,
+    signal: options.signal,
+  });
 }
 
 /**

--- a/packages/cli/src/lib/app/preview-build.ts
+++ b/packages/cli/src/lib/app/preview-build.ts
@@ -1,18 +1,4 @@
-import {
-  chmod,
-  copyFile,
-  cp,
-  lstat,
-  mkdir,
-  mkdtemp,
-  readdir,
-  readFile,
-  readlink,
-  rm,
-  stat,
-  writeFile,
-} from "node:fs/promises";
-import os from "node:os";
+import { cp, rm, stat } from "node:fs/promises";
 import path from "node:path";
 
 import {
@@ -20,24 +6,21 @@ import {
   type BuildArtifact,
   type BuildStrategy,
   BunBuild,
+  NestjsBuild,
+  NextjsBuild,
   NuxtBuild,
+  normalizeArtifactSymlinks,
+  stageStandaloneArtifact,
+  TanstackStartBuild,
 } from "@prisma/compute-sdk";
-import { resolveSourceRoot } from "@prisma/compute-sdk/config";
-import { readBunPackageJson, resolveBunEntrypoint } from "./bun-project";
-import {
-  hasAnyPackageDependency,
-  hasPackageDependency,
-  hasRootFile,
-  joinPosix,
-  nextOutputRootFromStandaloneDirectory,
-  PRISMA_APP_CONFIG_FILENAME,
-  type PreviewBuildSettings,
-  resolvePreviewBuildSettings,
-  runResolvedBuildCommand,
-} from "./preview-build-settings";
+
+import { resolveBunEntrypoint } from "./bun-project";
+import type { PreviewBuildSettings } from "./preview-build-settings";
 
 export {
   detectLegacyBuildSettings,
+  hasAnyPackageDependency,
+  hasPackageDependency,
   type LegacyBuildSettingsDetection,
   PRISMA_APP_CONFIG_FILENAME,
   type PreviewBuildSettings,
@@ -54,6 +37,7 @@ export const PREVIEW_BUILD_TYPES = [
   "nextjs",
   "nuxt",
   "astro",
+  "nestjs",
   "tanstack-start",
 ] as const;
 
@@ -202,6 +186,12 @@ export async function resolvePreviewBuildStrategy(options: {
   };
 }
 
+/**
+ * Constructs the SDK build strategy for a resolved framework. The strategies
+ * run the framework build (and any `package.json` build script) and stage a
+ * deployable artifact themselves; the CLI only resolves the Bun entrypoint,
+ * which supports the `module` field on top of `main`.
+ */
 async function createPreviewBuildStrategy(options: {
   appPath: string;
   entrypoint?: string;
@@ -211,7 +201,7 @@ async function createPreviewBuildStrategy(options: {
 }): Promise<BuildStrategy> {
   switch (options.buildType) {
     case "nextjs":
-      return new PreviewNextjsBuild({
+      return new NextjsBuild({
         appPath: options.appPath,
         buildSettings: options.buildSettings,
       });
@@ -219,8 +209,13 @@ async function createPreviewBuildStrategy(options: {
       return new NuxtBuild({ appPath: options.appPath });
     case "astro":
       return new AstroBuild({ appPath: options.appPath });
+    case "nestjs":
+      return new NestjsBuild({
+        appPath: options.appPath,
+        buildSettings: options.buildSettings,
+      });
     case "tanstack-start":
-      return new PreviewTanstackStartBuild({
+      return new TanstackStartBuild({
         appPath: options.appPath,
         buildSettings: options.buildSettings,
       });
@@ -230,384 +225,20 @@ async function createPreviewBuildStrategy(options: {
         options.entrypoint,
         options.signal,
       );
-      return new PreviewBunBuild({
+      return new BunBuild({
         appPath: options.appPath,
-        strategy: new BunBuild({
-          appPath: options.appPath,
-          entrypoint,
-        }),
+        entrypoint,
         buildSettings: options.buildSettings,
       });
     }
   }
 }
 
-class PreviewNextjsBuild implements BuildStrategy {
-  readonly #appPath: string;
-  readonly #buildSettings?: PreviewBuildSettings;
-
-  constructor(options: {
-    appPath: string;
-    buildSettings?: PreviewBuildSettings;
-  }) {
-    this.#appPath = options.appPath;
-    this.#buildSettings = options.buildSettings;
-  }
-
-  async canBuild(signal?: AbortSignal): Promise<boolean> {
-    const packageJson = await readBunPackageJson(this.#appPath, signal);
-    return (
-      (await hasRootFile(this.#appPath, NEXT_CONFIG_FILENAMES, signal)) ||
-      hasPackageDependency(packageJson, "next")
-    );
-  }
-
-  async execute(signal?: AbortSignal): Promise<BuildArtifact> {
-    const settings =
-      this.#buildSettings ??
-      (await resolvePreviewBuildSettings({
-        appPath: this.#appPath,
-        buildType: "nextjs",
-        signal,
-      }));
-    await runResolvedBuildCommand(this.#appPath, settings, "Next.js", signal);
-
-    const standaloneDir = path.join(this.#appPath, settings.outputDirectory);
-    if (!(await directoryExists(standaloneDir, signal))) {
-      // No `output: "standalone"` in next.config: the build itself
-      // succeeded, so package the full tree and serve with `next start`
-      // instead of failing. Bigger artifact, same running app.
-      return stageNextjsFullTreeFallbackArtifact(this.#appPath, signal);
-    }
-
-    const outDir = await unsupportedFilesystemBoundary(signal, () =>
-      mkdtemp(path.join(os.tmpdir(), "compute-build-")),
-    );
-
-    try {
-      const artifactDir = path.join(outDir, "app");
-      await stageNextjsStandaloneArtifact({
-        standaloneDir,
-        artifactDir,
-        appPath: this.#appPath,
-        signal,
-      });
-      const entrypoint = await findNextStandaloneEntrypoint(
-        artifactDir,
-        signal,
-      );
-      await copyNextjsStaticAssets({
-        appPath: this.#appPath,
-        artifactDir,
-        outputRoot: nextOutputRootFromStandaloneDirectory(
-          settings.outputDirectory,
-        ),
-        entrypoint,
-        signal,
-      });
-
-      return {
-        directory: artifactDir,
-        entrypoint,
-        defaultPortMapping: { http: 3000 },
-        cleanup: () => rm(outDir, { recursive: true, force: true }),
-      };
-    } catch (error) {
-      await rm(outDir, { recursive: true, force: true });
-      throw error;
-    }
-  }
-}
-
-const FULL_TREE_NEXT_START_ENTRYPOINT = "prisma-next-start.cjs";
-
-// Bootstrap for apps built without `output: "standalone"`. Entering through
-// the CLI bin (not `next/dist/server/lib/start-server`) keeps Next in charge
-// of config loading, which is the part that drifts across Next majors.
-const FULL_TREE_NEXT_START_SOURCE = [
-  // The runtime starts us at the unpack root, but `next start` resolves `.next` from cwd.
-  "process.chdir(__dirname);",
-  'process.env.NODE_ENV = "production";',
-  'process.argv.push("start", "-p", process.env.PORT ?? "3000");',
-  'require("next/dist/bin/next");',
-  "",
-].join("\n");
-
-async function stageNextjsFullTreeFallbackArtifact(
-  appPath: string,
-  signal?: AbortSignal,
-): Promise<BuildArtifact> {
-  const outDir = await unsupportedFilesystemBoundary(signal, () =>
-    mkdtemp(path.join(os.tmpdir(), "compute-build-")),
-  );
-
-  try {
-    const artifactDir = path.join(outDir, "app");
-    // node_modules ships on purpose: without standalone output the artifact
-    // must carry the full runtime dependency tree for `next start`.
-    await unsupportedFilesystemBoundary(signal, () =>
-      cp(appPath, artifactDir, {
-        recursive: true,
-        // Keep relative symlinks relative (node_modules/.bin/*): the default
-        // rewrites them to absolute paths into the source tree, which the
-        // archiver rejects as escaping the artifact root.
-        verbatimSymlinks: true,
-        filter: (source) =>
-          !isExcludedFromFullTreeArtifact(path.basename(source)),
-      }),
-    );
-    await unsupportedFilesystemBoundary(signal, () =>
-      writeFile(
-        path.join(artifactDir, FULL_TREE_NEXT_START_ENTRYPOINT),
-        FULL_TREE_NEXT_START_SOURCE,
-      ),
-    );
-
-    return {
-      directory: artifactDir,
-      entrypoint: FULL_TREE_NEXT_START_ENTRYPOINT,
-      defaultPortMapping: { http: 3000 },
-      cleanup: () => rm(outDir, { recursive: true, force: true }),
-    };
-  } catch (error) {
-    await rm(outDir, { recursive: true, force: true });
-    throw error;
-  }
-}
-
-/** Excludes VCS internals and dotenv files (local secrets, superseded by the deploy env). */
-function isExcludedFromFullTreeArtifact(basename: string): boolean {
-  return (
-    basename === ".git" || basename === ".env" || basename.startsWith(".env.")
-  );
-}
-
-class PreviewTanstackStartBuild implements BuildStrategy {
-  readonly #appPath: string;
-  readonly #buildSettings?: PreviewBuildSettings;
-
-  constructor(options: {
-    appPath: string;
-    buildSettings?: PreviewBuildSettings;
-  }) {
-    this.#appPath = options.appPath;
-    this.#buildSettings = options.buildSettings;
-  }
-
-  async canBuild(signal?: AbortSignal): Promise<boolean> {
-    const packageJson = await readBunPackageJson(this.#appPath, signal);
-    return hasAnyPackageDependency(packageJson, TANSTACK_START_PACKAGES);
-  }
-
-  async execute(signal?: AbortSignal): Promise<BuildArtifact> {
-    const settings =
-      this.#buildSettings ??
-      (await resolvePreviewBuildSettings({
-        appPath: this.#appPath,
-        buildType: "tanstack-start",
-        signal,
-      }));
-    await runResolvedBuildCommand(
-      this.#appPath,
-      settings,
-      "TanStack Start",
-      signal,
-    );
-
-    const outputDir = path.join(this.#appPath, settings.outputDirectory);
-    const entrypoint = "server/index.mjs";
-    const entryPath = path.join(outputDir, entrypoint);
-    const entryStat = await unsupportedFilesystemBoundary(signal, () =>
-      stat(entryPath).catch(() => null),
-    );
-    if (!entryStat?.isFile()) {
-      throw new Error(
-        `TanStack Start build did not produce a Nitro node server entrypoint at ${joinPosix(settings.outputDirectory, entrypoint)}. ` +
-          `Ensure your vite.config includes the tanstackStart() and nitro() plugins with the default node preset, or set build.outputDirectory in prisma.compute.ts.`,
-      );
-    }
-
-    const outDir = await unsupportedFilesystemBoundary(signal, () =>
-      mkdtemp(path.join(os.tmpdir(), "compute-build-")),
-    );
-
-    try {
-      const artifactDir = path.join(outDir, "app");
-      await unsupportedFilesystemBoundary(signal, () =>
-        cp(outputDir, artifactDir, {
-          recursive: true,
-          verbatimSymlinks: true,
-        }),
-      );
-
-      return {
-        directory: artifactDir,
-        entrypoint,
-        defaultPortMapping: { http: 3000 },
-        cleanup: () => rm(outDir, { recursive: true, force: true }),
-      };
-    } catch (error) {
-      await rm(outDir, { recursive: true, force: true });
-      throw error;
-    }
-  }
-}
-
-class PreviewBunBuild implements BuildStrategy {
-  readonly #appPath: string;
-  readonly #strategy: BuildStrategy;
-  readonly #buildSettings?: PreviewBuildSettings;
-
-  constructor(options: {
-    appPath: string;
-    strategy: BuildStrategy;
-    buildSettings?: PreviewBuildSettings;
-  }) {
-    this.#appPath = options.appPath;
-    this.#strategy = options.strategy;
-    this.#buildSettings = options.buildSettings;
-  }
-
-  async canBuild(signal?: AbortSignal): Promise<boolean> {
-    return this.#strategy.canBuild(signal);
-  }
-
-  async execute(signal?: AbortSignal): Promise<BuildArtifact> {
-    const settings =
-      this.#buildSettings ??
-      (await resolvePreviewBuildSettings({
-        appPath: this.#appPath,
-        buildType: "bun",
-        signal,
-      }));
-    await runResolvedBuildCommand(this.#appPath, settings, "Bun", signal);
-
-    return this.#strategy.execute(signal);
-  }
-}
-
-const NEXT_CONFIG_FILENAMES = [
-  "next.config.js",
-  "next.config.mjs",
-  "next.config.ts",
-  "next.config.mts",
-] as const;
-
-const TANSTACK_START_PACKAGES = [
-  "@tanstack/react-start",
-  "@tanstack/solid-start",
-  "@tanstack/start",
-] as const;
-
-export async function stageNextjsStandaloneArtifact(options: {
-  standaloneDir: string;
-  artifactDir: string;
-  appPath: string;
-  signal?: AbortSignal;
-}): Promise<void> {
-  const standaloneRoot = path.resolve(options.standaloneDir);
-  const artifactRoot = path.resolve(options.artifactDir);
-  const appRoot = path.resolve(options.appPath);
-  const sourceRoot = await resolveSourceRoot(appRoot, options.signal);
-
-  await copyPathMaterializingSymlinks(standaloneRoot, artifactRoot, {
-    standaloneRoot,
-    appRoot,
-    sourceRoot,
-    signal: options.signal,
-  });
-  await hoistIsolatedStoreDependencies(
-    path.join(artifactRoot, "node_modules"),
-    options.signal,
-  );
-}
-
-async function copyNextjsStaticAssets(options: {
-  appPath: string;
-  artifactDir: string;
-  outputRoot: string;
-  entrypoint: string;
-  signal?: AbortSignal;
-}): Promise<void> {
-  const serverSubpath = nextjsServerSubpath(options.entrypoint);
-  const serverDir = serverSubpath
-    ? path.join(options.artifactDir, serverSubpath)
-    : options.artifactDir;
-
-  const publicDir = path.join(options.appPath, "public");
-  if (await directoryExists(publicDir, options.signal)) {
-    await unsupportedFilesystemBoundary(options.signal, () =>
-      cp(publicDir, path.join(serverDir, "public"), {
-        recursive: true,
-        verbatimSymlinks: true,
-      }),
-    );
-  }
-
-  const staticDir = path.join(options.appPath, options.outputRoot, "static");
-  if (await directoryExists(staticDir, options.signal)) {
-    await unsupportedFilesystemBoundary(options.signal, () =>
-      cp(staticDir, path.join(serverDir, options.outputRoot, "static"), {
-        recursive: true,
-        verbatimSymlinks: true,
-      }),
-    );
-  }
-}
-
-async function findNextStandaloneEntrypoint(
-  artifactDir: string,
-  signal?: AbortSignal,
-): Promise<string> {
-  const rootEntrypoint = path.join(artifactDir, "server.js");
-  const rootStat = await unsupportedFilesystemBoundary(signal, () =>
-    stat(rootEntrypoint).catch(() => null),
-  );
-  if (rootStat?.isFile()) {
-    return "server.js";
-  }
-
-  const candidates: string[] = [];
-  await walk(artifactDir);
-  candidates.sort(
-    (left, right) =>
-      left.split("/").length - right.split("/").length ||
-      left.localeCompare(right),
-  );
-
-  const selected = candidates[0];
-  if (!selected) {
-    throw new Error(
-      `Next.js standalone output did not contain server.js in ${artifactDir}`,
-    );
-  }
-
-  return selected;
-
-  async function walk(directory: string): Promise<void> {
-    const entries = await unsupportedFilesystemBoundary(signal, () =>
-      readdir(directory, { withFileTypes: true }),
-    );
-    for (const entry of entries) {
-      if (entry.name === "node_modules") {
-        continue;
-      }
-
-      const fullPath = path.join(directory, entry.name);
-      if (entry.isDirectory()) {
-        await walk(fullPath);
-        continue;
-      }
-
-      if (entry.isFile() && entry.name === "server.js") {
-        candidates.push(
-          path.relative(artifactDir, fullPath).split(path.sep).join("/"),
-        );
-      }
-    }
-  }
-}
-
+/**
+ * Re-stages a Next.js standalone artifact in place after a local rebuild, then
+ * refreshes the static assets next to the server entrypoint. Used by the local
+ * preview when files change on disk.
+ */
 export async function restageNextjsArtifact(
   artifact: BuildArtifact,
   appPath: string,
@@ -616,10 +247,10 @@ export async function restageNextjsArtifact(
   const artifactDir = artifact.directory;
   const standaloneDir = path.join(appPath, ".next", "standalone");
 
-  await unsupportedFilesystemBoundary(signal, () =>
+  await withSignal(signal, () =>
     rm(artifactDir, { recursive: true, force: true }),
   );
-  await stageNextjsStandaloneArtifact({
+  await stageStandaloneArtifact({
     standaloneDir,
     artifactDir,
     appPath,
@@ -637,7 +268,7 @@ export async function restageNextjsArtifact(
 
   const publicDir = path.join(appPath, "public");
   if (await directoryExists(publicDir, signal)) {
-    await unsupportedFilesystemBoundary(signal, () =>
+    await withSignal(signal, () =>
       cp(publicDir, path.join(serverDir, "public"), {
         recursive: true,
         verbatimSymlinks: true,
@@ -647,7 +278,7 @@ export async function restageNextjsArtifact(
 
   const staticDir = path.join(appPath, ".next", "static");
   if (await directoryExists(staticDir, signal)) {
-    await unsupportedFilesystemBoundary(signal, () =>
+    await withSignal(signal, () =>
       cp(staticDir, path.join(serverDir, ".next", "static"), {
         recursive: true,
         verbatimSymlinks: true,
@@ -662,309 +293,12 @@ function nextjsServerSubpath(entrypoint: string): string {
   return dir === "." ? "" : dir;
 }
 
-/**
- * pnpm and bun (isolated linker) both keep packages in a virtual store with a
- * shared symlink farm (`.pnpm/node_modules`, `.bun/node_modules`). Hoist the
- * farm entries to the artifact's node_modules root so Node-style resolution
- * works after symlinks are materialized.
- */
-async function hoistIsolatedStoreDependencies(
-  nodeModulesDir: string,
-  signal?: AbortSignal,
-): Promise<void> {
-  await hoistStoreDependencies(
-    nodeModulesDir,
-    path.join(nodeModulesDir, ".pnpm", "node_modules"),
-    signal,
-  );
-  await hoistStoreDependencies(
-    nodeModulesDir,
-    path.join(nodeModulesDir, ".bun", "node_modules"),
-    signal,
-  );
-}
-
-async function hoistStoreDependencies(
-  nodeModulesDir: string,
-  storeNodeModulesDir: string,
-  signal?: AbortSignal,
-): Promise<void> {
-  if (!(await directoryExists(storeNodeModulesDir, signal))) {
-    return;
-  }
-
-  const entries = await unsupportedFilesystemBoundary(signal, () =>
-    readdir(storeNodeModulesDir, { withFileTypes: true }),
-  );
-  for (const entry of entries) {
-    const sourcePath = path.join(storeNodeModulesDir, entry.name);
-
-    if (entry.name.startsWith("@") && entry.isDirectory()) {
-      const scopedEntries = await unsupportedFilesystemBoundary(signal, () =>
-        readdir(sourcePath, { withFileTypes: true }),
-      );
-      for (const scopedEntry of scopedEntries) {
-        const scopedDestination = path.join(
-          nodeModulesDir,
-          entry.name,
-          scopedEntry.name,
-        );
-        if (await pathExists(scopedDestination, signal)) {
-          continue;
-        }
-
-        await unsupportedFilesystemBoundary(signal, () =>
-          mkdir(path.dirname(scopedDestination), { recursive: true }),
-        );
-        await copyPathMaterializingSymlinks(
-          path.join(sourcePath, scopedEntry.name),
-          scopedDestination,
-          {
-            standaloneRoot: storeNodeModulesDir,
-            appRoot: nodeModulesDir,
-            sourceRoot: nodeModulesDir,
-            signal,
-          },
-        );
-      }
-      continue;
-    }
-
-    const destinationPath = path.join(nodeModulesDir, entry.name);
-    if (await pathExists(destinationPath, signal)) {
-      continue;
-    }
-
-    await copyPathMaterializingSymlinks(sourcePath, destinationPath, {
-      standaloneRoot: storeNodeModulesDir,
-      appRoot: nodeModulesDir,
-      sourceRoot: nodeModulesDir,
-      signal,
-    });
-  }
-}
-
-export async function normalizeArtifactSymlinks(
-  artifactDir: string,
-  appPath: string,
-  signal?: AbortSignal,
-): Promise<void> {
-  const normalizedArtifactDir = path.resolve(artifactDir);
-  const normalizedAppPath = path.resolve(appPath);
-
-  await walkDirectory(normalizedArtifactDir);
-
-  async function walkDirectory(directory: string): Promise<void> {
-    const entries = await unsupportedFilesystemBoundary(signal, () =>
-      readdir(directory, { withFileTypes: true }),
-    );
-
-    for (const entry of entries) {
-      const fullPath = path.join(directory, entry.name);
-
-      if (entry.isDirectory()) {
-        await walkDirectory(fullPath);
-        continue;
-      }
-
-      if (!entry.isSymbolicLink()) {
-        continue;
-      }
-
-      const target = await unsupportedFilesystemBoundary(signal, () =>
-        readlink(fullPath),
-      );
-      const resolvedTarget = path.resolve(path.dirname(fullPath), target);
-
-      if (isPathWithin(normalizedArtifactDir, resolvedTarget)) {
-        continue;
-      }
-
-      if (!isPathWithin(normalizedAppPath, resolvedTarget)) {
-        throw new Error(
-          `Build artifact symlink escapes the app directory: ${resolvedTarget}`,
-        );
-      }
-
-      const targetStat = await unsupportedFilesystemBoundary(signal, () =>
-        stat(resolvedTarget),
-      );
-      await unsupportedFilesystemBoundary(signal, () =>
-        rm(fullPath, { force: true, recursive: true }),
-      );
-      await unsupportedFilesystemBoundary(signal, () =>
-        cp(resolvedTarget, fullPath, {
-          recursive: targetStat.isDirectory(),
-          dereference: true,
-        }),
-      );
-
-      if (targetStat.isDirectory()) {
-        await walkDirectory(fullPath);
-      }
-    }
-  }
-}
-
-function isPathWithin(rootPath: string, candidatePath: string): boolean {
-  const relativePath = path.relative(rootPath, candidatePath);
-
-  return (
-    relativePath === "" ||
-    (!relativePath.startsWith(`..${path.sep}`) &&
-      relativePath !== ".." &&
-      !path.isAbsolute(relativePath))
-  );
-}
-
-function isPathWithinWorkspaceDependency(
-  sourceRoot: string,
-  candidatePath: string,
-): boolean {
-  return isPathWithin(path.join(sourceRoot, "node_modules"), candidatePath);
-}
-
-async function copyPathMaterializingSymlinks(
-  sourcePath: string,
-  destinationPath: string,
-  options: {
-    standaloneRoot: string;
-    appRoot: string;
-    sourceRoot: string;
-    signal?: AbortSignal;
-  },
-): Promise<void> {
-  const sourceStat = await unsupportedFilesystemBoundary(options.signal, () =>
-    lstat(sourcePath),
-  );
-
-  if (sourceStat.isSymbolicLink()) {
-    const resolvedTarget = await resolveSymlinkTarget(sourcePath, options);
-    if (resolvedTarget === null) {
-      return;
-    }
-    await copyPathMaterializingSymlinks(
-      resolvedTarget,
-      destinationPath,
-      options,
-    );
-    return;
-  }
-
-  if (sourceStat.isDirectory()) {
-    await unsupportedFilesystemBoundary(options.signal, () =>
-      mkdir(destinationPath, { recursive: true }),
-    );
-
-    const entries = await unsupportedFilesystemBoundary(options.signal, () =>
-      readdir(sourcePath, { withFileTypes: true }),
-    );
-    for (const entry of entries) {
-      await copyPathMaterializingSymlinks(
-        path.join(sourcePath, entry.name),
-        path.join(destinationPath, entry.name),
-        options,
-      );
-    }
-
-    return;
-  }
-
-  if (sourceStat.isFile()) {
-    await unsupportedFilesystemBoundary(options.signal, () =>
-      mkdir(path.dirname(destinationPath), { recursive: true }),
-    );
-    await unsupportedFilesystemBoundary(options.signal, () =>
-      copyFile(sourcePath, destinationPath),
-    );
-    await unsupportedFilesystemBoundary(options.signal, () =>
-      chmod(destinationPath, sourceStat.mode),
-    );
-  }
-}
-
-async function resolveSymlinkTarget(
-  symlinkPath: string,
-  options: {
-    standaloneRoot: string;
-    appRoot: string;
-    sourceRoot: string;
-    signal?: AbortSignal;
-  },
-): Promise<string | null> {
-  const linkTarget = await unsupportedFilesystemBoundary(options.signal, () =>
-    readlink(symlinkPath),
-  );
-  const resolvedTarget = path.resolve(path.dirname(symlinkPath), linkTarget);
-
-  if (await pathExists(resolvedTarget, options.signal)) {
-    if (
-      !isPathWithin(options.appRoot, resolvedTarget) &&
-      !isPathWithinWorkspaceDependency(options.sourceRoot, resolvedTarget)
-    ) {
-      throw new Error(
-        `Build artifact symlink escapes the app directory: ${resolvedTarget}`,
-      );
-    }
-
-    return resolvedTarget;
-  }
-
-  if (isPathWithin(options.standaloneRoot, resolvedTarget)) {
-    const fallbackTarget = path.join(
-      options.appRoot,
-      path.relative(options.standaloneRoot, resolvedTarget),
-    );
-
-    if (await pathExists(fallbackTarget, options.signal)) {
-      return fallbackTarget;
-    }
-  }
-
-  // pnpm's hoist layer (.pnpm/node_modules/*) contains speculative links that
-  // are routinely dangling — Next's tracer doesn't always align with what pnpm
-  // populated. Drop these silently. Dangling links elsewhere still throw so a
-  // real missing dep doesn't get masked.
-  if (isPnpmHoistLink(symlinkPath)) {
-    return null;
-  }
-
-  throw new Error(
-    `Next.js standalone symlink target is missing: ${symlinkPath} -> ${linkTarget} (resolved to ${resolvedTarget})`,
-  );
-}
-
-function isPnpmHoistLink(symlinkPath: string): boolean {
-  const parts = path.dirname(symlinkPath).split(path.sep);
-  for (let i = 0; i < parts.length - 1; i++) {
-    if (parts[i] === ".pnpm" && parts[i + 1] === "node_modules") {
-      return true;
-    }
-  }
-  return false;
-}
-
-async function pathExists(
-  targetPath: string,
-  signal?: AbortSignal,
-): Promise<boolean> {
-  try {
-    await unsupportedFilesystemBoundary(signal, () => stat(targetPath));
-    return true;
-  } catch (error) {
-    if (signal?.aborted) throw error;
-    return false;
-  }
-}
-
 async function directoryExists(
   targetPath: string,
   signal?: AbortSignal,
 ): Promise<boolean> {
   try {
-    const targetStat = await unsupportedFilesystemBoundary(signal, () =>
-      stat(targetPath),
-    );
+    const targetStat = await withSignal(signal, () => stat(targetPath));
     return targetStat.isDirectory();
   } catch (error) {
     if (signal?.aborted) throw error;
@@ -972,7 +306,7 @@ async function directoryExists(
   }
 }
 
-async function unsupportedFilesystemBoundary<T>(
+async function withSignal<T>(
   signal: AbortSignal | undefined,
   operation: () => Promise<T>,
 ): Promise<T> {

--- a/packages/cli/src/lib/app/production-deploy-gate.ts
+++ b/packages/cli/src/lib/app/production-deploy-gate.ts
@@ -2,14 +2,11 @@ import { CliError } from "../../shell/errors";
 import { confirmPrompt } from "../../shell/prompt";
 import { type CommandContext, canPrompt } from "../../shell/runtime";
 import type { BranchKind } from "../../types/branch";
-import type {
-  PreviewAppProvider,
-  PreviewDeploymentRecord,
-} from "./preview-provider";
+import type { AppProvider, DeploymentRecord } from "./app-provider";
 
 export async function enforceProductionDeployGate(
   context: CommandContext,
-  provider: Pick<PreviewAppProvider, "listDeployments">,
+  provider: Pick<AppProvider, "listDeployments">,
   options: {
     appId: string | undefined;
     appName: string;
@@ -67,8 +64,8 @@ export async function enforceProductionDeployGate(
 }
 
 function resolveCurrentProductionDeployment(
-  result: Awaited<ReturnType<PreviewAppProvider["listDeployments"]>>,
-): PreviewDeploymentRecord | null {
+  result: Awaited<ReturnType<AppProvider["listDeployments"]>>,
+): DeploymentRecord | null {
   if (result.deployments.length === 0) {
     return null;
   }
@@ -112,7 +109,7 @@ function renderProductionDeployYesLine(context: CommandContext): void {
 
 function renderProductionDeployConfirmation(
   context: CommandContext,
-  currentLiveDeployment: PreviewDeploymentRecord,
+  currentLiveDeployment: DeploymentRecord,
 ): void {
   if (context.flags.json || context.flags.quiet) {
     return;

--- a/packages/cli/src/types/app.ts
+++ b/packages/cli/src/types/app.ts
@@ -111,7 +111,7 @@ export interface AppShowResult {
 export interface AppBuildResult {
   directory: string;
   entrypoint: string | null;
-  buildType: "bun" | "nextjs" | "nuxt" | "astro" | "tanstack-start";
+  buildType: "bun" | "nextjs" | "nuxt" | "astro" | "nestjs" | "tanstack-start";
 }
 
 export interface AppShowDeployResult {

--- a/packages/cli/tests/app-branch-database.test.ts
+++ b/packages/cli/tests/app-branch-database.test.ts
@@ -39,7 +39,7 @@ afterEach(() => {
 
   vi.doUnmock("../src/lib/auth/auth-ops");
   vi.doUnmock("../src/lib/auth/guard");
-  vi.doUnmock("../src/lib/app/preview-provider");
+  vi.doUnmock("../src/lib/app/app-provider");
   vi.doUnmock("../src/lib/app/branch-database");
   vi.doUnmock("../src/lib/app/branch-database-deploy");
   vi.doUnmock("../src/shell/prompt");
@@ -111,8 +111,8 @@ describe("app deploy branch database setup", () => {
         ...actual,
       };
     });
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() => ({
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() => ({
         resolveBranch: vi.fn().mockResolvedValue({
           id: branchId,
           name: "feature/db",
@@ -272,8 +272,8 @@ describe("app deploy branch database setup", () => {
         ...actual,
       };
     });
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() => ({
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() => ({
         resolveBranch: vi.fn().mockResolvedValue({
           id: branchId,
           name: "main",
@@ -413,8 +413,8 @@ describe("app deploy branch database setup", () => {
         ...actual,
       };
     });
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() => ({
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() => ({
         resolveBranch: vi.fn().mockResolvedValue({
           id: branchId,
           name: "feature/next",
@@ -532,8 +532,8 @@ describe("app deploy branch database setup", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() => ({
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() => ({
         resolveBranch: vi.fn().mockResolvedValue({
           id: branchId,
           name: "feature/db",
@@ -657,8 +657,8 @@ describe("app deploy branch database setup", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() => ({
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() => ({
         resolveBranch: vi.fn().mockResolvedValue({
           id: branchId,
           name: "main",
@@ -786,8 +786,8 @@ describe("app deploy branch database setup", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() => ({
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() => ({
         resolveBranch: vi.fn().mockResolvedValue({
           id: branchId,
           name: "main",
@@ -927,8 +927,8 @@ describe("app deploy branch database setup", () => {
         }),
       };
     });
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() => ({
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() => ({
         resolveBranch: vi.fn().mockResolvedValue({
           id: branchId,
           name: "feature/db",
@@ -1066,8 +1066,8 @@ describe("app deploy branch database setup", () => {
         }),
       };
     });
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() => ({
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() => ({
         resolveBranch: vi.fn().mockResolvedValue({
           id: branchId,
           name: "feature/db",
@@ -1198,8 +1198,8 @@ describe("app deploy branch database setup", () => {
         }),
       };
     });
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() => ({
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() => ({
         resolveBranch: vi.fn().mockResolvedValue({
           id: branchId,
           name: "feature/db",
@@ -1273,8 +1273,8 @@ describe("app deploy branch database setup", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() => ({
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() => ({
         resolveBranch: vi.fn().mockResolvedValue({
           id: branchId,
           name: "main",
@@ -1350,8 +1350,8 @@ describe("app deploy branch database setup", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() => ({
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() => ({
         resolveBranch: vi.fn().mockResolvedValue({
           id: branchId,
           name: "main",
@@ -1436,8 +1436,8 @@ describe("app deploy branch database setup", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() => ({
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() => ({
         resolveBranch: createResolveBranch(),
         listApps: vi.fn().mockResolvedValue([
           {
@@ -1537,8 +1537,8 @@ describe("app deploy branch database setup", () => {
         }),
       };
     });
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() => ({
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() => ({
         resolveBranch: vi.fn().mockResolvedValue({
           id: branchId,
           name: "feature/db",
@@ -1691,8 +1691,8 @@ describe("app deploy branch database setup", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() => ({
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() => ({
         resolveBranch: createResolveBranch(),
         listApps: vi.fn().mockResolvedValue([
           {

--- a/packages/cli/tests/app-build.test.ts
+++ b/packages/cli/tests/app-build.test.ts
@@ -21,8 +21,8 @@ afterEach(() => {
 
 describe("preview build strategy", () => {
   it("resolves inferred Next.js settings without writing any file", async () => {
-    const { resolveInferredPreviewBuildSettings } = await import(
-      "../src/lib/app/preview-build"
+    const { resolveInferredAppBuildSettings } = await import(
+      "../src/lib/app/build"
     );
     const cwd = await createTempCwd();
     const appPath = path.join(cwd, "app");
@@ -46,7 +46,7 @@ describe("preview build strategy", () => {
       "utf8",
     );
 
-    const resolution = await resolveInferredPreviewBuildSettings({
+    const resolution = await resolveInferredAppBuildSettings({
       appPath,
       buildType: "nextjs",
     });
@@ -65,12 +65,12 @@ describe("preview build strategy", () => {
   });
 
   it("describes the strategy-owned builds for nuxt and astro", async () => {
-    const { resolveInferredPreviewBuildSettings } = await import(
-      "../src/lib/app/preview-build"
+    const { resolveInferredAppBuildSettings } = await import(
+      "../src/lib/app/build"
     );
     const cwd = await createTempCwd();
 
-    const nuxt = await resolveInferredPreviewBuildSettings({
+    const nuxt = await resolveInferredAppBuildSettings({
       appPath: cwd,
       buildType: "nuxt",
     });
@@ -81,7 +81,7 @@ describe("preview build strategy", () => {
       outputDirectorySource: "Nuxt output",
     });
 
-    const astro = await resolveInferredPreviewBuildSettings({
+    const astro = await resolveInferredAppBuildSettings({
       appPath: cwd,
       buildType: "astro",
     });
@@ -94,9 +94,7 @@ describe("preview build strategy", () => {
   });
 
   it("packages the full tree with a next start launcher when the build produces no standalone output", async () => {
-    const { PreviewBuildStrategy } = await import(
-      "../src/lib/app/preview-build"
-    );
+    const { AppBuildStrategy } = await import("../src/lib/app/build");
     const cwd = await createTempCwd();
     const appPath = path.join(cwd, "app");
 
@@ -133,7 +131,7 @@ describe("preview build strategy", () => {
       path.join(appPath, "node_modules/.bin/next-link"),
     );
 
-    const strategy = new PreviewBuildStrategy({
+    const strategy = new AppBuildStrategy({
       appPath,
       buildType: "nextjs",
       buildSettings: {
@@ -190,8 +188,8 @@ describe("preview build strategy", () => {
   });
 
   it("infers TanStack and Hono build defaults", async () => {
-    const { resolveInferredPreviewBuildSettings } = await import(
-      "../src/lib/app/preview-build"
+    const { resolveInferredAppBuildSettings } = await import(
+      "../src/lib/app/build"
     );
     const cwd = await createTempCwd();
     const tanstackPath = path.join(cwd, "tanstack");
@@ -227,7 +225,7 @@ describe("preview build strategy", () => {
     );
 
     await expect(
-      resolveInferredPreviewBuildSettings({
+      resolveInferredAppBuildSettings({
         appPath: tanstackPath,
         buildType: "tanstack-start",
       }),
@@ -239,7 +237,7 @@ describe("preview build strategy", () => {
       },
     });
     await expect(
-      resolveInferredPreviewBuildSettings({
+      resolveInferredAppBuildSettings({
         appPath: honoPath,
         buildType: "bun",
       }),
@@ -253,9 +251,7 @@ describe("preview build strategy", () => {
   });
 
   it("classifies leftover prisma.app.json files for migration", async () => {
-    const { detectLegacyBuildSettings } = await import(
-      "../src/lib/app/preview-build"
-    );
+    const { detectLegacyBuildSettings } = await import("../src/lib/app/build");
     const cwd = await createTempCwd();
     const effective = {
       buildCommand: "bun run build",
@@ -303,9 +299,7 @@ describe("preview build strategy", () => {
   });
 
   it("resolves package.json build scripts and literal framework output directories", async () => {
-    const { resolvePreviewBuildSettings } = await import(
-      "../src/lib/app/preview-build"
-    );
+    const { resolveAppBuildSettings } = await import("../src/lib/app/build");
     const cwd = await createTempCwd();
     const appPath = path.join(cwd, "app");
 
@@ -334,7 +328,7 @@ describe("preview build strategy", () => {
     );
 
     await expect(
-      resolvePreviewBuildSettings({
+      resolveAppBuildSettings({
         appPath,
         buildType: "nextjs",
       }),
@@ -347,9 +341,7 @@ describe("preview build strategy", () => {
   });
 
   it("only reads Next.js distDir from the exported config object", async () => {
-    const { resolvePreviewBuildSettings } = await import(
-      "../src/lib/app/preview-build"
-    );
+    const { resolveAppBuildSettings } = await import("../src/lib/app/build");
     const cwd = await createTempCwd();
     const appPath = path.join(cwd, "app");
 
@@ -382,7 +374,7 @@ describe("preview build strategy", () => {
     );
 
     await expect(
-      resolvePreviewBuildSettings({
+      resolveAppBuildSettings({
         appPath,
         buildType: "nextjs",
       }),
@@ -393,9 +385,7 @@ describe("preview build strategy", () => {
   });
 
   it("ignores commented or unrelated Next.js distDir values", async () => {
-    const { resolvePreviewBuildSettings } = await import(
-      "../src/lib/app/preview-build"
-    );
+    const { resolveAppBuildSettings } = await import("../src/lib/app/build");
     const cwd = await createTempCwd();
     const appPath = path.join(cwd, "app");
 
@@ -428,7 +418,7 @@ describe("preview build strategy", () => {
     );
 
     await expect(
-      resolvePreviewBuildSettings({
+      resolveAppBuildSettings({
         appPath,
         buildType: "nextjs",
       }),
@@ -439,9 +429,7 @@ describe("preview build strategy", () => {
   });
 
   it("detects the package manager for package.json build scripts", async () => {
-    const { resolvePreviewBuildSettings } = await import(
-      "../src/lib/app/preview-build"
-    );
+    const { resolveAppBuildSettings } = await import("../src/lib/app/build");
     const cases = [
       { lockfile: "bun.lock", command: "bun run build" },
       { lockfile: "pnpm-lock.yaml", command: "pnpm run build" },
@@ -473,7 +461,7 @@ describe("preview build strategy", () => {
       await writeFile(path.join(appPath, testCase.lockfile), "", "utf8");
 
       await expect(
-        resolvePreviewBuildSettings({
+        resolveAppBuildSettings({
           appPath,
           buildType: "nextjs",
         }),
@@ -485,9 +473,7 @@ describe("preview build strategy", () => {
   });
 
   it("detects the package manager from the workspace root for app build scripts", async () => {
-    const { resolvePreviewBuildSettings } = await import(
-      "../src/lib/app/preview-build"
-    );
+    const { resolveAppBuildSettings } = await import("../src/lib/app/build");
     const cases = [
       {
         rootFiles: ["pnpm-workspace.yaml", "pnpm-lock.yaml"],
@@ -538,7 +524,7 @@ describe("preview build strategy", () => {
       );
 
       await expect(
-        resolvePreviewBuildSettings({
+        resolveAppBuildSettings({
           appPath,
           buildType: "nextjs",
         }),
@@ -550,9 +536,7 @@ describe("preview build strategy", () => {
   });
 
   it("prefers the app-level lockfile over the workspace root lockfile", async () => {
-    const { resolvePreviewBuildSettings } = await import(
-      "../src/lib/app/preview-build"
-    );
+    const { resolveAppBuildSettings } = await import("../src/lib/app/build");
     const cwd = await createTempCwd();
     const appPath = path.join(cwd, "apps", "web");
 
@@ -578,7 +562,7 @@ describe("preview build strategy", () => {
     );
 
     await expect(
-      resolvePreviewBuildSettings({
+      resolveAppBuildSettings({
         appPath,
         buildType: "nextjs",
       }),
@@ -588,9 +572,7 @@ describe("preview build strategy", () => {
   });
 
   it("does not use lockfiles above the repository root", async () => {
-    const { resolvePreviewBuildSettings } = await import(
-      "../src/lib/app/preview-build"
-    );
+    const { resolveAppBuildSettings } = await import("../src/lib/app/build");
     const cwd = await createTempCwd();
     const repoPath = path.join(cwd, "repo");
     const appPath = path.join(repoPath, "app");
@@ -616,7 +598,7 @@ describe("preview build strategy", () => {
     );
 
     await expect(
-      resolvePreviewBuildSettings({
+      resolveAppBuildSettings({
         appPath,
         buildType: "nextjs",
       }),
@@ -626,9 +608,7 @@ describe("preview build strategy", () => {
   });
 
   it("uses the literal package.json build script when no package manager is detected", async () => {
-    const { resolvePreviewBuildSettings } = await import(
-      "../src/lib/app/preview-build"
-    );
+    const { resolveAppBuildSettings } = await import("../src/lib/app/build");
     const cwd = await createTempCwd();
     const appPath = path.join(cwd, "app");
 
@@ -651,7 +631,7 @@ describe("preview build strategy", () => {
     );
 
     await expect(
-      resolvePreviewBuildSettings({
+      resolveAppBuildSettings({
         appPath,
         buildType: "nextjs",
       }),
@@ -662,9 +642,7 @@ describe("preview build strategy", () => {
   });
 
   it("does not detect unsupported next.config.cjs files as Next.js", async () => {
-    const { resolvePreviewBuildStrategy } = await import(
-      "../src/lib/app/preview-build"
-    );
+    const { resolveAppBuildStrategy } = await import("../src/lib/app/build");
     const cwd = await createTempCwd();
     const appPath = path.join(cwd, "app");
 
@@ -686,7 +664,7 @@ describe("preview build strategy", () => {
     );
 
     await expect(
-      resolvePreviewBuildStrategy({
+      resolveAppBuildStrategy({
         appPath,
         entrypoint: "server.ts",
         buildType: "auto",
@@ -732,10 +710,8 @@ describe("preview build strategy", () => {
       "utf8",
     );
 
-    const { executePreviewBuild } = await import(
-      "../src/lib/app/preview-build"
-    );
-    const result = await executePreviewBuild({
+    const { executeAppBuild } = await import("../src/lib/app/build");
+    const result = await executeAppBuild({
       appPath,
       buildType: "nextjs",
     });
@@ -769,10 +745,8 @@ describe("preview build strategy", () => {
       "utf8",
     );
 
-    const { executePreviewBuild } = await import(
-      "../src/lib/app/preview-build"
-    );
-    const result = await executePreviewBuild({
+    const { executeAppBuild } = await import("../src/lib/app/build");
+    const result = await executeAppBuild({
       appPath,
       buildType: "nextjs",
       buildSettings: {
@@ -830,10 +804,8 @@ describe("preview build strategy", () => {
       "utf8",
     );
 
-    const { executePreviewBuild } = await import(
-      "../src/lib/app/preview-build"
-    );
-    const result = await executePreviewBuild({
+    const { executeAppBuild } = await import("../src/lib/app/build");
+    const result = await executeAppBuild({
       appPath,
       buildType: "nextjs",
     });
@@ -1062,9 +1034,7 @@ describe("preview build strategy", () => {
   });
 
   it("places public and .next/static next to server.js when the entrypoint is nested (monorepo)", async () => {
-    const { restageNextjsArtifact } = await import(
-      "../src/lib/app/preview-build"
-    );
+    const { restageNextjsArtifact } = await import("../src/lib/app/build");
     const cwd = await createTempCwd();
     const appPath = path.join(cwd, "repo", "apps", "web");
     const standaloneDir = path.join(appPath, ".next", "standalone");

--- a/packages/cli/tests/app-build.test.ts
+++ b/packages/cli/tests/app-build.test.ts
@@ -857,9 +857,7 @@ describe("preview build strategy", () => {
   });
 
   it("materializes symlinks that point back to the source app directory", async () => {
-    const { normalizeArtifactSymlinks } = await import(
-      "../src/lib/app/preview-build"
-    );
+    const { normalizeArtifactSymlinks } = await import("@prisma/compute-sdk");
     const cwd = await createTempCwd();
     const appPath = path.join(cwd, "app");
     const artifactDir = path.join(cwd, "artifact");
@@ -891,9 +889,8 @@ describe("preview build strategy", () => {
   });
 
   it("stages Next.js standalone artifacts by materializing symlinks and falling back to app node_modules", async () => {
-    const { stageNextjsStandaloneArtifact } = await import(
-      "../src/lib/app/preview-build"
-    );
+    const { stageStandaloneArtifact: stageNextjsStandaloneArtifact } =
+      await import("@prisma/compute-sdk");
     const cwd = await createTempCwd();
     const appPath = path.join(cwd, "app");
     const standaloneDir = path.join(appPath, ".next", "standalone");
@@ -964,9 +961,8 @@ describe("preview build strategy", () => {
   });
 
   it("stages Next.js standalone symlinks that resolve through the monorepo root", async () => {
-    const { stageNextjsStandaloneArtifact } = await import(
-      "../src/lib/app/preview-build"
-    );
+    const { stageStandaloneArtifact: stageNextjsStandaloneArtifact } =
+      await import("@prisma/compute-sdk");
     const cwd = await createTempCwd();
     const repoRoot = path.join(cwd, "repo");
     const appPath = path.join(repoRoot, "apps", "web");
@@ -1004,9 +1000,8 @@ describe("preview build strategy", () => {
   });
 
   it("keeps pnpm transitive dependencies resolvable after flattening Next.js standalone packages", async () => {
-    const { stageNextjsStandaloneArtifact } = await import(
-      "../src/lib/app/preview-build"
-    );
+    const { stageStandaloneArtifact: stageNextjsStandaloneArtifact } =
+      await import("@prisma/compute-sdk");
     const cwd = await createTempCwd();
     const appPath = path.join(cwd, "app");
     const standaloneDir = path.join(appPath, ".next", "standalone");
@@ -1122,9 +1117,8 @@ describe("preview build strategy", () => {
   });
 
   it("drops dangling pnpm hoist symlinks when staging Next.js standalone artifacts", async () => {
-    const { stageNextjsStandaloneArtifact } = await import(
-      "../src/lib/app/preview-build"
-    );
+    const { stageStandaloneArtifact: stageNextjsStandaloneArtifact } =
+      await import("@prisma/compute-sdk");
     const cwd = await createTempCwd();
     const appPath = path.join(cwd, "app");
     const standaloneDir = path.join(appPath, ".next", "standalone");
@@ -1191,9 +1185,8 @@ describe("preview build strategy", () => {
   });
 
   it("still rejects dangling Next.js standalone symlinks outside the pnpm hoist layer", async () => {
-    const { stageNextjsStandaloneArtifact } = await import(
-      "../src/lib/app/preview-build"
-    );
+    const { stageStandaloneArtifact: stageNextjsStandaloneArtifact } =
+      await import("@prisma/compute-sdk");
     const cwd = await createTempCwd();
     const appPath = path.join(cwd, "app");
     const standaloneDir = path.join(appPath, ".next", "standalone");
@@ -1221,9 +1214,8 @@ describe("preview build strategy", () => {
   });
 
   it("rejects Next.js standalone symlinks that escape the app directory", async () => {
-    const { stageNextjsStandaloneArtifact } = await import(
-      "../src/lib/app/preview-build"
-    );
+    const { stageStandaloneArtifact: stageNextjsStandaloneArtifact } =
+      await import("@prisma/compute-sdk");
     const cwd = await createTempCwd();
     const appPath = path.join(cwd, "app");
     const standaloneDir = path.join(appPath, ".next", "standalone");

--- a/packages/cli/tests/app-bun-compat.test.ts
+++ b/packages/cli/tests/app-bun-compat.test.ts
@@ -110,14 +110,14 @@ describe("bun compatibility", () => {
     ).resolves.toMatchObject({ buildType: "tanstack-start" });
   });
 
-  it("still lets an explicit Bun entrypoint override package.json module", async () => {
+  it("lets an explicit Bun entrypoint override package.json main", async () => {
     const cwd = await createTempCwd();
 
     await writeFile(
       path.join(cwd, "package.json"),
       JSON.stringify(
         {
-          module: "index.ts",
+          main: "index.ts",
           devDependencies: {
             "@types/bun": "latest",
           },

--- a/packages/cli/tests/app-bun-compat.test.ts
+++ b/packages/cli/tests/app-bun-compat.test.ts
@@ -11,21 +11,8 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-function mockBuildStrategy(
-  createInstance: (options: object) => object = () => ({
-    canBuild: vi.fn(),
-    execute: vi.fn(),
-  }),
-) {
-  return vi.fn().mockImplementation(function BuildStrategyMock(
-    options: object,
-  ) {
-    return createInstance(options);
-  });
-}
-
 describe("bun compatibility", () => {
-  it("resolves the Bun entrypoint from package.json module", async () => {
+  it("does not fall back to package.json module for the Bun entrypoint", async () => {
     const cwd = await createTempCwd();
 
     await writeFile(
@@ -50,8 +37,8 @@ describe("bun compatibility", () => {
 
     const { resolveBunEntrypoint } = await import("../src/lib/app/bun-project");
 
-    await expect(resolveBunEntrypoint(cwd, undefined)).resolves.toBe(
-      "index.ts",
+    await expect(resolveBunEntrypoint(cwd, undefined)).rejects.toThrow(
+      "Entrypoint is required. Pass --entry or define package.json main.",
     );
   });
 
@@ -68,14 +55,14 @@ describe("bun compatibility", () => {
     );
   });
 
-  it("detects a Bun project when package.json uses module instead of main", async () => {
+  it("detects a Bun project from package.json main and a bun dev script", async () => {
     const cwd = await createTempCwd();
 
     await writeFile(
       path.join(cwd, "package.json"),
       JSON.stringify(
         {
-          module: "index.ts",
+          main: "index.ts",
           devDependencies: {
             "@types/bun": "latest",
           },
@@ -99,138 +86,8 @@ describe("bun compatibility", () => {
     await expect(detectLocalBuildType(cwd)).resolves.toBe("bun");
   });
 
-  it("passes the module-based Bun entrypoint into the shared deploy/build strategy", async () => {
+  it("forwards explicit build types to the SDK strategy resolver", async () => {
     const cwd = await createTempCwd();
-
-    await writeFile(
-      path.join(cwd, "package.json"),
-      JSON.stringify(
-        {
-          module: "index.ts",
-          devDependencies: {
-            "@types/bun": "latest",
-          },
-        },
-        null,
-        2,
-      ),
-      "utf8",
-    );
-    await writeFile(
-      path.join(cwd, "index.ts"),
-      "console.log('hello');\n",
-      "utf8",
-    );
-
-    const bunBuild = mockBuildStrategy((options: object) => ({
-      options,
-      canBuild: vi.fn().mockResolvedValue(true),
-      execute: vi.fn(),
-    }));
-    const nextjsBuild = mockBuildStrategy(() => ({
-      canBuild: vi.fn().mockResolvedValue(false),
-      execute: vi.fn(),
-    }));
-    const otherFrameworkBuild = mockBuildStrategy(() => ({
-      canBuild: vi.fn().mockResolvedValue(false),
-      execute: vi.fn(),
-    }));
-
-    vi.doMock("@prisma/compute-sdk", async (importOriginal) => ({
-      ...(await importOriginal<typeof import("@prisma/compute-sdk")>()),
-      AstroBuild: otherFrameworkBuild,
-      BunBuild: bunBuild,
-      NextjsBuild: nextjsBuild,
-      NuxtBuild: otherFrameworkBuild,
-      NestjsBuild: otherFrameworkBuild,
-      TanstackStartBuild: otherFrameworkBuild,
-    }));
-
-    const { resolvePreviewBuildStrategy } = await import(
-      "../src/lib/app/preview-build"
-    );
-
-    const result = await resolvePreviewBuildStrategy({
-      appPath: cwd,
-      buildType: "auto",
-      entrypoint: undefined,
-    });
-
-    expect(result.buildType).toBe("bun");
-    expect(bunBuild).toHaveBeenCalledWith({
-      appPath: cwd,
-      entrypoint: "index.ts",
-    });
-  });
-
-  it("auto-detects SDK framework strategies before falling back to Bun", async () => {
-    const cwd = await createTempCwd();
-
-    const bunBuild = mockBuildStrategy(() => ({
-      canBuild: vi.fn().mockResolvedValue(true),
-      execute: vi.fn(),
-    }));
-    const nextjsBuild = mockBuildStrategy(() => ({
-      canBuild: vi.fn().mockResolvedValue(false),
-      execute: vi.fn(),
-    }));
-    const nuxtBuild = mockBuildStrategy(() => ({
-      canBuild: vi.fn().mockResolvedValue(true),
-      execute: vi.fn(),
-    }));
-    const astroBuild = mockBuildStrategy(() => ({
-      canBuild: vi.fn().mockResolvedValue(true),
-      execute: vi.fn(),
-    }));
-    const tanstackStartBuild = mockBuildStrategy(() => ({
-      canBuild: vi.fn().mockResolvedValue(true),
-      execute: vi.fn(),
-    }));
-
-    vi.doMock("@prisma/compute-sdk", async (importOriginal) => ({
-      ...(await importOriginal<typeof import("@prisma/compute-sdk")>()),
-      AstroBuild: astroBuild,
-      BunBuild: bunBuild,
-      NextjsBuild: nextjsBuild,
-      NuxtBuild: nuxtBuild,
-      NestjsBuild: nextjsBuild,
-      TanstackStartBuild: tanstackStartBuild,
-    }));
-
-    const { resolvePreviewBuildStrategy } = await import(
-      "../src/lib/app/preview-build"
-    );
-
-    const result = await resolvePreviewBuildStrategy({
-      appPath: cwd,
-      buildType: "auto",
-      entrypoint: undefined,
-    });
-
-    expect(result.buildType).toBe("nuxt");
-    expect(nuxtBuild).toHaveBeenCalledWith({ appPath: cwd });
-    expect(bunBuild).not.toHaveBeenCalled();
-    expect(astroBuild).not.toHaveBeenCalled();
-    expect(tanstackStartBuild).not.toHaveBeenCalled();
-  });
-
-  it("resolves explicit SDK framework build strategies", async () => {
-    const cwd = await createTempCwd();
-
-    const buildStrategy = mockBuildStrategy(() => ({
-      canBuild: vi.fn(),
-      execute: vi.fn(),
-    }));
-
-    vi.doMock("@prisma/compute-sdk", async (importOriginal) => ({
-      ...(await importOriginal<typeof import("@prisma/compute-sdk")>()),
-      AstroBuild: buildStrategy,
-      BunBuild: buildStrategy,
-      NextjsBuild: buildStrategy,
-      NuxtBuild: buildStrategy,
-      NestjsBuild: buildStrategy,
-      TanstackStartBuild: buildStrategy,
-    }));
 
     const { resolvePreviewBuildStrategy } = await import(
       "../src/lib/app/preview-build"

--- a/packages/cli/tests/app-bun-compat.test.ts
+++ b/packages/cli/tests/app-bun-compat.test.ts
@@ -89,12 +89,10 @@ describe("bun compatibility", () => {
   it("forwards explicit build types to the SDK strategy resolver", async () => {
     const cwd = await createTempCwd();
 
-    const { resolvePreviewBuildStrategy } = await import(
-      "../src/lib/app/preview-build"
-    );
+    const { resolveAppBuildStrategy } = await import("../src/lib/app/build");
 
     await expect(
-      resolvePreviewBuildStrategy({
+      resolveAppBuildStrategy({
         appPath: cwd,
         buildType: "astro",
         entrypoint: undefined,
@@ -102,7 +100,7 @@ describe("bun compatibility", () => {
     ).resolves.toMatchObject({ buildType: "astro" });
 
     await expect(
-      resolvePreviewBuildStrategy({
+      resolveAppBuildStrategy({
         appPath: cwd,
         buildType: "tanstack-start",
         entrypoint: undefined,

--- a/packages/cli/tests/app-bun-compat.test.ts
+++ b/packages/cli/tests/app-bun-compat.test.ts
@@ -136,11 +136,13 @@ describe("bun compatibility", () => {
       execute: vi.fn(),
     }));
 
-    vi.doMock("@prisma/compute-sdk", () => ({
+    vi.doMock("@prisma/compute-sdk", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("@prisma/compute-sdk")>()),
       AstroBuild: otherFrameworkBuild,
       BunBuild: bunBuild,
       NextjsBuild: nextjsBuild,
       NuxtBuild: otherFrameworkBuild,
+      NestjsBuild: otherFrameworkBuild,
       TanstackStartBuild: otherFrameworkBuild,
     }));
 
@@ -185,11 +187,13 @@ describe("bun compatibility", () => {
       execute: vi.fn(),
     }));
 
-    vi.doMock("@prisma/compute-sdk", () => ({
+    vi.doMock("@prisma/compute-sdk", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("@prisma/compute-sdk")>()),
       AstroBuild: astroBuild,
       BunBuild: bunBuild,
       NextjsBuild: nextjsBuild,
       NuxtBuild: nuxtBuild,
+      NestjsBuild: nextjsBuild,
       TanstackStartBuild: tanstackStartBuild,
     }));
 
@@ -218,11 +222,13 @@ describe("bun compatibility", () => {
       execute: vi.fn(),
     }));
 
-    vi.doMock("@prisma/compute-sdk", () => ({
+    vi.doMock("@prisma/compute-sdk", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("@prisma/compute-sdk")>()),
       AstroBuild: buildStrategy,
       BunBuild: buildStrategy,
       NextjsBuild: buildStrategy,
       NuxtBuild: buildStrategy,
+      NestjsBuild: buildStrategy,
       TanstackStartBuild: buildStrategy,
     }));
 

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -2290,8 +2290,8 @@ describe("app controller", () => {
       expectedBuildType: "bun",
     },
     {
-      name: "Bun from --framework bun with package.json module",
-      packageJson: { module: "index.ts" },
+      name: "Bun from --framework bun with package.json main",
+      packageJson: { main: "index.ts" },
       framework: "bun",
       expectedEntrypoint: "index.ts",
       expectedBuildType: "bun",

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -38,7 +38,7 @@ afterEach(() => {
 
   vi.doUnmock("../src/lib/auth/auth-ops");
   vi.doUnmock("../src/lib/auth/guard");
-  vi.doUnmock("../src/lib/app/preview-provider");
+  vi.doUnmock("../src/lib/app/app-provider");
   vi.doUnmock("../src/lib/app/branch-database");
   vi.doUnmock("../src/shell/prompt");
   vi.doUnmock("open");
@@ -201,8 +201,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -272,8 +272,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -405,8 +405,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -496,8 +496,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -597,8 +597,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -664,8 +664,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject: vi.fn(),
@@ -738,14 +738,12 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", async (importOriginal) => {
+    vi.doMock("../src/lib/app/app-provider", async (importOriginal) => {
       const actual =
-        await importOriginal<
-          typeof import("../src/lib/app/preview-provider")
-        >();
+        await importOriginal<typeof import("../src/lib/app/app-provider")>();
       return {
         ...actual,
-        createPreviewAppProvider: vi.fn(() =>
+        createAppProvider: vi.fn(() =>
           withBranchDatabaseProviderDefaults({
             resolveBranch: createResolveBranch(),
             listApps,
@@ -836,14 +834,12 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", async (importOriginal) => {
+    vi.doMock("../src/lib/app/app-provider", async (importOriginal) => {
       const actual =
-        await importOriginal<
-          typeof import("../src/lib/app/preview-provider")
-        >();
+        await importOriginal<typeof import("../src/lib/app/app-provider")>();
       return {
         ...actual,
-        createPreviewAppProvider: vi.fn(() =>
+        createAppProvider: vi.fn(() =>
           withBranchDatabaseProviderDefaults({
             resolveBranch: createResolveBranch(),
             listApps,
@@ -895,14 +891,12 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", async (importOriginal) => {
+    vi.doMock("../src/lib/app/app-provider", async (importOriginal) => {
       const actual =
-        await importOriginal<
-          typeof import("../src/lib/app/preview-provider")
-        >();
+        await importOriginal<typeof import("../src/lib/app/app-provider")>();
       return {
         ...actual,
-        createPreviewAppProvider: vi.fn(() =>
+        createAppProvider: vi.fn(() =>
           withBranchDatabaseProviderDefaults({
             resolveBranch: createResolveBranch(),
             createProject,
@@ -976,14 +970,12 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", async (importOriginal) => {
+    vi.doMock("../src/lib/app/app-provider", async (importOriginal) => {
       const actual =
-        await importOriginal<
-          typeof import("../src/lib/app/preview-provider")
-        >();
+        await importOriginal<typeof import("../src/lib/app/app-provider")>();
       return {
         ...actual,
-        createPreviewAppProvider: vi.fn(() =>
+        createAppProvider: vi.fn(() =>
           withBranchDatabaseProviderDefaults({
             resolveBranch: createResolveBranch(),
             listApps,
@@ -1031,13 +1023,11 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", async (importOriginal) => {
+    vi.doMock("../src/lib/app/app-provider", async (importOriginal) => {
       const actual =
-        await importOriginal<
-          typeof import("../src/lib/app/preview-provider")
-        >();
+        await importOriginal<typeof import("../src/lib/app/app-provider")>();
       const addDomain = vi.fn().mockRejectedValue(
-        new actual.PreviewDomainApiError({
+        new actual.DomainApiError({
           summary: "Failed to add custom domain",
           status: 409,
           message: "Domain quota exceeded.",
@@ -1046,7 +1036,7 @@ describe("app controller", () => {
       );
       return {
         ...actual,
-        createPreviewAppProvider: vi.fn(() =>
+        createAppProvider: vi.fn(() =>
           withBranchDatabaseProviderDefaults({
             resolveBranch: createResolveBranch(),
             listApps,
@@ -1097,13 +1087,11 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", async (importOriginal) => {
+    vi.doMock("../src/lib/app/app-provider", async (importOriginal) => {
       const actual =
-        await importOriginal<
-          typeof import("../src/lib/app/preview-provider")
-        >();
+        await importOriginal<typeof import("../src/lib/app/app-provider")>();
       const addDomain = vi.fn().mockRejectedValue(
-        new actual.PreviewDomainApiError({
+        new actual.DomainApiError({
           summary: "Failed to add custom domain",
           status: 409,
           message: "Hostname already registered.",
@@ -1112,7 +1100,7 @@ describe("app controller", () => {
       );
       return {
         ...actual,
-        createPreviewAppProvider: vi.fn(() =>
+        createAppProvider: vi.fn(() =>
           withBranchDatabaseProviderDefaults({
             resolveBranch: createResolveBranch(),
             listApps,
@@ -1169,13 +1157,11 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", async (importOriginal) => {
+    vi.doMock("../src/lib/app/app-provider", async (importOriginal) => {
       const actual =
-        await importOriginal<
-          typeof import("../src/lib/app/preview-provider")
-        >();
+        await importOriginal<typeof import("../src/lib/app/app-provider")>();
       const addDomain = vi.fn().mockRejectedValue(
-        new actual.PreviewDomainApiError({
+        new actual.DomainApiError({
           summary: "Failed to add custom domain",
           status: 400,
           message: "No CNAME or A/AAAA records found for hostname.",
@@ -1184,7 +1170,7 @@ describe("app controller", () => {
       );
       return {
         ...actual,
-        createPreviewAppProvider: vi.fn(() =>
+        createAppProvider: vi.fn(() =>
           withBranchDatabaseProviderDefaults({
             resolveBranch: createResolveBranch(),
             listApps,
@@ -1240,13 +1226,11 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", async (importOriginal) => {
+    vi.doMock("../src/lib/app/app-provider", async (importOriginal) => {
       const actual =
-        await importOriginal<
-          typeof import("../src/lib/app/preview-provider")
-        >();
+        await importOriginal<typeof import("../src/lib/app/app-provider")>();
       const addDomain = vi.fn().mockRejectedValue(
-        new actual.PreviewDomainApiError({
+        new actual.DomainApiError({
           summary: "Failed to add custom domain",
           status: 400,
           message: "DNS is not configured for hostname compute-test.amanv.dev.",
@@ -1255,7 +1239,7 @@ describe("app controller", () => {
       );
       return {
         ...actual,
-        createPreviewAppProvider: vi.fn(() =>
+        createAppProvider: vi.fn(() =>
           withBranchDatabaseProviderDefaults({
             resolveBranch: createResolveBranch(),
             listApps,
@@ -1309,14 +1293,12 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", async (importOriginal) => {
+    vi.doMock("../src/lib/app/app-provider", async (importOriginal) => {
       const actual =
-        await importOriginal<
-          typeof import("../src/lib/app/preview-provider")
-        >();
+        await importOriginal<typeof import("../src/lib/app/app-provider")>();
       return {
         ...actual,
-        createPreviewAppProvider: vi.fn(() =>
+        createAppProvider: vi.fn(() =>
           withBranchDatabaseProviderDefaults({
             resolveBranch: createResolveBranch(),
             listApps,
@@ -1400,13 +1382,11 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", async (importOriginal) => {
+    vi.doMock("../src/lib/app/app-provider", async (importOriginal) => {
       const actual =
-        await importOriginal<
-          typeof import("../src/lib/app/preview-provider")
-        >();
+        await importOriginal<typeof import("../src/lib/app/app-provider")>();
       const retryDomain = vi.fn().mockRejectedValue(
-        new actual.PreviewDomainApiError({
+        new actual.DomainApiError({
           summary: "Failed to retry custom domain",
           status: 409,
           message: "Domain is not eligible for retry.",
@@ -1414,7 +1394,7 @@ describe("app controller", () => {
       );
       return {
         ...actual,
-        createPreviewAppProvider: vi.fn(() =>
+        createAppProvider: vi.fn(() =>
           withBranchDatabaseProviderDefaults({
             resolveBranch: createResolveBranch(),
             listApps,
@@ -1470,14 +1450,12 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", async (importOriginal) => {
+    vi.doMock("../src/lib/app/app-provider", async (importOriginal) => {
       const actual =
-        await importOriginal<
-          typeof import("../src/lib/app/preview-provider")
-        >();
+        await importOriginal<typeof import("../src/lib/app/app-provider")>();
       return {
         ...actual,
-        createPreviewAppProvider: vi.fn(() =>
+        createAppProvider: vi.fn(() =>
           withBranchDatabaseProviderDefaults({
             resolveBranch: createResolveBranch(),
             listApps,
@@ -1585,8 +1563,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject: vi.fn(),
@@ -1712,8 +1690,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps: vi.fn(),
@@ -1775,8 +1753,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -1864,8 +1842,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listEnvironmentVariables: vi.fn().mockResolvedValue([]),
@@ -1939,8 +1917,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject: vi.fn(),
@@ -2011,8 +1989,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject: vi.fn(),
@@ -2114,8 +2092,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -2209,8 +2187,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -2343,8 +2321,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -2417,8 +2395,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -2484,8 +2462,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject,
@@ -2640,8 +2618,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject,
@@ -2715,8 +2693,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           createProject,
           resolveBranch: createResolveBranch(),
@@ -2803,8 +2781,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject,
@@ -2874,8 +2852,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps: vi.fn(),
@@ -2920,8 +2898,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -2976,8 +2954,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -3076,8 +3054,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -3201,8 +3179,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -3271,8 +3249,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -3333,8 +3311,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -3402,8 +3380,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject,
@@ -3531,8 +3509,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject,
@@ -3660,8 +3638,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject,
@@ -3724,8 +3702,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject,
@@ -3780,8 +3758,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject,
@@ -3855,8 +3833,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -3938,8 +3916,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -3980,8 +3958,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -4052,8 +4030,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -4105,8 +4083,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject: vi.fn(),
@@ -4166,8 +4144,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject: vi.fn(),
@@ -4248,8 +4226,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject: vi.fn(),
@@ -4354,8 +4332,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject: vi.fn(),
@@ -4426,8 +4404,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps: vi.fn(),
@@ -4491,8 +4469,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps: vi.fn(),
@@ -4550,8 +4528,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps: vi.fn(),
@@ -4602,8 +4580,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps: vi.fn(),
@@ -4673,8 +4651,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject: vi.fn(),
@@ -4747,8 +4725,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject: vi.fn(),
@@ -4820,8 +4798,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject: vi.fn(),
@@ -4889,8 +4867,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject: vi.fn(),
@@ -4965,8 +4943,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject: vi.fn(),
@@ -5052,8 +5030,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject: vi.fn(),
@@ -5129,8 +5107,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject: vi.fn(),
@@ -5224,8 +5202,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject: vi.fn(),
@@ -5320,8 +5298,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject: vi.fn(),
@@ -5392,8 +5370,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject: vi.fn(),
@@ -5455,8 +5433,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -5553,8 +5531,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -5644,8 +5622,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -5714,8 +5692,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -5802,8 +5780,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           listApps,
@@ -5873,8 +5851,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject: vi.fn(),
@@ -5967,8 +5945,8 @@ describe("app controller", () => {
         textPrompt,
       };
     });
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject: vi.fn(),
@@ -6027,8 +6005,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject: vi.fn(),
@@ -6084,8 +6062,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject: vi.fn(),
@@ -6143,8 +6121,8 @@ describe("app controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() =>
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
         withBranchDatabaseProviderDefaults({
           resolveBranch: createResolveBranch(),
           createProject: vi.fn(),

--- a/packages/cli/tests/app-env-vars.test.ts
+++ b/packages/cli/tests/app-env-vars.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
 
   vi.doUnmock("../src/lib/auth/auth-ops");
   vi.doUnmock("../src/lib/auth/guard");
-  vi.doUnmock("../src/lib/app/preview-provider");
+  vi.doUnmock("../src/lib/app/app-provider");
   vi.resetModules();
   vi.restoreAllMocks();
 });
@@ -500,8 +500,8 @@ describe("app env vars", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() => ({
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() => ({
         resolveBranch: createResolveBranch(),
         createProject: vi.fn(),
         listApps,

--- a/packages/cli/tests/app-env.test.ts
+++ b/packages/cli/tests/app-env.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
 
   vi.doUnmock("../src/lib/auth/auth-ops");
   vi.doUnmock("../src/lib/auth/guard");
-  vi.doUnmock("../src/lib/app/preview-provider");
+  vi.doUnmock("../src/lib/app/app-provider");
   vi.resetModules();
   vi.restoreAllMocks();
 });

--- a/packages/cli/tests/app-local-dev.test.ts
+++ b/packages/cli/tests/app-local-dev.test.ts
@@ -5,14 +5,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 afterEach(() => {
   vi.doUnmock("../src/lib/app/local-dev");
-  vi.doUnmock("../src/lib/app/preview-build");
+  vi.doUnmock("../src/lib/app/build");
   vi.resetModules();
   vi.restoreAllMocks();
 });
 
 describe("app local dev commands", () => {
   it("build delegates to the shared preview build helper", async () => {
-    const executePreviewBuild = vi.fn().mockResolvedValue({
+    const executeAppBuild = vi.fn().mockResolvedValue({
       artifact: {
         directory: "/tmp/compute-build/app",
         entrypoint: "server.js",
@@ -20,13 +20,13 @@ describe("app local dev commands", () => {
       buildType: "bun",
     });
 
-    vi.doMock("../src/lib/app/preview-build", async () => {
+    vi.doMock("../src/lib/app/build", async () => {
       const actual = await vi.importActual<
-        typeof import("../src/lib/app/preview-build")
-      >("../src/lib/app/preview-build");
+        typeof import("../src/lib/app/build")
+      >("../src/lib/app/build");
       return {
         ...actual,
-        executePreviewBuild,
+        executeAppBuild,
       };
     });
 
@@ -46,7 +46,7 @@ describe("app local dev commands", () => {
       buildType: "bun",
     });
 
-    expect(executePreviewBuild).toHaveBeenCalledWith({
+    expect(executeAppBuild).toHaveBeenCalledWith({
       appPath: cwd,
       entrypoint: "server.ts",
       buildType: "bun",
@@ -60,7 +60,7 @@ describe("app local dev commands", () => {
   });
 
   it("build resolves the app target from prisma.compute.ts", async () => {
-    const executePreviewBuild = vi.fn().mockResolvedValue({
+    const executeAppBuild = vi.fn().mockResolvedValue({
       artifact: {
         directory: "/tmp/compute-build/app",
         entrypoint: "index.js",
@@ -68,13 +68,13 @@ describe("app local dev commands", () => {
       buildType: "bun",
     });
 
-    vi.doMock("../src/lib/app/preview-build", async () => {
+    vi.doMock("../src/lib/app/build", async () => {
       const actual = await vi.importActual<
-        typeof import("../src/lib/app/preview-build")
-      >("../src/lib/app/preview-build");
+        typeof import("../src/lib/app/build")
+      >("../src/lib/app/build");
       return {
         ...actual,
-        executePreviewBuild,
+        executeAppBuild,
       };
     });
 
@@ -105,7 +105,7 @@ describe("app local dev commands", () => {
 
     await runAppBuild(context, { configTarget: "api" });
 
-    expect(executePreviewBuild).toHaveBeenCalledWith({
+    expect(executeAppBuild).toHaveBeenCalledWith({
       appPath: path.join(cwd, "apps", "api"),
       entrypoint: "src/index.ts",
       buildType: "bun",
@@ -114,7 +114,7 @@ describe("app local dev commands", () => {
   });
 
   it("build run from inside a target root discovers the config and infers the target", async () => {
-    const executePreviewBuild = vi.fn().mockResolvedValue({
+    const executeAppBuild = vi.fn().mockResolvedValue({
       artifact: {
         directory: "/tmp/compute-build/app",
         entrypoint: "index.js",
@@ -122,13 +122,13 @@ describe("app local dev commands", () => {
       buildType: "bun",
     });
 
-    vi.doMock("../src/lib/app/preview-build", async () => {
+    vi.doMock("../src/lib/app/build", async () => {
       const actual = await vi.importActual<
-        typeof import("../src/lib/app/preview-build")
-      >("../src/lib/app/preview-build");
+        typeof import("../src/lib/app/build")
+      >("../src/lib/app/build");
       return {
         ...actual,
-        executePreviewBuild,
+        executeAppBuild,
       };
     });
 
@@ -160,7 +160,7 @@ describe("app local dev commands", () => {
 
     await runAppBuild(context, {});
 
-    expect(executePreviewBuild).toHaveBeenCalledWith({
+    expect(executeAppBuild).toHaveBeenCalledWith({
       appPath: path.join(repoDir, "apps", "api"),
       entrypoint: "src/index.ts",
       buildType: "bun",
@@ -169,7 +169,7 @@ describe("app local dev commands", () => {
   });
 
   it("build applies a committed build block by detecting the framework instead of ignoring it", async () => {
-    const executePreviewBuild = vi.fn().mockResolvedValue({
+    const executeAppBuild = vi.fn().mockResolvedValue({
       artifact: {
         directory: "/tmp/compute-build/app",
         entrypoint: "server.js",
@@ -177,13 +177,13 @@ describe("app local dev commands", () => {
       buildType: "nextjs",
     });
 
-    vi.doMock("../src/lib/app/preview-build", async () => {
+    vi.doMock("../src/lib/app/build", async () => {
       const actual = await vi.importActual<
-        typeof import("../src/lib/app/preview-build")
-      >("../src/lib/app/preview-build");
+        typeof import("../src/lib/app/build")
+      >("../src/lib/app/build");
       return {
         ...actual,
-        executePreviewBuild,
+        executeAppBuild,
       };
     });
 
@@ -221,7 +221,7 @@ describe("app local dev commands", () => {
 
     await runAppBuild(context, { configTarget: "web" });
 
-    expect(executePreviewBuild).toHaveBeenCalledWith(
+    expect(executeAppBuild).toHaveBeenCalledWith(
       expect.objectContaining({
         appPath: path.join(cwd, "apps", "web"),
         buildType: "nextjs",
@@ -265,7 +265,7 @@ describe("app local dev commands", () => {
   });
 
   it("build accepts explicit SDK framework strategies", async () => {
-    const executePreviewBuild = vi.fn().mockResolvedValue({
+    const executeAppBuild = vi.fn().mockResolvedValue({
       artifact: {
         directory: "/tmp/compute-build/app",
         entrypoint: "server/entry.mjs",
@@ -273,13 +273,13 @@ describe("app local dev commands", () => {
       buildType: "astro",
     });
 
-    vi.doMock("../src/lib/app/preview-build", async () => {
+    vi.doMock("../src/lib/app/build", async () => {
       const actual = await vi.importActual<
-        typeof import("../src/lib/app/preview-build")
-      >("../src/lib/app/preview-build");
+        typeof import("../src/lib/app/build")
+      >("../src/lib/app/build");
       return {
         ...actual,
-        executePreviewBuild,
+        executeAppBuild,
       };
     });
 
@@ -296,7 +296,7 @@ describe("app local dev commands", () => {
 
     const result = await runAppBuild(context, { buildType: "astro" });
 
-    expect(executePreviewBuild).toHaveBeenCalledWith({
+    expect(executeAppBuild).toHaveBeenCalledWith({
       appPath: cwd,
       entrypoint: undefined,
       buildType: "astro",
@@ -310,7 +310,7 @@ describe("app local dev commands", () => {
   });
 
   it("build returns USAGE_ERROR when framework detection is ambiguous", async () => {
-    const executePreviewBuild = vi
+    const executeAppBuild = vi
       .fn()
       .mockRejectedValue(
         new Error(
@@ -318,13 +318,13 @@ describe("app local dev commands", () => {
         ),
       );
 
-    vi.doMock("../src/lib/app/preview-build", async () => {
+    vi.doMock("../src/lib/app/build", async () => {
       const actual = await vi.importActual<
-        typeof import("../src/lib/app/preview-build")
-      >("../src/lib/app/preview-build");
+        typeof import("../src/lib/app/build")
+      >("../src/lib/app/build");
       return {
         ...actual,
-        executePreviewBuild,
+        executeAppBuild,
       };
     });
 

--- a/packages/cli/tests/app-provider.test.ts
+++ b/packages/cli/tests/app-provider.test.ts
@@ -4,13 +4,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 afterEach(() => {
   vi.doUnmock("@prisma/compute-sdk");
-  vi.doUnmock("../src/lib/app/preview-build");
+  vi.doUnmock("../src/lib/app/build");
   vi.resetModules();
   vi.restoreAllMocks();
 });
 
-function mockPreviewBuildStrategy() {
-  return vi.fn().mockImplementation(function PreviewBuildStrategyMock(
+function mockAppBuildStrategy() {
+  return vi.fn().mockImplementation(function AppBuildStrategyMock(
     options: object,
   ) {
     return { options };
@@ -43,11 +43,9 @@ describe("preview app provider", () => {
       ComputeClient: class {},
     }));
 
-    const { createPreviewAppProvider } = await import(
-      "../src/lib/app/preview-provider"
-    );
+    const { createAppProvider } = await import("../src/lib/app/app-provider");
 
-    const provider = createPreviewAppProvider(client as never);
+    const provider = createAppProvider(client as never);
     await expect(
       provider.resolveBranch("proj_123", {
         branchName: "production",
@@ -74,10 +72,10 @@ describe("preview app provider", () => {
         serviceEndpointDomain: "hello-world.fra.prisma.build",
       },
     });
-    const PreviewBuildStrategy = mockPreviewBuildStrategy();
+    const AppBuildStrategy = mockAppBuildStrategy();
 
-    vi.doMock("../src/lib/app/preview-build", () => ({
-      PreviewBuildStrategy,
+    vi.doMock("../src/lib/app/build", () => ({
+      AppBuildStrategy,
     }));
     vi.doMock("@prisma/compute-sdk", () => ({
       ApiError: { is: () => false },
@@ -86,11 +84,9 @@ describe("preview app provider", () => {
       },
     }));
 
-    const { createPreviewAppProvider } = await import(
-      "../src/lib/app/preview-provider"
-    );
+    const { createAppProvider } = await import("../src/lib/app/app-provider");
 
-    const provider = createPreviewAppProvider({} as never);
+    const provider = createAppProvider({} as never);
     const cwd = path.resolve("/tmp/next-smoke");
 
     await provider.deployApp({
@@ -102,7 +98,7 @@ describe("preview app provider", () => {
       portMapping: { http: 3000 },
     });
 
-    expect(PreviewBuildStrategy).toHaveBeenCalledWith({
+    expect(AppBuildStrategy).toHaveBeenCalledWith({
       appPath: cwd,
       entrypoint: undefined,
       buildType: "nextjs",
@@ -130,7 +126,7 @@ describe("preview app provider", () => {
         serviceEndpointDomain: "hello-world.fra.prisma.build",
       },
     });
-    const PreviewBuildStrategy = mockPreviewBuildStrategy();
+    const AppBuildStrategy = mockAppBuildStrategy();
     const client = {
       GET: vi.fn().mockResolvedValue({
         data: {
@@ -175,8 +171,8 @@ describe("preview app provider", () => {
       }),
     };
 
-    vi.doMock("../src/lib/app/preview-build", () => ({
-      PreviewBuildStrategy,
+    vi.doMock("../src/lib/app/build", () => ({
+      AppBuildStrategy,
     }));
     vi.doMock("@prisma/compute-sdk", () => ({
       ApiError: { is: () => false },
@@ -185,11 +181,9 @@ describe("preview app provider", () => {
       },
     }));
 
-    const { createPreviewAppProvider } = await import(
-      "../src/lib/app/preview-provider"
-    );
+    const { createAppProvider } = await import("../src/lib/app/app-provider");
 
-    const provider = createPreviewAppProvider(client as never);
+    const provider = createAppProvider(client as never);
     const cwd = path.resolve("/tmp/next-smoke");
 
     await provider.deployApp({
@@ -252,7 +246,7 @@ describe("preview app provider", () => {
         serviceEndpointDomain: "hello-world.fra.prisma.build",
       },
     });
-    const PreviewBuildStrategy = mockPreviewBuildStrategy();
+    const AppBuildStrategy = mockAppBuildStrategy();
     const client = {
       GET: vi.fn().mockImplementation((pathName: string) => {
         if (pathName === "/v1/projects/{projectId}/branches") {
@@ -311,8 +305,8 @@ describe("preview app provider", () => {
       }),
     };
 
-    vi.doMock("../src/lib/app/preview-build", () => ({
-      PreviewBuildStrategy,
+    vi.doMock("../src/lib/app/build", () => ({
+      AppBuildStrategy,
     }));
     vi.doMock("@prisma/compute-sdk", () => ({
       ApiError: { is: () => false },
@@ -321,11 +315,9 @@ describe("preview app provider", () => {
       },
     }));
 
-    const { createPreviewAppProvider } = await import(
-      "../src/lib/app/preview-provider"
-    );
+    const { createAppProvider } = await import("../src/lib/app/app-provider");
 
-    const provider = createPreviewAppProvider(client as never);
+    const provider = createAppProvider(client as never);
     const cwd = path.resolve("/tmp/next-smoke");
 
     await provider.deployApp({
@@ -422,11 +414,9 @@ describe("preview app provider", () => {
       ComputeClient: class {},
     }));
 
-    const { createPreviewAppProvider } = await import(
-      "../src/lib/app/preview-provider"
-    );
+    const { createAppProvider } = await import("../src/lib/app/app-provider");
 
-    const provider = createPreviewAppProvider(client as never);
+    const provider = createAppProvider(client as never);
     const result = await provider.addDomain({
       appId: "app_1",
       hostname: "Shop.Acme.com",
@@ -514,11 +504,9 @@ describe("preview app provider", () => {
       ComputeClient: class {},
     }));
 
-    const { createPreviewAppProvider } = await import(
-      "../src/lib/app/preview-provider"
-    );
+    const { createAppProvider } = await import("../src/lib/app/app-provider");
 
-    const provider = createPreviewAppProvider(client as never);
+    const provider = createAppProvider(client as never);
 
     await expect(
       provider.addDomain({

--- a/packages/cli/tests/app-provider.test.ts
+++ b/packages/cli/tests/app-provider.test.ts
@@ -37,7 +37,8 @@ describe("preview app provider", () => {
       POST: vi.fn(),
     };
 
-    vi.doMock("@prisma/compute-sdk", () => ({
+    vi.doMock("@prisma/compute-sdk", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("@prisma/compute-sdk")>()),
       ApiError: { is: () => false },
       ComputeClient: class {},
     }));
@@ -415,7 +416,8 @@ describe("preview app provider", () => {
       }),
     };
 
-    vi.doMock("@prisma/compute-sdk", () => ({
+    vi.doMock("@prisma/compute-sdk", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("@prisma/compute-sdk")>()),
       ApiError: { is: () => false },
       ComputeClient: class {},
     }));
@@ -506,7 +508,8 @@ describe("preview app provider", () => {
       }),
     };
 
-    vi.doMock("@prisma/compute-sdk", () => ({
+    vi.doMock("@prisma/compute-sdk", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("@prisma/compute-sdk")>()),
       ApiError: { is: () => false },
       ComputeClient: class {},
     }));

--- a/packages/cli/tests/compute-config.test.ts
+++ b/packages/cli/tests/compute-config.test.ts
@@ -160,7 +160,7 @@ describe("normalizeComputeConfig", () => {
       "`apps.web.name` must be a non-empty string.",
     );
     expect(issues.join(" ")).toContain(
-      "`apps.web.framework` must be one of: nextjs, nuxt, astro, hono, tanstack-start, bun.",
+      "`apps.web.framework` must be one of: nextjs, nuxt, astro, hono, nestjs, tanstack-start, bun.",
     );
     expect(issues.join(" ")).toContain(
       "`apps.web.httpPort` must be an integer between 1 and 65535.",

--- a/packages/cli/tests/output.test.ts
+++ b/packages/cli/tests/output.test.ts
@@ -93,8 +93,7 @@ describe("shell output", () => {
         summary: "App deploy failed",
         why: "ENOENT: missing file",
         fix: "Retry the command.",
-        debug:
-          "Error: ENOENT: missing file\n    at stageStandaloneArtifact",
+        debug: "Error: ENOENT: missing file\n    at stageStandaloneArtifact",
       }),
       { trace: true },
     );

--- a/packages/cli/tests/output.test.ts
+++ b/packages/cli/tests/output.test.ts
@@ -94,14 +94,14 @@ describe("shell output", () => {
         why: "ENOENT: missing file",
         fix: "Retry the command.",
         debug:
-          "Error: ENOENT: missing file\n    at stageNextjsStandaloneArtifact",
+          "Error: ENOENT: missing file\n    at stageStandaloneArtifact",
       }),
       { trace: true },
     );
 
     expect(stderr.buffer).toContain("Trace:");
     expect(stderr.buffer).toContain("Error: ENOENT: missing file");
-    expect(stderr.buffer).toContain("stageNextjsStandaloneArtifact");
+    expect(stderr.buffer).toContain("stageStandaloneArtifact");
     expect(stderr.buffer).not.toContain("More: Re-run with --trace");
   });
 });

--- a/packages/cli/tests/production-deploy-gate.test.ts
+++ b/packages/cli/tests/production-deploy-gate.test.ts
@@ -2,10 +2,10 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
-  PreviewAppProvider,
-  PreviewAppRecord,
-  PreviewDeploymentRecord,
-} from "../src/lib/app/preview-provider";
+  AppProvider,
+  AppRecord,
+  DeploymentRecord,
+} from "../src/lib/app/app-provider";
 import { confirmPrompt } from "../src/shell/prompt";
 import { createTempCwd, createTestCommandContext } from "./helpers";
 
@@ -179,8 +179,8 @@ async function createGateContext(
 
 function createGateProvider(
   app = createApp(),
-  deployments: PreviewDeploymentRecord[] = [createDeployment()],
-): Pick<PreviewAppProvider, "listDeployments"> {
+  deployments: DeploymentRecord[] = [createDeployment()],
+): Pick<AppProvider, "listDeployments"> {
   return {
     listDeployments: vi.fn().mockResolvedValue({
       app,
@@ -189,9 +189,7 @@ function createGateProvider(
   };
 }
 
-function createApp(
-  overrides: Partial<PreviewAppRecord> = {},
-): PreviewAppRecord {
+function createApp(overrides: Partial<AppRecord> = {}): AppRecord {
   return {
     id: "app_1",
     name: "hello-world",
@@ -204,8 +202,8 @@ function createApp(
 }
 
 function createDeployment(
-  overrides: Partial<PreviewDeploymentRecord> = {},
-): PreviewDeploymentRecord {
+  overrides: Partial<DeploymentRecord> = {},
+): DeploymentRecord {
   return {
     id: "dep_live",
     status: "running",

--- a/packages/cli/tests/project-controller.test.ts
+++ b/packages/cli/tests/project-controller.test.ts
@@ -9,7 +9,7 @@ const fixturePath = path.resolve("fixtures/mock-api.json");
 afterEach(() => {
   vi.doUnmock("../src/lib/auth/auth-ops");
   vi.doUnmock("../src/lib/auth/guard");
-  vi.doUnmock("../src/lib/app/preview-provider");
+  vi.doUnmock("../src/lib/app/app-provider");
   vi.resetModules();
   vi.restoreAllMocks();
 });
@@ -180,8 +180,8 @@ describe("project controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() => ({
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() => ({
         createProject,
       })),
     }));
@@ -266,8 +266,8 @@ describe("project controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() => ({
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() => ({
         createProject,
       })),
     }));
@@ -341,8 +341,8 @@ describe("project controller", () => {
     vi.doMock("../src/lib/auth/guard", () => ({
       requireComputeAuth,
     }));
-    vi.doMock("../src/lib/app/preview-provider", () => ({
-      createPreviewAppProvider: vi.fn(() => ({
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() => ({
         createProject,
       })),
     }));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
       '@prisma/compute-sdk':
-        specifier: ^0.23.0
-        version: 0.23.0(@prisma/management-api-sdk@1.37.0)
+        specifier: ^0.28.0
+        version: 0.28.0(@prisma/management-api-sdk@1.37.0)(rollup@4.61.0)
       '@prisma/credentials-store':
         specifier: ^7.8.0
         version: 7.8.0
@@ -523,6 +523,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -536,6 +540,11 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@mapbox/node-pre-gyp@2.0.3':
+    resolution: {integrity: sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
     peerDependencies:
@@ -545,8 +554,8 @@ packages:
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
-  '@prisma/compute-sdk@0.23.0':
-    resolution: {integrity: sha512-DvgU1CKyiKF3i8tdKnezIlU+XArTv2q/ZFkhqPpisSRGJIaF+Vs8gcUdBAAtT/2Tx7PtZ8rL6Wr2srjTv5uyxg==}
+  '@prisma/compute-sdk@0.28.0':
+    resolution: {integrity: sha512-Oy9E/Y3SrRezoVoXGFiZsWcXQOjO57inTNuIGkki9/CL7eMYqu10hdJEdoarlQPRFIqsYvJcUnHjISgfr5RaLA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@prisma/management-api-sdk': '>=1.36.0'
@@ -657,6 +666,15 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rollup/rollup-android-arm-eabi@4.61.0':
     resolution: {integrity: sha512-dnxczajOqt0gesZlN5pGQ1s1imQVrsmCw5G2Ci4oM+0WvNz3pyRnlWrT7McoZIb8VlFwCawdmbWRmxRn7HI+VQ==}
@@ -817,6 +835,11 @@ packages:
   '@types/node@22.19.19':
     resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
 
+  '@vercel/nft@1.10.2':
+    resolution: {integrity: sha512-w+WyX5Ulmj4dtTZrxaulqrjaLZHSbnPzx75SJsTNYmotKsqn1JlLnDJa+lz5hn90HJofhl/2MAtw0mCrgM3qYw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   '@vitest/expect@4.1.8':
     resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
@@ -846,6 +869,24 @@ packages:
   '@vitest/utils@4.1.8':
     resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
+  abbrev@3.0.1:
+    resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
@@ -869,6 +910,9 @@ packages:
     resolution: {integrity: sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw==}
     engines: {node: '>=20.19.0'}
 
+  async-sema@3.1.1:
+    resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
+
   b4a@1.8.1:
     resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
     peerDependencies:
@@ -876,6 +920,10 @@ packages:
     peerDependenciesMeta:
       react-native-b4a:
         optional: true
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   bare-events@2.8.3:
     resolution: {integrity: sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==}
@@ -921,8 +969,15 @@ packages:
   better-result@2.9.2:
     resolution: {integrity: sha512-WIFoBPCdnTOdk9inkE1ZRvCZ4P0CpSkAiLlchC65N7n9DcjZ3NhqkBOlafzpOVnO8ixyi37kicmSJ3ENhPZl7Q==}
 
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -936,6 +991,10 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
@@ -943,8 +1002,21 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   default-browser-id@5.0.1:
     resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
@@ -960,6 +1032,10 @@ packages:
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -996,6 +1072,9 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -1031,6 +1110,9 @@ packages:
       picomatch:
         optional: true
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1043,12 +1125,23 @@ packages:
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
 
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   import-without-cache@0.3.3:
     resolution: {integrity: sha512-bDxwDdF04gm550DfZHgffvlX+9kUlcz32UD0AeBTmVPFiWkrexF2XVmiuFFbDhiFuP8fQkrkvI2KdSNPYWAXkQ==}
@@ -1093,15 +1186,52 @@ packages:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
 
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   magicast@0.5.3:
     resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
+
+  nopt@8.1.0:
+    resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
+    engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
 
   obug@2.1.1:
@@ -1120,6 +1250,10 @@ packages:
   os-paths@7.4.0:
     resolution: {integrity: sha512-Ux1J4NUqC6tZayBqLN1kUlDAEvLiQlli/53sSddU4IN+h+3xxnv2HmRSMpVSvr1hvJzotfMs3ERvETGK+f4OwA==}
     engines: {node: '>= 4.0'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1145,6 +1279,10 @@ packages:
 
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -1233,6 +1371,10 @@ packages:
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
+  tar@7.5.16:
+    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
+    engines: {node: '>=18'}
+
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
@@ -1256,6 +1398,9 @@ packages:
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -1399,6 +1544,12 @@ packages:
       jsdom:
         optional: true
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -1431,6 +1582,10 @@ packages:
   xdg-portable@10.6.0:
     resolution: {integrity: sha512-xrcqhWDvtZ7WLmt8G4f3hHy37iK7D2idtosRgkeiSPZEPmBShp0VfmRBLWAPC6zLF48APJ21yfea+RfQMF4/Aw==}
     engines: {node: '>= 4.0'}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -1693,6 +1848,10 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1707,6 +1866,19 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mapbox/node-pre-gyp@2.0.3':
+    dependencies:
+      consola: 3.4.2
+      detect-libc: 2.1.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 2.7.0
+      nopt: 8.1.0
+      semver: 7.8.1
+      tar: 7.5.16
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -1716,11 +1888,13 @@ snapshots:
 
   '@oxc-project/types@0.127.0': {}
 
-  '@prisma/compute-sdk@0.23.0(@prisma/management-api-sdk@1.37.0)':
+  '@prisma/compute-sdk@0.28.0(@prisma/management-api-sdk@1.37.0)(rollup@4.61.0)':
     dependencies:
       '@prisma/management-api-sdk': 1.37.0
+      '@vercel/nft': 1.10.2(rollup@4.61.0)
       better-result: 2.9.2
       jiti: 2.7.0
+      magicast: 0.5.3
       tar-stream: 3.2.0
       tiny-invariant: 1.3.3
       ws: 8.21.0
@@ -1728,7 +1902,10 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - bufferutil
+      - encoding
       - react-native-b4a
+      - rollup
+      - supports-color
       - utf-8-validate
 
   '@prisma/credentials-store@7.8.0':
@@ -1793,6 +1970,14 @@ snapshots:
     optional: true
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
+
+  '@rollup/pluginutils@5.4.0(rollup@4.61.0)':
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.61.0
 
   '@rollup/rollup-android-arm-eabi@4.61.0':
     optional: true
@@ -1891,6 +2076,25 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@vercel/nft@1.10.2(rollup@4.61.0)':
+    dependencies:
+      '@mapbox/node-pre-gyp': 2.0.3
+      '@rollup/pluginutils': 5.4.0(rollup@4.61.0)
+      acorn: 8.17.0
+      acorn-import-attributes: 1.9.5(acorn@8.17.0)
+      async-sema: 3.1.1
+      bindings: 1.5.0
+      estree-walker: 2.0.2
+      glob: 13.0.6
+      graceful-fs: 4.2.11
+      node-gyp-build: 4.8.4
+      picomatch: 4.0.4
+      resolve-from: 5.0.0
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
   '@vitest/expect@4.1.8':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -1932,6 +2136,16 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  abbrev@3.0.1: {}
+
+  acorn-import-attributes@1.9.5(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
+  acorn@8.17.0: {}
+
+  agent-base@7.1.4: {}
+
   ansi-regex@6.2.2: {}
 
   ansi-styles@6.2.3: {}
@@ -1950,7 +2164,11 @@ snapshots:
       estree-walker: 3.0.3
       pathe: 2.0.3
 
+  async-sema@3.1.1: {}
+
   b4a@1.8.1: {}
+
+  balanced-match@4.0.4: {}
 
   bare-events@2.8.3: {}
 
@@ -1986,7 +2204,15 @@ snapshots:
 
   better-result@2.9.2: {}
 
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
   birpc@4.0.0: {}
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   bundle-name@4.1.0:
     dependencies:
@@ -1996,11 +2222,19 @@ snapshots:
 
   chai@6.2.2: {}
 
+  chownr@3.0.0: {}
+
   colorette@2.0.20: {}
 
   commander@14.0.3: {}
 
+  consola@3.4.2: {}
+
   convert-source-map@2.0.0: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
 
   default-browser-id@5.0.1: {}
 
@@ -2012,6 +2246,8 @@ snapshots:
   define-lazy-prop@3.0.0: {}
 
   defu@6.1.7: {}
+
+  detect-libc@2.1.2: {}
 
   dotenv@17.4.2: {}
 
@@ -2081,6 +2317,8 @@ snapshots:
 
   esprima@4.0.1: {}
 
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
@@ -2113,6 +2351,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  file-uri-to-path@1.0.0: {}
+
   fsevents@2.3.3:
     optional: true
 
@@ -2122,6 +2362,14 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
+  graceful-fs@4.2.11: {}
+
   gray-matter@4.0.3:
     dependencies:
       js-yaml: 3.14.2
@@ -2130,6 +2378,13 @@ snapshots:
       strip-bom-string: 1.0.0
 
   hookable@6.1.1: {}
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   import-without-cache@0.3.3: {}
 
@@ -2158,6 +2413,8 @@ snapshots:
 
   kind-of@6.0.3: {}
 
+  lru-cache@11.5.1: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2168,7 +2425,29 @@ snapshots:
       '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
+  minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
+  ms@2.1.3: {}
+
   nanoid@3.3.12: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-gyp-build@4.8.4: {}
+
+  nopt@8.1.0:
+    dependencies:
+      abbrev: 3.0.1
 
   obug@2.1.1: {}
 
@@ -2191,6 +2470,11 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.1
+      minipass: 7.1.3
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
@@ -2208,6 +2492,8 @@ snapshots:
   powershell-utils@0.1.0: {}
 
   quansync@1.0.0: {}
+
+  resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -2337,6 +2623,14 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
+  tar@7.5.16:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
   teex@1.0.1:
     dependencies:
       streamx: 2.26.0
@@ -2362,6 +2656,8 @@ snapshots:
       picomatch: 4.0.4
 
   tinyrainbow@3.1.0: {}
+
+  tr46@0.0.3: {}
 
   tree-kill@1.2.2: {}
 
@@ -2456,6 +2752,13 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -2485,5 +2788,7 @@ snapshots:
       os-paths: 7.4.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  yallist@5.0.0: {}
 
   yaml@2.9.0: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,6 @@ packages:
 
 allowBuilds:
   esbuild: true
+
+minimumReleaseAgeExclude:
+  - '@prisma/compute-sdk@0.28.0'


### PR DESCRIPTION
## What

Replaces the CLI's vendored preview build pipeline with the published `@prisma/compute-sdk@^0.28.0` build strategies, and enables **NestJS** deploys via `app deploy`.

The build strategy classes and the build-settings / artifact-staging helpers were extracted into the SDK in project-compute **#91** and **#94**. The CLI was still carrying its own copies (~1,750 lines). This swap deletes them and delegates to the SDK.

## Changes

- **`preview-build.ts`** — build strategies now come from the SDK (`NextjsBuild` / `NuxtBuild` / `AstroBuild` / `NestjsBuild` / `TanstackStartBuild` / `BunBuild`). `executePreviewBuild` and `restageNextjsArtifact` use the SDK's `normalizeArtifactSymlinks` and `stageStandaloneArtifact`. The CLI keeps the auto-detection order, the `PreviewBuildStrategy` wrapper, and `resolveBunEntrypoint` (which honors the `package.json` `module` field on top of `main`).
- **`preview-build-settings.ts`** — settings resolution delegates to the SDK's `resolveBuildSettings` / `resolveConfiguredBuildSettings`. The CLI keeps the provenance wrapper (`PreviewBuildSettingsResolution`) and the legacy `prisma.app.json` detection.
- **Enable NestJS** — `nestjs` is added to `PREVIEW_BUILD_TYPES` and `formatBuildTypeName`, so `app deploy` detects and builds NestJS apps. This is the user-facing payoff of #94.
- Net **~1,360 lines of vendored logic removed**.

## Verification

- Bumped `@prisma/compute-sdk` `^0.23.0` → `^0.28.0` (which exports all the strategies + `NestjsBuild`).
- `tsc --noEmit` clean, **481/481 tests pass**, biome clean, `tsdown` build succeeds.
- End-to-end (outside CI): built a real npm-workspace NestJS app through `NestjsBuild` and ran the artifact with `node` — boots correctly, including the monorepo dependency-hoisting case fixed in #94.

Public API of the two modules is unchanged (same export names), so consumers (`controllers/app.ts`, `preview-provider.ts`, `local-dev.ts`) are untouched apart from the additive `nestjs` build type. Tests point the staging/strategy mocks at the SDK via `importOriginal`.