### PR TITLE
fix(app): resolve the custom-domain production branch by role, not name

### DIFF
--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -2118,11 +2118,19 @@ async function resolveAppDomainTarget(
 function resolveDomainBranch(
   explicitBranchName: string | undefined,
 ): ResolvedDeployBranch {
+  const branchName = explicitBranchName?.trim();
+  if (branchName) {
+    return {
+      name: branchName,
+      annotation: BRANCH_FLAG_ANNOTATION,
+      explicit: true,
+    };
+  }
+
   return {
-    name: explicitBranchName?.trim() || "production",
-    annotation: explicitBranchName
-      ? BRANCH_FLAG_ANNOTATION
-      : "production default",
+    name: "production",
+    annotation: "production default",
+    explicit: false,
   };
 }
 
@@ -3307,14 +3315,20 @@ async function resolveProjectContext(
     // Resolve it by role so a project whose production branch is named e.g.
     // `master` still resolves, instead of guessing from the literal name. An
     // explicit --branch is matched by name so the caller can validate its role.
+    const explicitBranchName = options.branch?.explicit
+      ? requested.name
+      : undefined;
     const production = await resolveProductionBranch(client, {
       projectId: resolved.project.id,
-      branchName:
-        options.branch?.annotation === BRANCH_FLAG_ANNOTATION
-          ? requested.name
-          : undefined,
+      branchName: explicitBranchName,
       signal: context.runtime.signal,
     });
+    if (explicitBranchName && !production) {
+      throw explicitDomainBranchNotFoundError(
+        explicitBranchName,
+        options.commandName,
+      );
+    }
     return { ...resolved, branch: production ?? fallback };
   }
 
@@ -3663,9 +3677,29 @@ function assertExclusiveDeployProjectInputs(options: {
 /** Branch annotation marking a branch the user named via `--branch`. */
 const BRANCH_FLAG_ANNOTATION = "set by --branch";
 
+function explicitDomainBranchNotFoundError(
+  branchName: string,
+  commandName: string | undefined,
+): CliError {
+  return new CliError({
+    code: "BRANCH_NOT_FOUND",
+    domain: "branch",
+    summary: `Branch "${branchName}" not found`,
+    why: "Custom domain commands only target an existing production branch.",
+    fix: "Pass the production branch name for this project, or omit --branch to resolve the production branch by role.",
+    exitCode: 1,
+    nextSteps: [
+      commandName
+        ? `prisma-cli ${commandName}`
+        : "prisma-cli app domain add <hostname>",
+    ],
+  });
+}
+
 interface ResolvedDeployBranch {
   name: string;
   annotation: string;
+  explicit: boolean;
 }
 
 async function resolveDeployBranch(
@@ -3676,6 +3710,7 @@ async function resolveDeployBranch(
     return {
       name: explicitBranchName,
       annotation: BRANCH_FLAG_ANNOTATION,
+      explicit: true,
     };
   }
 
@@ -3687,12 +3722,14 @@ async function resolveDeployBranch(
     return {
       name: gitBranch,
       annotation: "from local Git branch",
+      explicit: false,
     };
   }
 
   return {
     name: "main",
     annotation: "default",
+    explicit: false,
   };
 }
 

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -86,7 +86,10 @@ import {
   runLocalApp,
 } from "../lib/app/local-dev";
 import { enforceProductionDeployGate } from "../lib/app/production-deploy-gate";
-import { resolveReadBranch } from "../lib/app/read-branch";
+import {
+  resolveProductionBranch,
+  resolveReadBranch,
+} from "../lib/app/read-branch";
 import { readAuthState } from "../lib/auth/auth-ops";
 import { getApiBaseUrl, SERVICE_TOKEN_ENV_VAR } from "../lib/auth/client";
 import { requireComputeAuth } from "../lib/auth/guard";
@@ -2050,17 +2053,6 @@ async function resolveAppDomainTarget(
     commandName.replace(/^app /, ""),
   );
   const branch = resolveDomainBranch(options?.branchName);
-  if (toBranchKind(branch.name) !== "production") {
-    throw new CliError({
-      code: "BRANCH_NOT_DEPLOYABLE",
-      domain: "branch",
-      summary: "Custom domains require the production branch",
-      why: `Custom domains on preview branch "${branch.name}" are not supported in Public Beta.`,
-      fix: "Use --branch production, or attach the domain after promoting/deploying to the production branch.",
-      exitCode: 2,
-      nextSteps: ["prisma-cli app domain add <hostname> --branch production"],
-    });
-  }
 
   const envProjectId = readDeployEnvOverride(
     context,
@@ -2071,10 +2063,27 @@ async function resolveAppDomainTarget(
   const { provider, target, projectId } =
     await requireProviderAndProjectContext(context, options?.projectRef, {
       branch,
+      // Domains attach to the production branch; resolve it by role (not by the
+      // literal name "production") so a project whose production branch is
+      // named e.g. `master` still works.
+      productionBranch: true,
       commandName,
       envProjectId,
       projectDir: compute.projectDir,
     });
+
+  // Gate on the resolved branch's role, not a guess from its name.
+  if (target.branch.kind !== "production") {
+    throw new CliError({
+      code: "BRANCH_NOT_DEPLOYABLE",
+      domain: "branch",
+      summary: "Custom domains require the production branch",
+      why: `Custom domains on preview branch "${target.branch.name}" are not supported in Public Beta.`,
+      fix: "Use --branch <production-branch>, or attach the domain after promoting/deploying to the production branch.",
+      exitCode: 2,
+      nextSteps: ["prisma-cli app domain add <hostname>"],
+    });
+  }
   const apps = await listApps(context, provider, projectId, target.branch.name);
   const selectedApp = await resolveDomainAppSelection(
     context,
@@ -2111,7 +2120,9 @@ function resolveDomainBranch(
 ): ResolvedDeployBranch {
   return {
     name: explicitBranchName?.trim() || "production",
-    annotation: explicitBranchName ? "set by --branch" : "production default",
+    annotation: explicitBranchName
+      ? BRANCH_FLAG_ANNOTATION
+      : "production default",
   };
 }
 
@@ -3188,6 +3199,7 @@ async function requireProviderAndProjectContext(
   explicitProject: string | undefined,
   options?: {
     branch?: ResolvedDeployBranch;
+    productionBranch?: boolean;
     commandName?: string;
     envProjectId?: string;
     projectDir?: string;
@@ -3252,6 +3264,7 @@ async function resolveProjectContext(
   explicitProject: string | undefined,
   options?: {
     branch?: ResolvedDeployBranch;
+    productionBranch?: boolean;
     commandName?: string;
     envProjectId?: string;
     projectDir?: string;
@@ -3283,6 +3296,28 @@ async function resolveProjectContext(
   const requested =
     options?.branch ?? (await resolveDeployBranch(context, undefined));
 
+  const fallback = {
+    id: null,
+    name: requested.name,
+    kind: toBranchKind(requested.name),
+  };
+
+  if (options?.productionBranch) {
+    // Production-only commands (custom domains) target the production branch.
+    // Resolve it by role so a project whose production branch is named e.g.
+    // `master` still resolves, instead of guessing from the literal name. An
+    // explicit --branch is matched by name so the caller can validate its role.
+    const production = await resolveProductionBranch(client, {
+      projectId: resolved.project.id,
+      branchName:
+        options.branch?.annotation === BRANCH_FLAG_ANNOTATION
+          ? requested.name
+          : undefined,
+      signal: context.runtime.signal,
+    });
+    return { ...resolved, branch: production ?? fallback };
+  }
+
   // An explicit --branch is honored as-is. An inferred branch (active Git
   // branch or the default) is resolved against the project's branches and
   // falls back to the default branch so a git-push app on a non-`main`
@@ -3295,14 +3330,7 @@ async function resolveProjectContext(
         signal: context.runtime.signal,
       });
 
-  return {
-    ...resolved,
-    branch: remoteBranch ?? {
-      id: null,
-      name: requested.name,
-      kind: toBranchKind(requested.name),
-    },
-  };
+  return { ...resolved, branch: remoteBranch ?? fallback };
 }
 
 async function resolveDeployProjectContext(
@@ -3632,6 +3660,9 @@ function assertExclusiveDeployProjectInputs(options: {
   );
 }
 
+/** Branch annotation marking a branch the user named via `--branch`. */
+const BRANCH_FLAG_ANNOTATION = "set by --branch";
+
 interface ResolvedDeployBranch {
   name: string;
   annotation: string;
@@ -3644,7 +3675,7 @@ async function resolveDeployBranch(
   if (explicitBranchName) {
     return {
       name: explicitBranchName,
-      annotation: "set by --branch",
+      annotation: BRANCH_FLAG_ANNOTATION,
     };
   }
 

--- a/packages/cli/src/lib/app/read-branch.ts
+++ b/packages/cli/src/lib/app/read-branch.ts
@@ -8,15 +8,18 @@ export interface ReadBranch {
   kind: BranchKind;
 }
 
+interface ProjectBranch extends ReadBranch {
+  isDefault: boolean;
+}
+
 /**
- * Resolves the branch an app management command should read from, without ever
- * creating one. Returns the branch whose `gitName` matches `branchName`, else
- * the project's default branch, else null when the project has no branches.
+ * Lists every branch in a project, following pagination. Management commands
+ * read branch context against this list so they never create a branch.
  */
-export async function resolveReadBranch(
+export async function listProjectBranches(
   client: ManagementApiClient,
-  options: { projectId: string; branchName: string; signal?: AbortSignal },
-): Promise<ReadBranch | null> {
+  options: { projectId: string; signal?: AbortSignal },
+): Promise<ProjectBranch[]> {
   const branches: Array<{
     id: string;
     gitName: string;
@@ -42,11 +45,62 @@ export async function resolveReadBranch(
       : undefined;
   } while (cursor);
 
+  return branches.map((branch) => ({
+    id: branch.id,
+    name: branch.gitName,
+    kind: branch.role,
+    isDefault: branch.isDefault,
+  }));
+}
+
+/**
+ * Resolves the branch an app management command should read from, without ever
+ * creating one. Returns the branch whose name matches `branchName`, else the
+ * project's default branch, else null when the project has no branches.
+ */
+export async function resolveReadBranch(
+  client: ManagementApiClient,
+  options: { projectId: string; branchName: string; signal?: AbortSignal },
+): Promise<ReadBranch | null> {
+  const branches = await listProjectBranches(client, {
+    projectId: options.projectId,
+    signal: options.signal,
+  });
   const chosen =
-    branches.find((branch) => branch.gitName === options.branchName) ??
+    branches.find((branch) => branch.name === options.branchName) ??
     branches.find((branch) => branch.isDefault) ??
     null;
   return chosen
-    ? { id: chosen.id, name: chosen.gitName, kind: chosen.role }
+    ? { id: chosen.id, name: chosen.name, kind: chosen.kind }
+    : null;
+}
+
+/**
+ * Resolves a project's production branch by role, not by name. The production
+ * branch is the durable default branch; resolving it from the API keeps
+ * production-only commands (custom domains) working when that branch is named
+ * something other than `production` or `main` (for example `master`).
+ *
+ * When `branchName` is given (an explicit `--branch`), that branch is matched
+ * first so the caller can validate its role; otherwise the production-role
+ * branch (falling back to the default branch) is returned.
+ */
+export async function resolveProductionBranch(
+  client: ManagementApiClient,
+  options: { projectId: string; branchName?: string; signal?: AbortSignal },
+): Promise<ReadBranch | null> {
+  const branches = await listProjectBranches(client, {
+    projectId: options.projectId,
+    signal: options.signal,
+  });
+  const chosen =
+    (options.branchName
+      ? branches.find((branch) => branch.name === options.branchName)
+      : undefined) ??
+    branches.find((branch) => branch.kind === "production") ??
+    branches.find((branch) => branch.isDefault) ??
+    null;
+  return chosen
+    ? { id: chosen.id, name: chosen.name, kind: chosen.kind }
     : null;
 }

--- a/packages/cli/src/lib/app/read-branch.ts
+++ b/packages/cli/src/lib/app/read-branch.ts
@@ -81,9 +81,10 @@ export async function resolveReadBranch(
  * production-only commands (custom domains) working when that branch is named
  * something other than `production` or `main` (for example `master`).
  *
- * When `branchName` is given (an explicit `--branch`), that branch is matched
- * first so the caller can validate its role; otherwise the production-role
- * branch (falling back to the default branch) is returned.
+ * When `branchName` is given (an explicit `--branch`), only that branch is
+ * returned so the caller can validate its role; a missing explicit branch
+ * returns null. Without `branchName`, the production-role branch (falling back
+ * to the default branch) is returned.
  */
 export async function resolveProductionBranch(
   client: ManagementApiClient,
@@ -93,10 +94,17 @@ export async function resolveProductionBranch(
     projectId: options.projectId,
     signal: options.signal,
   });
+
+  if (options.branchName !== undefined) {
+    const explicit = branches.find(
+      (branch) => branch.name === options.branchName,
+    );
+    return explicit
+      ? { id: explicit.id, name: explicit.name, kind: explicit.kind }
+      : null;
+  }
+
   const chosen =
-    (options.branchName
-      ? branches.find((branch) => branch.name === options.branchName)
-      : undefined) ??
     branches.find((branch) => branch.kind === "production") ??
     branches.find((branch) => branch.isDefault) ??
     null;

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -1445,6 +1445,63 @@ describe("app controller", () => {
     });
   });
 
+  it("domain add rejects explicit missing branches without falling back to production", async () => {
+    const requireComputeAuth = vi
+      .fn()
+      .mockResolvedValue(
+        createProjectClient("proj_123", { defaultBranchName: "master" }),
+      );
+    const listApps = vi.fn();
+    const addDomain = vi.fn();
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/app-provider", async (importOriginal) => {
+      const actual =
+        await importOriginal<typeof import("../src/lib/app/app-provider")>();
+      return {
+        ...actual,
+        createAppProvider: vi.fn(() =>
+          withBranchDatabaseProviderDefaults({
+            resolveBranch: createResolveBranch(),
+            listApps,
+            addDomain,
+          }),
+        ),
+      };
+    });
+
+    const { createTempCwd, createTestCommandContext } = await import(
+      "./helpers"
+    );
+    const { runAppDomainAdd } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await expect(
+      runAppDomainAdd(context, "shop.acme.com", {
+        projectRef: "proj_123",
+        appName: "shop",
+        branchName: "feat/missing",
+      }),
+    ).rejects.toMatchObject({
+      code: "BRANCH_NOT_FOUND",
+      domain: "branch",
+      exitCode: 1,
+    });
+    expect(listApps).not.toHaveBeenCalled();
+    expect(addDomain).not.toHaveBeenCalled();
+  });
+
   it("domain retry maps API 409 to DOMAIN_RETRY_NOT_ELIGIBLE", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
     const listApps = vi.fn().mockResolvedValue([

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -73,7 +73,7 @@ function expectedAppVerboseContext() {
     branch: {
       id: "branch_main",
       name: "main",
-      kind: "preview",
+      kind: "production",
     },
     resolution: {
       projectSource: "local-pin",
@@ -791,7 +791,7 @@ describe("app controller", () => {
         name: "Acme Dashboard",
       },
       branch: {
-        name: "production",
+        name: "main",
         kind: "production",
       },
       app: {
@@ -1336,6 +1336,15 @@ describe("app controller", () => {
   });
 
   it("domain add rejects preview branches", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue(
+      createProjectClient("proj_123", {
+        extraBranches: [{ name: "feat/login", role: "preview" }],
+      }),
+    );
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+
     const { createTempCwd, createTestCommandContext } = await import(
       "./helpers"
     );
@@ -1351,6 +1360,8 @@ describe("app controller", () => {
       },
     });
 
+    // The project's production branch is `main`; `feat/login` is a real preview
+    // branch, so resolving it by role rejects the domain on its actual role.
     await expect(
       runAppDomainAdd(context, "shop.acme.com", {
         projectRef: "proj_123",
@@ -1361,6 +1372,76 @@ describe("app controller", () => {
       code: "BRANCH_NOT_DEPLOYABLE",
       domain: "branch",
       exitCode: 2,
+    });
+  });
+
+  it("resolves the production branch by role when it is named master", async () => {
+    const requireComputeAuth = vi
+      .fn()
+      .mockResolvedValue(
+        createProjectClient("proj_123", { defaultBranchName: "master" }),
+      );
+    const activeDomain = createDomain({ status: "active" });
+    const listApps = vi.fn().mockResolvedValue([
+      {
+        id: "app_1",
+        name: "shop",
+        region: "eu-central-1",
+        liveDeploymentId: "dep_live",
+        liveUrl: "https://shop.prisma.app",
+      },
+    ]);
+    const addDomain = vi
+      .fn()
+      .mockResolvedValue({ domain: activeDomain, existing: true });
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/app-provider", async (importOriginal) => {
+      const actual =
+        await importOriginal<typeof import("../src/lib/app/app-provider")>();
+      return {
+        ...actual,
+        createAppProvider: vi.fn(() =>
+          withBranchDatabaseProviderDefaults({
+            resolveBranch: createResolveBranch(),
+            listApps,
+            listDomains: vi.fn(),
+            addDomain,
+            retryDomain: vi.fn(),
+          }),
+        ),
+      };
+    });
+
+    const { createTempCwd, createTestCommandContext } = await import(
+      "./helpers"
+    );
+    const { runAppDomainAdd } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    // No --branch: the production branch is resolved by role, so the domain is
+    // added on `master` instead of failing because no branch is named
+    // "production".
+    const result = await runAppDomainAdd(context, "shop.acme.com", {
+      projectRef: "proj_123",
+      appName: "shop",
+    });
+
+    expect(addDomain).toHaveBeenCalled();
+    expect(result.result).toMatchObject({
+      branch: { name: "master", kind: "production" },
+      domain: { hostname: "shop.acme.com" },
     });
   });
 

--- a/packages/cli/tests/helpers/mock-factories.ts
+++ b/packages/cli/tests/helpers/mock-factories.ts
@@ -5,14 +5,31 @@ export function createProjectClient(
   options: {
     branchExists?: boolean;
     isDefault?: boolean;
+    defaultBranchName?: string;
+    extraBranches?: Array<{
+      name: string;
+      role?: "preview" | "production";
+      isDefault?: boolean;
+    }>;
   } = {},
 ) {
-  const branchRecord = (branchName: string) => ({
-    id: `branch_${branchName.replace(/[^a-z0-9]+/gi, "_")}`,
-    gitName: branchName,
-    isDefault: options.isDefault ?? branchName === "main",
-    role: "preview",
-  });
+  const defaultBranchName = options.defaultBranchName ?? "main";
+  const branchRecord = (branchName: string) => {
+    const isDefault = options.isDefault ?? branchName === defaultBranchName;
+    return {
+      id: `branch_${branchName.replace(/[^a-z0-9]+/gi, "_")}`,
+      gitName: branchName,
+      isDefault,
+      // The default (durable) branch is the production branch.
+      role: isDefault ? "production" : "preview",
+    };
+  };
+  const extraBranchRecords = (options.extraBranches ?? []).map((branch) => ({
+    id: `branch_${branch.name.replace(/[^a-z0-9]+/gi, "_")}`,
+    gitName: branch.name,
+    isDefault: branch.isDefault ?? false,
+    role: branch.role ?? "preview",
+  }));
 
   return {
     token: "token",
@@ -48,13 +65,14 @@ export function createProjectClient(
           }
 
           if (pathName === "/v1/projects/{projectId}/branches") {
-            const branchName = request?.params?.query?.gitName ?? "main";
+            const branchName =
+              request?.params?.query?.gitName ?? defaultBranchName;
             return {
               data: {
                 data:
                   options.branchExists === false
                     ? []
-                    : [branchRecord(branchName)],
+                    : [branchRecord(branchName), ...extraBranchRecords],
                 pagination: { hasMore: false, nextCursor: null },
               },
             };

--- a/packages/cli/tests/read-branch.test.ts
+++ b/packages/cli/tests/read-branch.test.ts
@@ -1,7 +1,10 @@
 import type { ManagementApiClient } from "@prisma/management-api-sdk";
 import { describe, expect, it, vi } from "vitest";
 
-import { resolveReadBranch } from "../src/lib/app/read-branch";
+import {
+  resolveProductionBranch,
+  resolveReadBranch,
+} from "../src/lib/app/read-branch";
 
 type RawBranch = {
   id: string;
@@ -146,5 +149,87 @@ describe("resolveReadBranch", () => {
         },
       }),
     );
+  });
+});
+
+describe("resolveProductionBranch", () => {
+  it("returns the production-role branch even when it is not named production", async () => {
+    const client = clientReturning([
+      {
+        id: "b_master",
+        gitName: "master",
+        isDefault: true,
+        role: "production",
+      },
+      { id: "b_feat", gitName: "feat/x", isDefault: false, role: "preview" },
+    ]);
+
+    const result = await resolveProductionBranch(client, {
+      projectId: "proj_1",
+    });
+
+    expect(result).toEqual({
+      id: "b_master",
+      name: "master",
+      kind: "production",
+    });
+  });
+
+  it("returns an explicit branch by name so callers can validate its role", async () => {
+    const client = clientReturning([
+      {
+        id: "b_main",
+        gitName: "main",
+        isDefault: true,
+        role: "production",
+      },
+      { id: "b_feat", gitName: "feat/x", isDefault: false, role: "preview" },
+    ]);
+
+    const result = await resolveProductionBranch(client, {
+      projectId: "proj_1",
+      branchName: "feat/x",
+    });
+
+    expect(result).toEqual({ id: "b_feat", name: "feat/x", kind: "preview" });
+  });
+
+  it("returns null when an explicit branch does not exist", async () => {
+    const client = clientReturning([
+      {
+        id: "b_master",
+        gitName: "master",
+        isDefault: true,
+        role: "production",
+      },
+    ]);
+
+    const result = await resolveProductionBranch(client, {
+      projectId: "proj_1",
+      branchName: "feat/missing",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("falls back to the default branch when no production-role branch exists", async () => {
+    const client = clientReturning([
+      {
+        id: "b_master",
+        gitName: "master",
+        isDefault: true,
+        role: "preview",
+      },
+    ]);
+
+    const result = await resolveProductionBranch(client, {
+      projectId: "proj_1",
+    });
+
+    expect(result).toEqual({
+      id: "b_master",
+      name: "master",
+      kind: "preview",
+    });
   });
 });

--- a/packages/cli/tests/read-branch.test.ts
+++ b/packages/cli/tests/read-branch.test.ts
@@ -175,6 +175,30 @@ describe("resolveProductionBranch", () => {
     });
   });
 
+  it("resolves the production branch by role even when a different branch is the default", async () => {
+    // The platform model marks `isDefault` independently from `role`, so the
+    // default branch is not necessarily the production branch. Resolve by role.
+    const client = clientReturning([
+      { id: "b_dev", gitName: "dev", isDefault: true, role: "preview" },
+      {
+        id: "b_release",
+        gitName: "release",
+        isDefault: false,
+        role: "production",
+      },
+    ]);
+
+    const result = await resolveProductionBranch(client, {
+      projectId: "proj_1",
+    });
+
+    expect(result).toEqual({
+      id: "b_release",
+      name: "release",
+      kind: "production",
+    });
+  });
+
   it("returns an explicit branch by name so callers can validate its role", async () => {
     const client = clientReturning([
       {


### PR DESCRIPTION
## Problem

Custom-domain commands (`app domain add/show/remove/retry/wait`) attach to the **production branch**, but they identified it by the **literal name** `production`:

- `toBranchKind(name)` only returns `"production"` for a branch named `production` or `main`.
- The flow defaulted the branch to the literal string `"production"` and queried by that name.

So a project whose production branch is named anything else — e.g. **`master`** (a git-push deploy on `master`) — could never attach a custom domain. `domain add` looked for a branch named `production`, found none, and failed with a confusing *"no app on the production branch."* This is the same name-vs-role flaw as #91, on the domain path.

## Fix

Resolve the production branch from the project's branches **by role** (the durable default branch) and use its real name. The production-only gate now checks the **resolved branch's role**, not a guess from its name.

- **`read-branch.ts`** — extract `listProjectBranches`; add `resolveProductionBranch` (matches an explicit `--branch` by name so its role can be validated, else returns the production-role / default branch).
- **`resolveProjectContext`** — a `productionBranch` mode resolves the branch by role.
- **`resolveAppDomainTarget`** — drop the early name-based gate; gate on the **resolved** branch's role after resolution. Use the resolved branch's real name for the app lookup.

So `domain add` on a `master`-default project now finds `master` (role production) and attaches the domain there. An explicit `--branch <preview>` is still rejected — now by its **actual** role, not its name.

## Testing

- The branch mock now marks the default (durable) branch as `production` role (it was unrealistically `preview`).
- New: domain resolves a **`master`-named** production branch by role and attaches the domain.
- New: domain rejects a **real preview** branch by its role.
- Full suite **485 passing**, `tsc --noEmit` clean, biome clean.