### PR TITLE
feat(auth): support workspace session switching

### DIFF
--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -68,11 +68,11 @@ The CLI accepts two authentication sources, in this fixed precedence:
 1. `PRISMA_SERVICE_TOKEN` environment variable — long-lived service token, intended for CI and other headless contexts.
 2. Stored OAuth session — created by `prisma-cli auth login`, kept in the OS-appropriate credentials store, refreshed automatically.
 
-Stored OAuth sessions include a short-lived access token and a refresh token. Commands refresh the access token automatically when the API rejects it, coordinate refreshes across concurrent CLI processes, and tolerate short refresh-token rotation races. If the stored session cannot be refreshed, commands fail with a structured `AUTH_REQUIRED` error instead of surfacing SDK stack traces.
+Stored OAuth sessions include a short-lived access token and a refresh token. The local credentials store may contain OAuth grants for multiple workspaces. One local active workspace pointer selects which grant authenticated commands use. Commands refresh the selected access token automatically when the API rejects it, coordinate refreshes across concurrent CLI processes, and tolerate short refresh-token rotation races. If the selected session cannot be refreshed, commands fail with a structured `AUTH_REQUIRED` error instead of surfacing SDK stack traces or silently falling through to another workspace.
 
 When `PRISMA_SERVICE_TOKEN` is set and non-empty, the token is fully sufficient for authenticated commands. If `PRISMA_SERVICE_TOKEN` is set but empty or only whitespace, commands fail with an auth configuration error instead of falling back to stored OAuth. The CLI does not read any locally stored OAuth session when a non-empty service token is present, so behavior is identical on a fresh runner and a developer machine that happens to be signed in. The active workspace is derived from the token's `sub` claim; no additional flag or environment variable is required for the common case where the token is scoped to a single workspace.
 
-`auth login` and `auth logout` operate on the stored OAuth session. They do not affect the `PRISMA_SERVICE_TOKEN` environment variable.
+`auth login`, `auth logout`, and `auth workspace` operate on stored OAuth sessions. They do not affect the `PRISMA_SERVICE_TOKEN` environment variable. `auth login` stores the authorized workspace and makes it active. `auth logout` clears all local OAuth workspace sessions. `auth workspace logout` and `auth logout --workspace` clear one local OAuth workspace session. If that workspace was active, the CLI does not silently fall through to another cached workspace; the user must explicitly choose the next workspace with `auth workspace use`. `auth workspace use` changes only local CLI context and never mutates a remote resource. When `PRISMA_SERVICE_TOKEN` is set, workspace switching is unavailable because the token is the active auth source.
 
 ## Context Resolution
 
@@ -249,6 +249,58 @@ Rules:
 - `credential` identifies the active credential when known, or is `null`
 - signed-out state is an empty auth state, not an error
 
+`auth workspace list --json` returns local workspace sessions:
+
+```json
+{
+  "context": {
+    "authSource": "oauth",
+    "activeWorkspaceId": "wksp_123",
+    "activeWorkspaceName": "Acme Inc"
+  },
+  "items": [
+    {
+      "id": "wksp_123",
+      "name": "Acme Inc",
+      "status": "active",
+      "source": "oauth",
+      "switchable": true,
+      "credentialWorkspaceId": "cmmx...",
+      "lastSeenAt": "2026-06-19T00:00:00.000Z"
+    }
+  ],
+  "count": 1
+}
+```
+
+`auth workspace use --json` returns:
+
+```json
+{
+  "previousWorkspace": {
+    "id": "wksp_123",
+    "name": "Acme Inc"
+  },
+  "workspace": {
+    "id": "wksp_456",
+    "name": "Prisma Labs"
+  }
+}
+```
+
+`auth workspace logout --json` returns:
+
+```json
+{
+  "workspace": {
+    "id": "wksp_123",
+    "name": "Acme Inc"
+  },
+  "wasActive": true,
+  "activeWorkspace": null
+}
+```
+
 ## `prisma-cli version`
 
 Purpose:
@@ -346,18 +398,20 @@ prisma-cli auth login --json
 
 Purpose:
 
-- clear stored authentication credentials
+- clear all stored OAuth workspace credentials
 
 Behavior:
 
-- removes local session state
+- removes all local OAuth workspace sessions
+- with `--workspace <id-or-name>`, removes only the target local OAuth workspace session
 - succeeds even if no session exists
-- returns the signed-out auth state
+- returns the signed-out auth state unless `PRISMA_SERVICE_TOKEN` is still set
 
 Examples:
 
 ```bash
 prisma-cli auth logout
+prisma-cli auth logout --workspace wksp_123
 prisma-cli auth logout --json
 ```
 
@@ -377,6 +431,73 @@ Examples:
 ```bash
 prisma-cli auth whoami
 prisma-cli auth whoami --json
+```
+
+## `prisma-cli auth workspace list`
+
+Purpose:
+
+- list locally authenticated workspaces
+
+Behavior:
+
+- succeeds when signed out
+- lists local OAuth workspaces stored on this machine
+- marks the active local workspace when one is selected
+- when `PRISMA_SERVICE_TOKEN` is set, shows the token workspace when resolvable and also shows stored local OAuth workspaces as non-switchable until the variable is unset
+- does not claim to list every workspace the user can access unless each workspace has been authorized locally
+- does not mutate local or remote state
+
+Examples:
+
+```bash
+prisma-cli auth workspace list
+prisma-cli auth workspace list --json
+```
+
+## `prisma-cli auth workspace use <id-or-name>`
+
+Purpose:
+
+- switch the local CLI workspace
+
+Behavior:
+
+- requires a stored OAuth session for the target workspace
+- accepts the cached workspace id, credential workspace id, or exact cached workspace name
+- changes local CLI context only; it does not mutate a remote resource
+- fails with `WORKSPACE_SWITCH_UNAVAILABLE` when `PRISMA_SERVICE_TOKEN` is set
+- fails with `WORKSPACE_NOT_AUTHENTICATED` when no cached OAuth session matches
+- fails with `WORKSPACE_AMBIGUOUS` when an exact workspace name matches multiple cached workspaces
+
+Examples:
+
+```bash
+prisma-cli auth workspace use wksp_123
+prisma-cli auth workspace use "Acme Inc"
+```
+
+## `prisma-cli auth workspace logout <id-or-name>`
+
+Purpose:
+
+- remove one local OAuth workspace session
+
+Behavior:
+
+- requires a stored OAuth session for the target workspace
+- accepts the cached workspace id, credential workspace id, or exact cached workspace name
+- removes only the target workspace's local OAuth grant
+- if the removed workspace was active, leaves no active local OAuth workspace selected
+- does not mutate a remote resource and does not revoke remote access
+- fails with `WORKSPACE_NOT_AUTHENTICATED` when no cached OAuth session matches
+- fails with `WORKSPACE_AMBIGUOUS` when an exact workspace name matches multiple cached workspaces
+
+Examples:
+
+```bash
+prisma-cli auth workspace logout wksp_123
+prisma-cli auth workspace logout "Acme Inc"
 ```
 
 ## `prisma-cli project list`

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -464,7 +464,7 @@ Purpose:
 Behavior:
 
 - requires a stored OAuth session for the target workspace
-- accepts the cached workspace id, credential workspace id, or exact cached workspace name
+- accepts the cached workspace id, credential workspace id, or cached workspace name case-insensitively
 - changes local CLI context only; it does not mutate a remote resource
 - fails with `WORKSPACE_SWITCH_UNAVAILABLE` when `PRISMA_SERVICE_TOKEN` is set
 - fails with `WORKSPACE_NOT_AUTHENTICATED` when no cached OAuth session matches
@@ -486,7 +486,7 @@ Purpose:
 Behavior:
 
 - requires a stored OAuth session for the target workspace
-- accepts the cached workspace id, credential workspace id, or exact cached workspace name
+- accepts the cached workspace id, credential workspace id, or cached workspace name case-insensitively
 - removes only the target workspace's local OAuth grant
 - works while `PRISMA_SERVICE_TOKEN` is set; the service token remains the active auth source
 - if the removed workspace was active, leaves no active local OAuth workspace selected

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -443,6 +443,7 @@ Behavior:
 
 - succeeds when signed out
 - lists local OAuth workspaces stored on this machine
+- human output includes a table with workspace name and workspace id
 - marks the active local workspace when one is selected
 - when `PRISMA_SERVICE_TOKEN` is set, shows the token workspace when resolvable and also shows stored local OAuth workspaces as non-switchable until the variable is unset
 - does not claim to list every workspace the user can access unless each workspace has been authorized locally
@@ -468,13 +469,34 @@ Behavior:
 - changes local CLI context only; it does not mutate a remote resource
 - fails with `WORKSPACE_SWITCH_UNAVAILABLE` when `PRISMA_SERVICE_TOKEN` is set
 - fails with `WORKSPACE_NOT_AUTHENTICATED` when no cached OAuth session matches
-- fails with `WORKSPACE_AMBIGUOUS` when an exact workspace name matches multiple cached workspaces
+- fails with `WORKSPACE_AMBIGUOUS` when a workspace name matches multiple cached workspaces
 
 Examples:
 
 ```bash
 prisma-cli auth workspace use wksp_123
 prisma-cli auth workspace use "Acme Inc"
+```
+
+## `prisma-cli auth workspace select`
+
+Purpose:
+
+- interactively switch the local CLI workspace
+
+Behavior:
+
+- lists locally authenticated OAuth workspaces in an interactive picker
+- shows the workspace name and workspace id for each choice
+- changes local CLI context only; it does not mutate a remote resource
+- fails with `WORKSPACE_SWITCH_UNAVAILABLE` when `PRISMA_SERVICE_TOKEN` is set
+- when exactly one local OAuth workspace is available, selects it without prompting
+- fails in non-interactive mode when more than one local OAuth workspace is available
+
+Examples:
+
+```bash
+prisma-cli auth workspace select
 ```
 
 ## `prisma-cli auth workspace logout <id-or-name>`
@@ -492,7 +514,7 @@ Behavior:
 - if the removed workspace was active, leaves no active local OAuth workspace selected
 - does not mutate a remote resource and does not revoke remote access
 - fails with `WORKSPACE_NOT_AUTHENTICATED` when no cached OAuth session matches
-- fails with `WORKSPACE_AMBIGUOUS` when an exact workspace name matches multiple cached workspaces
+- fails with `WORKSPACE_AMBIGUOUS` when a workspace name matches multiple cached workspaces
 
 Examples:
 

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -72,7 +72,7 @@ Stored OAuth sessions include a short-lived access token and a refresh token. Th
 
 When `PRISMA_SERVICE_TOKEN` is set and non-empty, the token is fully sufficient for authenticated commands. If `PRISMA_SERVICE_TOKEN` is set but empty or only whitespace, commands fail with an auth configuration error instead of falling back to stored OAuth. The CLI does not read any locally stored OAuth session when a non-empty service token is present, so behavior is identical on a fresh runner and a developer machine that happens to be signed in. The active workspace is derived from the token's `sub` claim; no additional flag or environment variable is required for the common case where the token is scoped to a single workspace.
 
-`auth login`, `auth logout`, and `auth workspace` operate on stored OAuth sessions. They do not affect the `PRISMA_SERVICE_TOKEN` environment variable. `auth login` stores the authorized workspace and makes it active. `auth logout` clears all local OAuth workspace sessions. `auth workspace logout` and `auth logout --workspace` clear one local OAuth workspace session. If that workspace was active, the CLI does not silently fall through to another cached workspace; the user must explicitly choose the next workspace with `auth workspace use`. `auth workspace use` changes only local CLI context and never mutates a remote resource. When `PRISMA_SERVICE_TOKEN` is set, workspace switching is unavailable because the token is the active auth source.
+`auth login`, `auth logout`, and `auth workspace` operate on stored OAuth sessions. They do not affect the `PRISMA_SERVICE_TOKEN` environment variable. `auth login` stores the authorized workspace and makes it active. `auth logout` clears all local OAuth workspace sessions. `auth workspace logout` and `auth logout --workspace` clear one local OAuth workspace session, including while `PRISMA_SERVICE_TOKEN` is set, because they only clean local OAuth state. If that workspace was active, the CLI does not silently fall through to another cached workspace; the user must explicitly choose the next workspace with `auth workspace use`. `auth workspace use` changes only local CLI context and never mutates a remote resource. When `PRISMA_SERVICE_TOKEN` is set, workspace switching is unavailable because the token is the active auth source.
 
 ## Context Resolution
 
@@ -488,6 +488,7 @@ Behavior:
 - requires a stored OAuth session for the target workspace
 - accepts the cached workspace id, credential workspace id, or exact cached workspace name
 - removes only the target workspace's local OAuth grant
+- works while `PRISMA_SERVICE_TOKEN` is set; the service token remains the active auth source
 - if the removed workspace was active, leaves no active local OAuth workspace selected
 - does not mutate a remote resource and does not revoke remote access
 - fails with `WORKSPACE_NOT_AUTHENTICATED` when no cached OAuth session matches

--- a/docs/product/error-conventions.md
+++ b/docs/product/error-conventions.md
@@ -160,6 +160,10 @@ These codes are the minimum stable set for the MVP:
 
 - `USAGE_ERROR`
 - `AUTH_REQUIRED`
+- `AUTH_CONFIG_INVALID`
+- `WORKSPACE_SWITCH_UNAVAILABLE`
+- `WORKSPACE_NOT_AUTHENTICATED`
+- `WORKSPACE_AMBIGUOUS`
 - `PROJECT_SETUP_REQUIRED`
 - `PROJECT_LINK_TARGET_REQUIRED`
 - `PROJECT_CREATE_FAILED`
@@ -217,13 +221,17 @@ Recommended meanings:
 
 - `USAGE_ERROR`: invalid arguments or invalid command combination
 - `AUTH_REQUIRED`: command needs an authenticated session
+- `AUTH_CONFIG_INVALID`: environment auth configuration is present but unusable, such as an empty `PRISMA_SERVICE_TOKEN`
+- `WORKSPACE_SWITCH_UNAVAILABLE`: `PRISMA_SERVICE_TOKEN` is the active auth source, so local OAuth workspace switching cannot apply
+- `WORKSPACE_NOT_AUTHENTICATED`: requested workspace is not present in the local OAuth credentials store for a switch/logout operation; callers should run `auth login` for that workspace
+- `WORKSPACE_AMBIGUOUS`: requested workspace name matches more than one local OAuth workspace; callers should switch by workspace id
 - `PROJECT_SETUP_REQUIRED`: command needs explicit or durable Project context before it can continue
 - `PROJECT_LINK_TARGET_REQUIRED`: `project link` needs the user to choose an existing Project or create a new one
 - `PROJECT_CREATE_FAILED`: Project creation failed before deployment or linking could continue
 - `PROJECT_NOT_FOUND`: requested project does not exist or is not accessible
 - `PROJECT_AMBIGUOUS`: multiple safe project candidates matched
 - `APP_AMBIGUOUS`: multiple apps matched the inferred or explicit app target
-- `LOCAL_PROJECT_WORKSPACE_MISMATCH`: local Project pin points at a different workspace than the active authenticated workspace; callers should sign in to the linked workspace or relink the directory
+- `LOCAL_PROJECT_WORKSPACE_MISMATCH`: local Project pin points at a different workspace than the active authenticated workspace; callers should switch to the linked workspace or relink the directory
 - `LOCAL_STATE_WRITE_FAILED`: the CLI could not save local Project binding state such as `.prisma/local.json` or the matching `.gitignore` entry; callers should fix directory permissions or filesystem state before retrying
 - `LOCAL_STATE_STALE`: local Project pin no longer matches platform data and continuing would be ambiguous
 - `BRANCH_NOT_DEPLOYABLE`: command tried to deploy to a non-deployable branch context

--- a/docs/product/output-conventions.md
+++ b/docs/product/output-conventions.md
@@ -99,6 +99,9 @@ Current MVP commands map to patterns like this:
 | `auth login` | `mutate` |
 | `auth logout` | `mutate` |
 | `auth whoami` | `show` |
+| `auth workspace list` | `list` |
+| `auth workspace use` | `mutate` |
+| `auth workspace logout` | `mutate` |
 | `project list` | `list` |
 | `project show` | `show` |
 | `git connect` | `mutate` |

--- a/packages/cli/src/adapters/token-storage.ts
+++ b/packages/cli/src/adapters/token-storage.ts
@@ -45,7 +45,14 @@ interface AuthContextReadResult {
 export interface FileTokenStorageOptions {
   activateOnSetTokens?: boolean;
   lockSetTokens?: boolean;
+  lockRetryMs?: number;
+  lockStaleMs?: number;
+  lockWaitTimeoutMs?: number;
 }
+
+const REFRESH_LOCK_RETRY_MS = 100;
+const REFRESH_LOCK_STALE_MS = 30_000;
+const REFRESH_LOCK_WAIT_TIMEOUT_MS = 25_000;
 
 const EMPTY_AUTH_CONTEXT: AuthContextState = {
   activeWorkspaceId: null,
@@ -194,6 +201,9 @@ export class FileTokenStorage implements TokenStorage {
   }
 
   async setTokens(tokens: Tokens): Promise<void> {
+    // The management-api-sdk calls setTokens from inside withRefreshLock during
+    // refresh. That path must pass lockSetTokens:false, otherwise setTokens
+    // would wait on the lock it already owns and eventually time out.
     if (this.options.lockSetTokens === false) {
       await this.setTokensUnlocked(tokens);
       return;
@@ -222,6 +232,8 @@ export class FileTokenStorage implements TokenStorage {
     this.signal?.throwIfAborted();
     // Logout clears every OAuth grant in the local auth file. SDK refresh
     // failures use clearTokensIfCurrent below, which stays workspace-scoped.
+    // CredentialsStore exposes workspace-scoped deletion only, so full logout
+    // writes the store's empty on-disk shape directly.
     await fs.mkdir(path.dirname(this.authFilePath), { recursive: true });
     this.signal?.throwIfAborted();
     await fs.writeFile(
@@ -419,41 +431,65 @@ export class FileTokenStorage implements TokenStorage {
 
   private async acquireRefreshLock(): Promise<string> {
     const lockId = randomUUID();
+    const startedAt = Date.now();
+    const retryMs = this.options.lockRetryMs ?? REFRESH_LOCK_RETRY_MS;
+    const waitTimeoutMs =
+      this.options.lockWaitTimeoutMs ?? REFRESH_LOCK_WAIT_TIMEOUT_MS;
     this.signal?.throwIfAborted();
     // mkdir does not accept AbortSignal; check before the filesystem boundary.
     await fs.mkdir(path.dirname(this.lockFilePath), { recursive: true });
 
     while (true) {
       this.signal?.throwIfAborted();
-      let lockFileCreated = false;
-      try {
-        // open does not accept AbortSignal; check before the filesystem boundary.
-        const handle = await fs.open(this.lockFilePath, "wx");
-        lockFileCreated = true;
-        try {
-          this.signal?.throwIfAborted();
-          await handle.writeFile(lockId, { encoding: "utf8" });
-          this.signal?.throwIfAborted();
-        } finally {
-          await handle.close();
-        }
+      if (await this.tryCreateRefreshLock(lockId)) {
         return lockId;
-      } catch (error) {
-        if (lockFileCreated) {
-          await fs.unlink(this.lockFilePath).catch(() => undefined);
-        }
-        const code = (error as NodeJS.ErrnoException).code;
-        if (code !== "EEXIST") throw error;
-
-        const staleLockId = await this.getStaleRefreshLockId();
-        if (staleLockId) {
-          await this.releaseRefreshLock(staleLockId);
-          continue;
-        }
-
-        await sleep(100, this.signal);
       }
+
+      if (await this.releaseStaleRefreshLock()) continue;
+
+      this.throwIfRefreshLockWaitTimedOut(startedAt, waitTimeoutMs);
+      await sleep(retryMs, this.signal);
     }
+  }
+
+  private async tryCreateRefreshLock(lockId: string): Promise<boolean> {
+    let lockFileCreated = false;
+    try {
+      // open does not accept AbortSignal; check before the filesystem boundary.
+      const handle = await fs.open(this.lockFilePath, "wx");
+      lockFileCreated = true;
+      try {
+        this.signal?.throwIfAborted();
+        await handle.writeFile(lockId, { encoding: "utf8" });
+        this.signal?.throwIfAborted();
+      } finally {
+        await handle.close();
+      }
+      return true;
+    } catch (error) {
+      if (lockFileCreated) {
+        await fs.unlink(this.lockFilePath).catch(() => undefined);
+      }
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "EEXIST") return false;
+      throw error;
+    }
+  }
+
+  private async releaseStaleRefreshLock(): Promise<boolean> {
+    const staleLockId = await this.getStaleRefreshLockId();
+    if (!staleLockId) return false;
+
+    await this.releaseRefreshLock(staleLockId);
+    return true;
+  }
+
+  private throwIfRefreshLockWaitTimedOut(
+    startedAt: number,
+    waitTimeoutMs: number,
+  ): void {
+    if (Date.now() - startedAt < waitTimeoutMs) return;
+    throw new RefreshLockTimeoutError(this.lockFilePath, waitTimeoutMs);
   }
 
   private async getStaleRefreshLockId(): Promise<string | null> {
@@ -471,7 +507,8 @@ export class FileTokenStorage implements TokenStorage {
     const stats = await fs.stat(this.lockFilePath).catch(() => null);
     this.signal?.throwIfAborted();
     if (!stats) return null;
-    return Date.now() - stats.mtimeMs > 30_000 ? lockId : null;
+    const staleMs = this.options.lockStaleMs ?? REFRESH_LOCK_STALE_MS;
+    return Date.now() - stats.mtimeMs > staleMs ? lockId : null;
   }
 
   private async releaseRefreshLock(lockId: string): Promise<void> {
@@ -629,6 +666,15 @@ export class WorkspaceSelectionError extends Error {
   ) {
     super(reason);
     this.name = "WorkspaceSelectionError";
+  }
+}
+
+export class RefreshLockTimeoutError extends Error {
+  constructor(lockFilePath: string, waitTimeoutMs: number) {
+    super(
+      `Timed out waiting ${waitTimeoutMs}ms for auth refresh lock at ${lockFilePath}`,
+    );
+    this.name = "RefreshLockTimeoutError";
   }
 }
 

--- a/packages/cli/src/adapters/token-storage.ts
+++ b/packages/cli/src/adapters/token-storage.ts
@@ -233,6 +233,10 @@ export class FileTokenStorage implements TokenStorage {
   }
 
   async clearTokens(): Promise<void> {
+    await this.withRefreshLock(() => this.clearTokensUnlocked());
+  }
+
+  private async clearTokensUnlocked(): Promise<void> {
     this.signal?.throwIfAborted();
     // Logout clears every OAuth grant in the local auth file. SDK refresh
     // failures use clearTokensIfCurrent below, which stays workspace-scoped.

--- a/packages/cli/src/adapters/token-storage.ts
+++ b/packages/cli/src/adapters/token-storage.ts
@@ -12,6 +12,55 @@ interface StoredCredential {
   refreshToken?: unknown;
 }
 
+export interface StoredAuthWorkspace {
+  id: string;
+  name: string;
+  credentialWorkspaceId: string;
+  active: boolean;
+  lastSeenAt: string | null;
+}
+
+export interface StoredAuthWorkspaceLogout {
+  workspace: StoredAuthWorkspace;
+  wasActive: boolean;
+  activeWorkspace: StoredAuthWorkspace | null;
+}
+
+interface AuthContextWorkspace {
+  id?: unknown;
+  name?: unknown;
+  lastSeenAt?: unknown;
+}
+
+interface AuthContextState {
+  activeWorkspaceId: string | null;
+  workspaces: Record<string, AuthContextWorkspace>;
+}
+
+interface AuthContextReadResult {
+  exists: boolean;
+  state: AuthContextState;
+}
+
+export interface FileTokenStorageOptions {
+  activateOnSetTokens?: boolean;
+  lockSetTokens?: boolean;
+}
+
+const EMPTY_AUTH_CONTEXT: AuthContextState = {
+  activeWorkspaceId: null,
+  workspaces: {},
+};
+
+export function getAuthContextFilePath(authFilePath: string): string {
+  const extension = path.extname(authFilePath);
+  if (!extension) {
+    return `${authFilePath}.context.json`;
+  }
+
+  return `${authFilePath.slice(0, -extension.length)}.context${extension}`;
+}
+
 function findLatestValidTokens(
   allCredentials: StoredCredential[],
 ): Tokens | null {
@@ -39,6 +88,42 @@ function findLatestValidTokens(
   return null;
 }
 
+function storedCredentialToTokens(
+  credential: StoredCredential | undefined,
+): Tokens | null {
+  if (!credential) return null;
+
+  if (
+    typeof credential.workspaceId !== "string" ||
+    credential.workspaceId.length === 0 ||
+    typeof credential.token !== "string" ||
+    credential.token.length === 0 ||
+    typeof credential.refreshToken !== "string" ||
+    credential.refreshToken.length === 0
+  ) {
+    return null;
+  }
+
+  return {
+    workspaceId: credential.workspaceId,
+    accessToken: credential.token,
+    refreshToken: credential.refreshToken,
+  };
+}
+
+function findTokensForWorkspace(
+  allCredentials: StoredCredential[],
+  workspaceId: string,
+): Tokens | null {
+  return (
+    storedCredentialToTokens(
+      allCredentials.find(
+        (credential) => credential?.workspaceId === workspaceId,
+      ),
+    ) ?? null
+  );
+}
+
 function tokensEqual(a: Tokens | null, b: Tokens | null): boolean {
   return (
     a?.workspaceId === b?.workspaceId &&
@@ -64,13 +149,18 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
 
 export class FileTokenStorage implements TokenStorage {
   private readonly credentialsStore: CredentialsStore;
+  private readonly authFilePath: string;
+  private readonly contextFilePath: string;
   private readonly lockFilePath: string;
 
   constructor(
     env: NodeJS.ProcessEnv = process.env,
     private readonly signal?: AbortSignal,
+    private readonly options: FileTokenStorageOptions = {},
   ) {
     const authFilePath = getAuthFilePath(env);
+    this.authFilePath = authFilePath;
+    this.contextFilePath = getAuthContextFilePath(authFilePath);
     this.credentialsStore = new CredentialsStore(authFilePath);
     this.lockFilePath = `${authFilePath}.lock`;
   }
@@ -79,9 +169,24 @@ export class FileTokenStorage implements TokenStorage {
     this.signal?.throwIfAborted();
     try {
       // CredentialsStore does not accept AbortSignal; check immediately before and after the boundary.
-      const all = await this.credentialsStore.getCredentials();
-      this.signal?.throwIfAborted();
-      return findLatestValidTokens(all as StoredCredential[]);
+      const credentials = await this.readCredentialsFromDisk();
+      const context = await this.readAuthContext();
+
+      if (context.state.activeWorkspaceId) {
+        return findTokensForWorkspace(
+          credentials,
+          context.state.activeWorkspaceId,
+        );
+      }
+
+      const latest = findLatestValidTokens(credentials);
+      if (!latest) return null;
+
+      if (!context.exists) {
+        await this.setActiveWorkspaceId(latest.workspaceId);
+      }
+
+      return context.exists ? null : latest;
     } catch (_error) {
       if (this.signal?.aborted) throw this.signal.reason;
       return null;
@@ -89,6 +194,15 @@ export class FileTokenStorage implements TokenStorage {
   }
 
   async setTokens(tokens: Tokens): Promise<void> {
+    if (this.options.lockSetTokens === false) {
+      await this.setTokensUnlocked(tokens);
+      return;
+    }
+
+    await this.withRefreshLock(() => this.setTokensUnlocked(tokens));
+  }
+
+  private async setTokensUnlocked(tokens: Tokens): Promise<void> {
     this.signal?.throwIfAborted();
     // CredentialsStore does not accept AbortSignal; check immediately before and after the boundary.
     await this.credentialsStore.storeCredentials({
@@ -97,16 +211,26 @@ export class FileTokenStorage implements TokenStorage {
       refreshToken: tokens.refreshToken,
     });
     this.signal?.throwIfAborted();
+    await this.rememberWorkspaceUnlocked(tokens.workspaceId, {
+      id: tokens.workspaceId,
+      name: tokens.workspaceId,
+    });
+    await this.maybeActivateWorkspaceId(tokens.workspaceId);
   }
 
   async clearTokens(): Promise<void> {
     this.signal?.throwIfAborted();
-    const all = await this.credentialsStore.getCredentials();
+    // Logout clears every OAuth grant in the local auth file. SDK refresh
+    // failures use clearTokensIfCurrent below, which stays workspace-scoped.
+    await fs.mkdir(path.dirname(this.authFilePath), { recursive: true });
     this.signal?.throwIfAborted();
-    const tokens = findLatestValidTokens(all as StoredCredential[]);
-    if (!tokens) return;
-    // CredentialsStore does not accept AbortSignal; check immediately before and after the boundary.
-    await this.credentialsStore.deleteCredentials(tokens.workspaceId);
+    await fs.writeFile(
+      this.authFilePath,
+      `${JSON.stringify({ tokens: [] }, null, 2)}\n`,
+      { encoding: "utf8", signal: this.signal },
+    );
+    await this.clearAuthContext();
+    await this.credentialsStore.reloadCredentialsFromDisk();
     this.signal?.throwIfAborted();
   }
 
@@ -114,7 +238,174 @@ export class FileTokenStorage implements TokenStorage {
     this.signal?.throwIfAborted();
     const current = await this.getTokens();
     if (!tokensEqual(current, tokens)) return;
-    await this.clearTokens();
+    await this.credentialsStore.deleteCredentials(tokens.workspaceId);
+    await this.removeRememberedWorkspace(tokens.workspaceId, {
+      preserveActivePointer: true,
+    });
+    this.signal?.throwIfAborted();
+  }
+
+  async listWorkspaces(): Promise<StoredAuthWorkspace[]> {
+    this.signal?.throwIfAborted();
+    const credentials = await this.readCredentialsFromDisk();
+    const context = await this.ensureMigratedAuthContext(credentials);
+
+    return credentials
+      .map((credential) => storedCredentialToTokens(credential))
+      .filter((tokens): tokens is Tokens => tokens !== null)
+      .map((tokens) => {
+        const cached = context.state.workspaces[tokens.workspaceId];
+        const id =
+          typeof cached?.id === "string" && cached.id.trim().length > 0
+            ? cached.id.trim()
+            : tokens.workspaceId;
+        const name =
+          typeof cached?.name === "string" && cached.name.trim().length > 0
+            ? cached.name.trim()
+            : id;
+        const lastSeenAt =
+          typeof cached?.lastSeenAt === "string" &&
+          cached.lastSeenAt.trim().length > 0
+            ? cached.lastSeenAt.trim()
+            : null;
+
+        return {
+          id,
+          name,
+          credentialWorkspaceId: tokens.workspaceId,
+          active: context.state.activeWorkspaceId === tokens.workspaceId,
+          lastSeenAt,
+        };
+      });
+  }
+
+  async useWorkspace(workspaceRef: string): Promise<{
+    previous: StoredAuthWorkspace | null;
+    selected: StoredAuthWorkspace;
+  }> {
+    return this.withRefreshLock(() => this.useWorkspaceUnlocked(workspaceRef));
+  }
+
+  private async useWorkspaceUnlocked(workspaceRef: string): Promise<{
+    previous: StoredAuthWorkspace | null;
+    selected: StoredAuthWorkspace;
+  }> {
+    const ref = workspaceRef.trim();
+    if (!ref) {
+      throw new WorkspaceSelectionError("missing");
+    }
+
+    const workspaces = await this.listWorkspaces();
+    const context = await this.readAuthContext();
+    const previous =
+      workspaces.find(
+        (workspace) =>
+          workspace.credentialWorkspaceId === context.state.activeWorkspaceId,
+      ) ?? null;
+    const matches = workspaces.filter((workspace) =>
+      workspaceMatchesRef(workspace, ref),
+    );
+
+    if (matches.length === 0) {
+      throw new WorkspaceSelectionError("not-found", ref);
+    }
+
+    if (matches.length > 1) {
+      throw new WorkspaceSelectionError("ambiguous", ref, matches);
+    }
+
+    const selected = matches[0];
+    await this.setActiveWorkspaceId(selected.credentialWorkspaceId);
+    return { previous, selected };
+  }
+
+  async logoutWorkspace(
+    workspaceRef: string,
+  ): Promise<StoredAuthWorkspaceLogout> {
+    return this.withRefreshLock(() =>
+      this.logoutWorkspaceUnlocked(workspaceRef),
+    );
+  }
+
+  private async logoutWorkspaceUnlocked(
+    workspaceRef: string,
+  ): Promise<StoredAuthWorkspaceLogout> {
+    const ref = workspaceRef.trim();
+    if (!ref) {
+      throw new WorkspaceSelectionError("missing");
+    }
+
+    const workspaces = await this.listWorkspaces();
+    const context = await this.readAuthContext();
+    const matches = workspaces.filter((workspace) =>
+      workspaceMatchesRef(workspace, ref),
+    );
+
+    if (matches.length === 0) {
+      throw new WorkspaceSelectionError("not-found", ref);
+    }
+
+    if (matches.length > 1) {
+      throw new WorkspaceSelectionError("ambiguous", ref, matches);
+    }
+
+    const workspace = matches[0];
+    const wasActive =
+      context.state.activeWorkspaceId === workspace.credentialWorkspaceId;
+
+    await this.credentialsStore.deleteCredentials(
+      workspace.credentialWorkspaceId,
+    );
+    this.signal?.throwIfAborted();
+
+    const remainingWorkspaces = workspaces.filter(
+      (candidate) =>
+        candidate.credentialWorkspaceId !== workspace.credentialWorkspaceId,
+    );
+
+    if (remainingWorkspaces.length === 0) {
+      await this.clearAuthContext();
+      return { workspace, wasActive, activeWorkspace: null };
+    }
+
+    delete context.state.workspaces[workspace.credentialWorkspaceId];
+    if (wasActive) {
+      context.state.activeWorkspaceId = null;
+    }
+    await this.writeAuthContext(context.state);
+
+    const activeWorkspace =
+      context.state.activeWorkspaceId === null
+        ? null
+        : (remainingWorkspaces.find(
+            (candidate) =>
+              candidate.credentialWorkspaceId ===
+              context.state.activeWorkspaceId,
+          ) ?? null);
+
+    return { workspace, wasActive, activeWorkspace };
+  }
+
+  async rememberWorkspace(
+    credentialWorkspaceId: string,
+    workspace: { id: string; name: string },
+  ): Promise<void> {
+    await this.withRefreshLock(() =>
+      this.rememberWorkspaceUnlocked(credentialWorkspaceId, workspace),
+    );
+  }
+
+  private async rememberWorkspaceUnlocked(
+    credentialWorkspaceId: string,
+    workspace: { id: string; name: string },
+  ): Promise<void> {
+    const context = await this.readAuthContext();
+    context.state.workspaces[credentialWorkspaceId] = {
+      id: workspace.id,
+      name: workspace.name,
+      lastSeenAt: new Date().toISOString(),
+    };
+    await this.writeAuthContext(context.state);
   }
 
   async withRefreshLock<T>(fn: () => Promise<T>): Promise<T> {
@@ -191,4 +482,170 @@ export class FileTokenStorage implements TokenStorage {
     // unlink does not accept AbortSignal; refresh-lock cleanup must run even after cancellation.
     await fs.unlink(this.lockFilePath).catch(() => {});
   }
+
+  private async readCredentialsFromDisk(): Promise<StoredCredential[]> {
+    this.signal?.throwIfAborted();
+    await this.credentialsStore.reloadCredentialsFromDisk();
+    this.signal?.throwIfAborted();
+    return (await this.credentialsStore.getCredentials()) as StoredCredential[];
+  }
+
+  private async ensureMigratedAuthContext(
+    credentials: StoredCredential[],
+  ): Promise<AuthContextReadResult> {
+    const context = await this.readAuthContext();
+    if (context.state.activeWorkspaceId || context.exists) {
+      return context;
+    }
+
+    const latest = findLatestValidTokens(credentials);
+    if (!latest) {
+      return context;
+    }
+
+    context.state.activeWorkspaceId = latest.workspaceId;
+    context.state.workspaces[latest.workspaceId] ??= {
+      id: latest.workspaceId,
+      name: latest.workspaceId,
+      lastSeenAt: new Date().toISOString(),
+    };
+    await this.writeAuthContext(context.state);
+    return { exists: true, state: context.state };
+  }
+
+  private async setActiveWorkspaceId(workspaceId: string): Promise<void> {
+    const context = await this.readAuthContext();
+    context.state.activeWorkspaceId = workspaceId;
+    context.state.workspaces[workspaceId] ??= {
+      id: workspaceId,
+      name: workspaceId,
+      lastSeenAt: new Date().toISOString(),
+    };
+    await this.writeAuthContext(context.state);
+  }
+
+  private async maybeActivateWorkspaceId(workspaceId: string): Promise<void> {
+    const context = await this.readAuthContext();
+    if (
+      this.options.activateOnSetTokens === false &&
+      context.exists &&
+      context.state.activeWorkspaceId &&
+      context.state.activeWorkspaceId !== workspaceId
+    ) {
+      return;
+    }
+
+    context.state.activeWorkspaceId = workspaceId;
+    context.state.workspaces[workspaceId] ??= {
+      id: workspaceId,
+      name: workspaceId,
+      lastSeenAt: new Date().toISOString(),
+    };
+    await this.writeAuthContext(context.state);
+  }
+
+  private async removeRememberedWorkspace(
+    workspaceId: string,
+    options: { preserveActivePointer: boolean },
+  ): Promise<void> {
+    const context = await this.readAuthContext();
+    delete context.state.workspaces[workspaceId];
+    if (
+      !options.preserveActivePointer &&
+      context.state.activeWorkspaceId === workspaceId
+    ) {
+      context.state.activeWorkspaceId = null;
+    }
+    await this.writeAuthContext(context.state);
+  }
+
+  private async readAuthContext(): Promise<AuthContextReadResult> {
+    this.signal?.throwIfAborted();
+    const raw = await fs
+      .readFile(this.contextFilePath, {
+        encoding: "utf8",
+        signal: this.signal,
+      })
+      .catch((error) => {
+        if (this.signal?.aborted) throw error;
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          return null;
+        }
+        return null;
+      });
+
+    if (raw === null) {
+      return { exists: false, state: structuredClone(EMPTY_AUTH_CONTEXT) };
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as Partial<AuthContextState>;
+      return {
+        exists: true,
+        state: {
+          activeWorkspaceId:
+            typeof parsed.activeWorkspaceId === "string" &&
+            parsed.activeWorkspaceId.trim().length > 0
+              ? parsed.activeWorkspaceId.trim()
+              : null,
+          workspaces:
+            parsed.workspaces &&
+            typeof parsed.workspaces === "object" &&
+            !Array.isArray(parsed.workspaces)
+              ? parsed.workspaces
+              : {},
+        },
+      };
+    } catch {
+      return { exists: false, state: structuredClone(EMPTY_AUTH_CONTEXT) };
+    }
+  }
+
+  private async writeAuthContext(state: AuthContextState): Promise<void> {
+    this.signal?.throwIfAborted();
+    await fs.mkdir(path.dirname(this.contextFilePath), { recursive: true });
+    this.signal?.throwIfAborted();
+    await fs.writeFile(
+      this.contextFilePath,
+      `${JSON.stringify(state, null, 2)}\n`,
+      { encoding: "utf8", signal: this.signal },
+    );
+    this.signal?.throwIfAborted();
+  }
+
+  private async clearAuthContext(): Promise<void> {
+    await fs.unlink(this.contextFilePath).catch((error) => {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw error;
+    });
+  }
+}
+
+export class WorkspaceSelectionError extends Error {
+  constructor(
+    readonly reason: "missing" | "not-found" | "ambiguous",
+    readonly workspaceRef?: string,
+    readonly matches: StoredAuthWorkspace[] = [],
+  ) {
+    super(reason);
+    this.name = "WorkspaceSelectionError";
+  }
+}
+
+function workspaceMatchesRef(
+  workspace: StoredAuthWorkspace,
+  ref: string,
+): boolean {
+  return (
+    workspace.credentialWorkspaceId === ref ||
+    workspace.id === ref ||
+    stripWorkspacePrefix(workspace.credentialWorkspaceId) ===
+      stripWorkspacePrefix(ref) ||
+    stripWorkspacePrefix(workspace.id) === stripWorkspacePrefix(ref) ||
+    workspace.name === ref
+  );
+}
+
+function stripWorkspacePrefix(value: string): string {
+  return value.startsWith("wksp_") ? value.slice("wksp_".length) : value;
 }

--- a/packages/cli/src/adapters/token-storage.ts
+++ b/packages/cli/src/adapters/token-storage.ts
@@ -191,9 +191,13 @@ export class FileTokenStorage implements TokenStorage {
 
       if (!context.exists) {
         await this.setActiveWorkspaceId(latest.workspaceId);
+        return latest;
       }
 
-      return context.exists ? null : latest;
+      // A context file with no active workspace is an explicit local signed-out
+      // state, usually after logging out the active workspace. Do not fall back
+      // to another cached workspace without an explicit `auth workspace use`.
+      return null;
     } catch (_error) {
       if (this.signal?.aborted) throw this.signal.reason;
       return null;
@@ -251,6 +255,8 @@ export class FileTokenStorage implements TokenStorage {
     const current = await this.getTokens();
     if (!tokensEqual(current, tokens)) return;
     await this.credentialsStore.deleteCredentials(tokens.workspaceId);
+    // Preserve the active pointer so a refresh failure for the selected
+    // workspace does not silently move commands to another cached workspace.
     await this.removeRememberedWorkspace(tokens.workspaceId, {
       preserveActivePointer: true,
     });
@@ -608,7 +614,7 @@ export class FileTokenStorage implements TokenStorage {
         if ((error as NodeJS.ErrnoException).code === "ENOENT") {
           return null;
         }
-        return null;
+        throw error;
       });
 
     if (raw === null) {
@@ -688,7 +694,7 @@ function workspaceMatchesRef(
     stripWorkspacePrefix(workspace.credentialWorkspaceId) ===
       stripWorkspacePrefix(ref) ||
     stripWorkspacePrefix(workspace.id) === stripWorkspacePrefix(ref) ||
-    workspace.name === ref
+    workspace.name.toLowerCase() === ref.toLowerCase()
   );
 }
 

--- a/packages/cli/src/commands/auth/index.ts
+++ b/packages/cli/src/commands/auth/index.ts
@@ -8,6 +8,7 @@ import {
   runAuthWhoAmI,
   runAuthWorkspaceList,
   runAuthWorkspaceLogout,
+  runAuthWorkspaceSelect,
   runAuthWorkspaceUse,
 } from "../../controllers/auth";
 import {
@@ -159,6 +160,7 @@ function createAuthWorkspaceCommand(runtime: CliRuntime): Command {
 
   workspace.addCommand(createAuthWorkspaceListCommand(runtime));
   workspace.addCommand(createAuthWorkspaceUseCommand(runtime));
+  workspace.addCommand(createAuthWorkspaceSelectCommand(runtime));
   workspace.addCommand(createAuthWorkspaceLogoutCommand(runtime));
 
   return workspace;
@@ -182,6 +184,31 @@ function createAuthWorkspaceListCommand(runtime: CliRuntime): Command {
         renderHuman: (context, descriptor, result) =>
           renderAuthWorkspaceList(context, descriptor, result),
         renderJson: (result) => serializeAuthWorkspaceList(result),
+      },
+    );
+  });
+
+  return command;
+}
+
+function createAuthWorkspaceSelectCommand(runtime: CliRuntime): Command {
+  const command = attachCommandDescriptor(
+    configureRuntimeCommand(new Command("select"), runtime),
+    "auth.workspace.select",
+  );
+
+  addGlobalFlags(command);
+
+  command.action(async (options) => {
+    await runCommand<AuthWorkspaceUseResult>(
+      runtime,
+      "auth.workspace.select",
+      options as Record<string, unknown>,
+      (context) => runAuthWorkspaceSelect(context),
+      {
+        renderHuman: (context, descriptor, result) =>
+          renderAuthWorkspaceUse(context, descriptor, result),
+        renderJson: (result) => serializeAuthWorkspaceUse(result),
       },
     );
   });

--- a/packages/cli/src/commands/auth/index.ts
+++ b/packages/cli/src/commands/auth/index.ts
@@ -2,11 +2,23 @@ import { Command, Option } from "commander";
 
 import {
   type AuthLoginCommandOptions,
+  type AuthLogoutCommandOptions,
   runAuthLogin,
   runAuthLogout,
   runAuthWhoAmI,
+  runAuthWorkspaceList,
+  runAuthWorkspaceLogout,
+  runAuthWorkspaceUse,
 } from "../../controllers/auth";
-import { renderAuthSuccess } from "../../presenters/auth";
+import {
+  renderAuthSuccess,
+  renderAuthWorkspaceList,
+  renderAuthWorkspaceLogout,
+  renderAuthWorkspaceUse,
+  serializeAuthWorkspaceList,
+  serializeAuthWorkspaceLogout,
+  serializeAuthWorkspaceUse,
+} from "../../presenters/auth";
 import { attachCommandDescriptor } from "../../shell/command-meta";
 import { runCommand } from "../../shell/command-runner";
 import {
@@ -14,7 +26,12 @@ import {
   addGlobalFlags,
 } from "../../shell/global-flags";
 import { type CliRuntime, configureRuntimeCommand } from "../../shell/runtime";
-import type { AuthStateResult } from "../../types/auth";
+import type {
+  AuthStateResult,
+  AuthWorkspaceListResult,
+  AuthWorkspaceLogoutResult,
+  AuthWorkspaceUseResult,
+} from "../../types/auth";
 
 export function createAuthCommand(runtime: CliRuntime): Command {
   const auth = attachCommandDescriptor(
@@ -27,6 +44,7 @@ export function createAuthCommand(runtime: CliRuntime): Command {
   auth.addCommand(createAuthLoginCommand(runtime));
   auth.addCommand(createAuthLogoutCommand(runtime));
   auth.addCommand(createAuthWhoAmICommand(runtime));
+  auth.addCommand(createAuthWorkspaceCommand(runtime));
 
   return auth;
 }
@@ -66,9 +84,32 @@ function createAuthLogoutCommand(runtime: CliRuntime): Command {
     "auth.logout",
   );
 
+  command.addOption(
+    new Option(
+      "--workspace <id-or-name>",
+      "Remove one stored OAuth workspace session",
+    ),
+  );
+
   addGlobalFlags(command);
 
   command.action(async (options) => {
+    const logoutOptions = options as AuthLogoutCommandOptions;
+    if (logoutOptions.workspace?.trim()) {
+      await runCommand<AuthWorkspaceLogoutResult>(
+        runtime,
+        "auth.workspace.logout",
+        options as Record<string, unknown>,
+        (context) => runAuthWorkspaceLogout(context, logoutOptions.workspace),
+        {
+          renderHuman: (context, descriptor, result) =>
+            renderAuthWorkspaceLogout(context, descriptor, result),
+          renderJson: (result) => serializeAuthWorkspaceLogout(result),
+        },
+      );
+      return;
+    }
+
     await runCommand<AuthStateResult>(
       runtime,
       "auth.logout",
@@ -101,6 +142,106 @@ function createAuthWhoAmICommand(runtime: CliRuntime): Command {
       {
         renderHuman: (context, descriptor, result) =>
           renderAuthSuccess(context, descriptor, "auth.whoami", result),
+      },
+    );
+  });
+
+  return command;
+}
+
+function createAuthWorkspaceCommand(runtime: CliRuntime): Command {
+  const workspace = attachCommandDescriptor(
+    configureRuntimeCommand(new Command("workspace"), runtime),
+    "auth.workspace",
+  );
+
+  addCompactGlobalFlags(workspace);
+
+  workspace.addCommand(createAuthWorkspaceListCommand(runtime));
+  workspace.addCommand(createAuthWorkspaceUseCommand(runtime));
+  workspace.addCommand(createAuthWorkspaceLogoutCommand(runtime));
+
+  return workspace;
+}
+
+function createAuthWorkspaceListCommand(runtime: CliRuntime): Command {
+  const command = attachCommandDescriptor(
+    configureRuntimeCommand(new Command("list"), runtime),
+    "auth.workspace.list",
+  );
+
+  addGlobalFlags(command);
+
+  command.action(async (options) => {
+    await runCommand<AuthWorkspaceListResult>(
+      runtime,
+      "auth.workspace.list",
+      options as Record<string, unknown>,
+      (context) => runAuthWorkspaceList(context),
+      {
+        renderHuman: (context, descriptor, result) =>
+          renderAuthWorkspaceList(context, descriptor, result),
+        renderJson: (result) => serializeAuthWorkspaceList(result),
+      },
+    );
+  });
+
+  return command;
+}
+
+function createAuthWorkspaceLogoutCommand(runtime: CliRuntime): Command {
+  const command = attachCommandDescriptor(
+    configureRuntimeCommand(new Command("logout"), runtime),
+    "auth.workspace.logout",
+  );
+
+  command.argument("<id-or-name>", "Workspace id or exact name");
+  addGlobalFlags(command);
+
+  command.action(async (workspaceRef, options) => {
+    await runCommand<AuthWorkspaceLogoutResult>(
+      runtime,
+      "auth.workspace.logout",
+      options as Record<string, unknown>,
+      (context) =>
+        runAuthWorkspaceLogout(
+          context,
+          typeof workspaceRef === "string" ? workspaceRef : undefined,
+        ),
+      {
+        renderHuman: (context, descriptor, result) =>
+          renderAuthWorkspaceLogout(context, descriptor, result),
+        renderJson: (result) => serializeAuthWorkspaceLogout(result),
+      },
+    );
+  });
+
+  return command;
+}
+
+function createAuthWorkspaceUseCommand(runtime: CliRuntime): Command {
+  const command = attachCommandDescriptor(
+    configureRuntimeCommand(new Command("use"), runtime),
+    "auth.workspace.use",
+  );
+
+  command.argument("<id-or-name>", "Workspace id or exact name");
+  addGlobalFlags(command);
+
+  command.action(async (workspaceRef, options) => {
+    await runCommand<AuthWorkspaceUseResult>(
+      runtime,
+      "auth.workspace.use",
+      options as Record<string, unknown>,
+      (context) =>
+        runAuthWorkspaceUse(
+          context,
+          typeof workspaceRef === "string" ? workspaceRef : undefined,
+        ),
+      {
+        renderHuman: (context, descriptor, result) =>
+          renderAuthWorkspaceUse(context, descriptor, result),
+        renderJson: (result) => serializeAuthWorkspaceUse(result),
       },
     );
   });

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -102,6 +102,7 @@ import {
   buildProjectSetupNextActions,
   type InferredTargetName,
   inferTargetName,
+  localProjectWorkspaceMismatchError,
   type ProjectCandidate,
   projectNotFoundError,
   projectResolutionErrorToCliError,
@@ -3409,7 +3410,11 @@ async function resolveDeployProjectContext(
   const localPin = options.localPin;
   if (localPin.kind === "present") {
     if (localPin.pin.workspaceId !== workspace.id) {
-      throw localResolutionPinStaleError();
+      throw localProjectWorkspaceMismatchError({
+        pinnedWorkspaceId: localPin.pin.workspaceId,
+        pinnedProjectId: localPin.pin.projectId,
+        activeWorkspace: workspace,
+      });
     }
 
     const project = projects.find(

--- a/packages/cli/src/controllers/auth.ts
+++ b/packages/cli/src/controllers/auth.ts
@@ -1,12 +1,30 @@
 import {
+  FileTokenStorage,
+  type StoredAuthWorkspace,
+  WorkspaceSelectionError,
+} from "../adapters/token-storage";
+import {
   performLogin,
   performLogout,
   readAuthState,
 } from "../lib/auth/auth-ops";
-import { authRequiredError, usageError } from "../shell/errors";
+import { SERVICE_TOKEN_ENV_VAR } from "../lib/auth/client";
+import {
+  authRequiredError,
+  usageError,
+  workspaceAmbiguousError,
+  workspaceNotAuthenticatedError,
+  workspaceSwitchUnavailableError,
+} from "../shell/errors";
 import type { CommandSuccess } from "../shell/output";
 import { type CommandContext, canPrompt } from "../shell/runtime";
-import type { AuthStateResult } from "../types/auth";
+import type {
+  AuthStateResult,
+  AuthWorkspace,
+  AuthWorkspaceListResult,
+  AuthWorkspaceLogoutResult,
+  AuthWorkspaceUseResult,
+} from "../types/auth";
 import { createAuthUseCases } from "../use-cases/auth";
 import type { LoginSelection, SelectPromptPort } from "../use-cases/contracts";
 import { createCliUseCaseGateways } from "../use-cases/create-cli-gateways";
@@ -15,6 +33,10 @@ import { createSelectPromptPort } from "./select-prompt-port";
 export interface AuthLoginCommandOptions {
   provider?: string;
   user?: string;
+  workspace?: string;
+}
+
+export interface AuthLogoutCommandOptions {
   workspace?: string;
 }
 
@@ -80,6 +102,84 @@ export async function runAuthWhoAmI(
   );
 }
 
+export async function runAuthWorkspaceList(
+  context: CommandContext,
+): Promise<CommandSuccess<AuthWorkspaceListResult>> {
+  const result = isRealMode(context)
+    ? await listRealAuthWorkspaces(context)
+    : await createAuthUseCases(
+        createCliUseCaseGateways(context),
+      ).listWorkspaces();
+
+  return {
+    command: "auth.workspace.list",
+    result,
+    warnings: [],
+    nextSteps: result.workspaces.length === 0 ? ["prisma-cli auth login"] : [],
+  };
+}
+
+export async function runAuthWorkspaceUse(
+  context: CommandContext,
+  workspaceRef: string | undefined,
+): Promise<CommandSuccess<AuthWorkspaceUseResult>> {
+  if (!workspaceRef?.trim()) {
+    throw usageError(
+      "Workspace required",
+      "auth workspace use needs a workspace id or exact workspace name.",
+      "Pass a workspace from prisma-cli auth workspace list.",
+      ["prisma-cli auth workspace list"],
+      "auth",
+    );
+  }
+
+  const result = isRealMode(context)
+    ? await useRealAuthWorkspace(context, workspaceRef)
+    : await createAuthUseCases(createCliUseCaseGateways(context)).useWorkspace(
+        workspaceRef,
+      );
+
+  return {
+    command: "auth.workspace.use",
+    result,
+    warnings: [],
+    nextSteps: ["prisma-cli auth whoami", "prisma-cli project list"],
+  };
+}
+
+export async function runAuthWorkspaceLogout(
+  context: CommandContext,
+  workspaceRef: string | undefined,
+): Promise<CommandSuccess<AuthWorkspaceLogoutResult>> {
+  if (!workspaceRef?.trim()) {
+    throw usageError(
+      "Workspace required",
+      "auth workspace logout needs a workspace id or exact workspace name.",
+      "Pass a workspace from prisma-cli auth workspace list.",
+      ["prisma-cli auth workspace list"],
+      "auth",
+    );
+  }
+
+  const result = isRealMode(context)
+    ? await logoutRealAuthWorkspace(context, workspaceRef)
+    : await createAuthUseCases(
+        createCliUseCaseGateways(context),
+      ).logoutWorkspace(workspaceRef);
+
+  return {
+    command: "auth.workspace.logout",
+    result,
+    warnings: [],
+    nextSteps: result.activeWorkspace
+      ? ["prisma-cli auth workspace list"]
+      : [
+          "prisma-cli auth workspace list",
+          "prisma-cli auth workspace use <id>",
+        ],
+  };
+}
+
 export async function requireAuthenticatedAuthState(
   context: CommandContext,
 ): Promise<AuthStateResult> {
@@ -112,6 +212,150 @@ export async function requireAuthenticatedAuthState(
   }
 
   return loginWithSelectionFlow(context, useCases, {});
+}
+
+async function listRealAuthWorkspaces(
+  context: CommandContext,
+): Promise<AuthWorkspaceListResult> {
+  const rawServiceToken = context.runtime.env[SERVICE_TOKEN_ENV_VAR];
+  const storage = new FileTokenStorage(
+    context.runtime.env,
+    context.runtime.signal,
+  );
+  const localWorkspaces = await storage.listWorkspaces();
+
+  if (rawServiceToken !== undefined) {
+    const authState = await readAuthState(
+      context.runtime.env,
+      context.runtime.signal,
+    );
+    return {
+      authSource: authState.authenticated ? "service_token" : "none",
+      activeWorkspace: authState.workspace,
+      workspaces: [
+        ...(authState.workspace
+          ? [
+              {
+                ...authState.workspace,
+                credentialWorkspaceId: null,
+                active: true,
+                source: "service_token" as const,
+                switchable: false,
+                lastSeenAt: null,
+              },
+            ]
+          : []),
+        ...localWorkspaces.map((workspace) => ({
+          ...toAuthWorkspace(workspace),
+          credentialWorkspaceId: workspace.credentialWorkspaceId,
+          active: false,
+          source: "oauth" as const,
+          switchable: false,
+          lastSeenAt: workspace.lastSeenAt,
+        })),
+      ],
+    };
+  }
+
+  const active = localWorkspaces.find((workspace) => workspace.active) ?? null;
+  return {
+    authSource: localWorkspaces.length > 0 ? "oauth" : "none",
+    activeWorkspace: active ? toAuthWorkspace(active) : null,
+    workspaces: localWorkspaces.map((workspace) => ({
+      ...toAuthWorkspace(workspace),
+      credentialWorkspaceId: workspace.credentialWorkspaceId,
+      active: workspace.active,
+      source: "oauth" as const,
+      switchable: true,
+      lastSeenAt: workspace.lastSeenAt,
+    })),
+  };
+}
+
+async function useRealAuthWorkspace(
+  context: CommandContext,
+  workspaceRef: string,
+): Promise<AuthWorkspaceUseResult> {
+  if (context.runtime.env[SERVICE_TOKEN_ENV_VAR] !== undefined) {
+    throw workspaceSwitchUnavailableError();
+  }
+
+  const storage = new FileTokenStorage(
+    context.runtime.env,
+    context.runtime.signal,
+  );
+
+  try {
+    const result = await storage.useWorkspace(workspaceRef);
+    return {
+      previousWorkspace: result.previous
+        ? toAuthWorkspace(result.previous)
+        : null,
+      workspace: toAuthWorkspace(result.selected),
+    };
+  } catch (error) {
+    if (error instanceof WorkspaceSelectionError) {
+      if (error.reason === "ambiguous") {
+        throw workspaceAmbiguousError(
+          error.workspaceRef ?? workspaceRef,
+          error.matches.map((match) => ({
+            id: match.id,
+            name: match.name,
+            credentialWorkspaceId: match.credentialWorkspaceId,
+          })),
+        );
+      }
+
+      throw workspaceNotAuthenticatedError(error.workspaceRef ?? workspaceRef);
+    }
+
+    throw error;
+  }
+}
+
+async function logoutRealAuthWorkspace(
+  context: CommandContext,
+  workspaceRef: string,
+): Promise<AuthWorkspaceLogoutResult> {
+  const storage = new FileTokenStorage(
+    context.runtime.env,
+    context.runtime.signal,
+  );
+
+  try {
+    const result = await storage.logoutWorkspace(workspaceRef);
+    return {
+      workspace: toAuthWorkspace(result.workspace),
+      wasActive: result.wasActive,
+      activeWorkspace: result.activeWorkspace
+        ? toAuthWorkspace(result.activeWorkspace)
+        : null,
+    };
+  } catch (error) {
+    if (error instanceof WorkspaceSelectionError) {
+      if (error.reason === "ambiguous") {
+        throw workspaceAmbiguousError(
+          error.workspaceRef ?? workspaceRef,
+          error.matches.map((match) => ({
+            id: match.id,
+            name: match.name,
+            credentialWorkspaceId: match.credentialWorkspaceId,
+          })),
+        );
+      }
+
+      throw workspaceNotAuthenticatedError(error.workspaceRef ?? workspaceRef);
+    }
+
+    throw error;
+  }
+}
+
+function toAuthWorkspace(workspace: StoredAuthWorkspace): AuthWorkspace {
+  return {
+    id: workspace.id,
+    name: workspace.name,
+  };
 }
 
 async function loginWithSelectionFlow(

--- a/packages/cli/src/controllers/auth.ts
+++ b/packages/cli/src/controllers/auth.ts
@@ -126,7 +126,7 @@ export async function runAuthWorkspaceUse(
   if (!workspaceRef?.trim()) {
     throw usageError(
       "Workspace required",
-      "auth workspace use needs a workspace id or exact workspace name.",
+      "auth workspace use needs a workspace id or cached workspace name.",
       "Pass a workspace from prisma-cli auth workspace list.",
       ["prisma-cli auth workspace list"],
       "auth",
@@ -147,6 +147,17 @@ export async function runAuthWorkspaceUse(
   };
 }
 
+export async function runAuthWorkspaceSelect(
+  context: CommandContext,
+): Promise<CommandSuccess<AuthWorkspaceUseResult>> {
+  const workspaceRef = await selectWorkspaceSession(context);
+  const success = await runAuthWorkspaceUse(context, workspaceRef);
+  return {
+    ...success,
+    command: "auth.workspace.select",
+  };
+}
+
 export async function runAuthWorkspaceLogout(
   context: CommandContext,
   workspaceRef: string | undefined,
@@ -154,7 +165,7 @@ export async function runAuthWorkspaceLogout(
   if (!workspaceRef?.trim()) {
     throw usageError(
       "Workspace required",
-      "auth workspace logout needs a workspace id or exact workspace name.",
+      "auth workspace logout needs a workspace id or cached workspace name.",
       "Pass a workspace from prisma-cli auth workspace list.",
       ["prisma-cli auth workspace list"],
       "auth",
@@ -349,6 +360,59 @@ async function logoutRealAuthWorkspace(
 
     throw error;
   }
+}
+
+async function selectWorkspaceSession(
+  context: CommandContext,
+): Promise<string> {
+  const realMode = isRealMode(context);
+  if (realMode && context.runtime.env[SERVICE_TOKEN_ENV_VAR] !== undefined) {
+    throw workspaceSwitchUnavailableError();
+  }
+
+  const result = realMode
+    ? await listRealAuthWorkspaces(context)
+    : await createAuthUseCases(
+        createCliUseCaseGateways(context),
+      ).listWorkspaces();
+  const workspaces = result.workspaces.filter(
+    (workspace) => workspace.switchable,
+  );
+
+  if (workspaces.length === 0) {
+    throw usageError(
+      "No authenticated workspaces",
+      "There are no local OAuth workspace sessions to select.",
+      "Run prisma-cli auth login and authorize a workspace.",
+      ["prisma-cli auth login"],
+      "auth",
+    );
+  }
+
+  if (workspaces.length === 1) {
+    return workspaces[0].id;
+  }
+
+  if (!canPrompt(context)) {
+    throw usageError(
+      "Interactive workspace selection unavailable",
+      "auth workspace select needs an interactive terminal when more than one workspace is available.",
+      "Run prisma-cli auth workspace use <id-or-name> with a workspace from prisma-cli auth workspace list.",
+      ["prisma-cli auth workspace list"],
+      "auth",
+    );
+  }
+
+  const prompt = createSelectPromptPort(context);
+  const selected = await prompt.select({
+    message: "Select a workspace",
+    choices: workspaces.map((workspace) => ({
+      label: `${workspace.name} (${workspace.id})${workspace.active ? " active" : ""}`,
+      value: workspace,
+    })),
+  });
+
+  return selected.id;
 }
 
 function toAuthWorkspace(workspace: StoredAuthWorkspace): AuthWorkspace {

--- a/packages/cli/src/lib/auth/auth-ops.ts
+++ b/packages/cli/src/lib/auth/auth-ops.ts
@@ -38,7 +38,13 @@ export async function performLogin(
   env: NodeJS.ProcessEnv,
   signal?: AbortSignal,
 ): Promise<void> {
-  await login({ tokenStorage: new FileTokenStorage(env, signal), env, signal });
+  await login({
+    tokenStorage: new FileTokenStorage(env, signal, {
+      activateOnSetTokens: true,
+    }),
+    env,
+    signal,
+  });
 }
 
 export async function readAuthState(
@@ -78,17 +84,30 @@ export async function readAuthState(
   const client = await requireComputeAuth(env, signal);
   const currentPrincipal = await readCurrentPrincipalAuthState(client, signal);
   if (currentPrincipal) {
+    if (currentPrincipal.authenticated && currentPrincipal.workspace) {
+      await tokenStorage.rememberWorkspace?.(
+        tokens.workspaceId,
+        currentPrincipal.workspace,
+      );
+    }
     return currentPrincipal;
   }
 
   const claims = decodeJwtPayload(tokens.accessToken);
-  return buildAuthState({
+  const authState = await buildAuthState({
     workspaceIdFromCredential: tokens.workspaceId,
     claims,
     env,
     client,
     signal,
   });
+  if (authState.authenticated && authState.workspace) {
+    await tokenStorage.rememberWorkspace?.(
+      tokens.workspaceId,
+      authState.workspace,
+    );
+  }
+  return authState;
 }
 
 async function readServiceTokenAuthState(

--- a/packages/cli/src/lib/auth/guard.ts
+++ b/packages/cli/src/lib/auth/guard.ts
@@ -36,7 +36,10 @@ export async function requireComputeAuth(
     });
   }
 
-  const tokenStorage = new FileTokenStorage(env, signal);
+  const tokenStorage = new FileTokenStorage(env, signal, {
+    activateOnSetTokens: false,
+    lockSetTokens: false,
+  });
   const tokens = await tokenStorage.getTokens();
 
   if (!tokens) {

--- a/packages/cli/src/lib/auth/guard.ts
+++ b/packages/cli/src/lib/auth/guard.ts
@@ -38,6 +38,9 @@ export async function requireComputeAuth(
 
   const tokenStorage = new FileTokenStorage(env, signal, {
     activateOnSetTokens: false,
+    // createManagementApiSdk already wraps refresh writes in withRefreshLock.
+    // Re-acquiring the same file lock inside setTokens would deadlock until
+    // the bounded lock wait fails, so refresh storage writes opt out here.
     lockSetTokens: false,
   });
   const tokens = await tokenStorage.getTokens();

--- a/packages/cli/src/lib/auth/login.ts
+++ b/packages/cli/src/lib/auth/login.ts
@@ -253,7 +253,10 @@ class LoginState {
     },
   ) {
     this.tokenStorage =
-      options.tokenStorage ?? new FileTokenStorage(options.env, options.signal);
+      options.tokenStorage ??
+      new FileTokenStorage(options.env, options.signal, {
+        activateOnSetTokens: true,
+      });
     this.sdk = createManagementApiSdk({
       clientId: options.clientId ?? CLIENT_ID,
       redirectUri: `http://${options.hostname}:${options.port}/auth/callback`,

--- a/packages/cli/src/lib/project/resolution.ts
+++ b/packages/cli/src/lib/project/resolution.ts
@@ -326,7 +326,7 @@ function localProjectWorkspaceMismatchCliError(options: {
     domain: "project",
     summary: "Project link uses another workspace",
     why: `${LOCAL_RESOLUTION_PIN_RELATIVE_PATH} links this directory to project ${options.pinnedProjectId} in workspace ${options.pinnedWorkspaceId}, but your current CLI session is workspace "${options.activeWorkspace.name}" (${options.activeWorkspace.id}).`,
-    fix: "Sign in to the linked workspace, or relink this directory to a project in the current workspace.",
+    fix: "Switch to the linked workspace, or relink this directory to a project in the current workspace.",
     meta: {
       pinPath: LOCAL_RESOLUTION_PIN_RELATIVE_PATH,
       pinnedWorkspaceId: options.pinnedWorkspaceId,
@@ -336,7 +336,7 @@ function localProjectWorkspaceMismatchCliError(options: {
     },
     exitCode: 1,
     nextSteps: [
-      "prisma-cli auth login",
+      `prisma-cli auth workspace use ${options.pinnedWorkspaceId}`,
       "prisma-cli project list",
       "prisma-cli project link <id-or-name>",
     ],

--- a/packages/cli/src/presenters/auth.ts
+++ b/packages/cli/src/presenters/auth.ts
@@ -1,6 +1,9 @@
-import { renderList, renderMutate, renderShow } from "../output/patterns";
+import stringWidth from "string-width";
+import { renderMutate, renderShow } from "../output/patterns";
 import type { CommandDescriptor } from "../shell/command-meta";
+import { formatDescriptorLabel } from "../shell/command-meta";
 import type { CommandContext } from "../shell/runtime";
+import { padDisplay } from "../shell/ui";
 import type {
   AuthProviderId,
   AuthStateResult,
@@ -84,29 +87,56 @@ export function renderAuthWorkspaceList(
   descriptor: CommandDescriptor,
   result: AuthWorkspaceListResult,
 ): string[] {
+  const ui = context.ui;
+  const rail = ui.dim("│");
+  const lines = [
+    `${ui.strong(formatDescriptorLabel(descriptor))} ${ui.dim("→")} ${ui.dim("Listing authenticated workspaces on this machine.")}`,
+    "",
+    `${rail}  ${ui.accent("auth source:")}  ${authSourceLabel(result.authSource)}`,
+  ];
   const hasMixedSources =
     new Set(result.workspaces.map((workspace) => workspace.source)).size > 1;
 
-  return renderList(
-    {
-      title: "Listing authenticated workspaces on this machine.",
-      descriptor,
-      parentContext: {
-        key: "auth source",
-        value: authSourceLabel(result.authSource),
-      },
-      items: result.workspaces.map((workspace) => ({
-        noun: "workspace",
-        label: hasMixedSources
-          ? `${workspace.name} (${workspaceSourceLabel(workspace.source)})`
-          : workspace.name,
-        id: workspace.id,
-        status: workspace.active ? "active" : null,
-      })),
-      emptyMessage: "No local OAuth workspaces found.",
-    },
-    context.ui,
+  if (result.workspaces.length === 0) {
+    lines.push(`${rail}  ${ui.dim("No local OAuth workspaces found.")}`);
+    return lines;
+  }
+
+  const nameWidth = Math.max(
+    "name".length,
+    ...result.workspaces.map((workspace) => stringWidth(workspace.name)),
   );
+  const idWidth = Math.max(
+    "id".length,
+    ...result.workspaces.map((workspace) => stringWidth(workspace.id)),
+  );
+  const sourceWidth = hasMixedSources
+    ? Math.max(
+        "source".length,
+        ...result.workspaces.map((workspace) =>
+          stringWidth(workspaceSourceLabel(workspace.source)),
+        ),
+      )
+    : 0;
+
+  lines.push(rail);
+  lines.push(
+    hasMixedSources
+      ? `${rail}  ${ui.accent(padDisplay("name", nameWidth))}  ${ui.accent(padDisplay("id", idWidth))}  ${ui.accent(padDisplay("source", sourceWidth))}  ${ui.accent("status")}`
+      : `${rail}  ${ui.accent(padDisplay("name", nameWidth))}  ${ui.accent(padDisplay("id", idWidth))}  ${ui.accent("status")}`,
+  );
+
+  for (const workspace of result.workspaces) {
+    const status = workspace.active ? "active" : "";
+    const source = workspaceSourceLabel(workspace.source);
+    lines.push(
+      hasMixedSources
+        ? `${rail}  ${padDisplay(workspace.name, nameWidth)}  ${padDisplay(workspace.id, idWidth)}  ${padDisplay(source, sourceWidth)}  ${status}`
+        : `${rail}  ${padDisplay(workspace.name, nameWidth)}  ${padDisplay(workspace.id, idWidth)}  ${status}`,
+    );
+  }
+
+  return lines;
 }
 
 export function serializeAuthWorkspaceList(result: AuthWorkspaceListResult) {

--- a/packages/cli/src/presenters/auth.ts
+++ b/packages/cli/src/presenters/auth.ts
@@ -1,7 +1,13 @@
-import { renderMutate, renderShow } from "../output/patterns";
+import { renderList, renderMutate, renderShow } from "../output/patterns";
 import type { CommandDescriptor } from "../shell/command-meta";
 import type { CommandContext } from "../shell/runtime";
-import type { AuthProviderId, AuthStateResult } from "../types/auth";
+import type {
+  AuthProviderId,
+  AuthStateResult,
+  AuthWorkspaceListResult,
+  AuthWorkspaceLogoutResult,
+  AuthWorkspaceUseResult,
+} from "../types/auth";
 
 export function renderAuthSuccess(
   context: CommandContext,
@@ -73,6 +79,116 @@ export function renderAuthSuccess(
   );
 }
 
+export function renderAuthWorkspaceList(
+  context: CommandContext,
+  descriptor: CommandDescriptor,
+  result: AuthWorkspaceListResult,
+): string[] {
+  const hasMixedSources =
+    new Set(result.workspaces.map((workspace) => workspace.source)).size > 1;
+
+  return renderList(
+    {
+      title: "Listing authenticated workspaces on this machine.",
+      descriptor,
+      parentContext: {
+        key: "auth source",
+        value: authSourceLabel(result.authSource),
+      },
+      items: result.workspaces.map((workspace) => ({
+        noun: "workspace",
+        label: hasMixedSources
+          ? `${workspace.name} (${workspaceSourceLabel(workspace.source)})`
+          : workspace.name,
+        id: workspace.id,
+        status: workspace.active ? "active" : null,
+      })),
+      emptyMessage: "No local OAuth workspaces found.",
+    },
+    context.ui,
+  );
+}
+
+export function serializeAuthWorkspaceList(result: AuthWorkspaceListResult) {
+  return {
+    context: {
+      authSource: result.authSource,
+      activeWorkspaceId: result.activeWorkspace?.id ?? null,
+      activeWorkspaceName: result.activeWorkspace?.name ?? null,
+    },
+    items: result.workspaces.map((workspace) => ({
+      id: workspace.id,
+      name: workspace.name,
+      status: workspace.active ? "active" : null,
+      source: workspace.source,
+      switchable: workspace.switchable,
+      credentialWorkspaceId: workspace.credentialWorkspaceId,
+      lastSeenAt: workspace.lastSeenAt,
+    })),
+    count: result.workspaces.length,
+  };
+}
+
+export function renderAuthWorkspaceUse(
+  context: CommandContext,
+  descriptor: CommandDescriptor,
+  result: AuthWorkspaceUseResult,
+): string[] {
+  return renderMutate(
+    {
+      title: "Switching the local CLI workspace.",
+      descriptor,
+      context: [
+        ...(result.previousWorkspace
+          ? [{ key: "previous", value: result.previousWorkspace.name }]
+          : []),
+        { key: "workspace", value: result.workspace.name },
+      ],
+      operationDescription: "Applying workspace selection",
+      operationCount: 1,
+      details: ["Local OAuth workspace selection updated."],
+    },
+    context.ui,
+  );
+}
+
+export function serializeAuthWorkspaceUse(result: AuthWorkspaceUseResult) {
+  return result;
+}
+
+export function renderAuthWorkspaceLogout(
+  context: CommandContext,
+  descriptor: CommandDescriptor,
+  result: AuthWorkspaceLogoutResult,
+): string[] {
+  return renderMutate(
+    {
+      title: "Removing a local OAuth workspace session.",
+      descriptor,
+      context: [
+        { key: "workspace", value: result.workspace.name },
+        ...(result.activeWorkspace
+          ? [{ key: "active", value: result.activeWorkspace.name }]
+          : [{ key: "active", value: "none", tone: "dim" as const }]),
+      ],
+      operationDescription: "Removing workspace session",
+      operationCount: 1,
+      details: [
+        result.wasActive
+          ? "Removed active workspace session; no replacement workspace was selected."
+          : "Removed workspace session.",
+      ],
+    },
+    context.ui,
+  );
+}
+
+export function serializeAuthWorkspaceLogout(
+  result: AuthWorkspaceLogoutResult,
+) {
+  return result;
+}
+
 function providerLabel(provider: AuthProviderId | null): string {
   if (provider === "github") {
     return "GitHub";
@@ -83,6 +199,24 @@ function providerLabel(provider: AuthProviderId | null): string {
   }
 
   return "";
+}
+
+function authSourceLabel(
+  source: AuthWorkspaceListResult["authSource"],
+): string {
+  if (source === "oauth") {
+    return "local OAuth";
+  }
+
+  if (source === "service_token") {
+    return "PRISMA_SERVICE_TOKEN";
+  }
+
+  return "none";
+}
+
+function workspaceSourceLabel(source: "oauth" | "service_token"): string {
+  return source === "service_token" ? "service token" : "OAuth";
 }
 
 function authUserLabel(result: AuthStateResult): string | null {

--- a/packages/cli/src/shell/command-meta.ts
+++ b/packages/cli/src/shell/command-meta.ts
@@ -51,6 +51,43 @@ const DESCRIPTORS: CommandDescriptor[] = [
     examples: ["prisma-cli auth whoami", "prisma-cli auth whoami --json"],
   },
   {
+    id: "auth.workspace",
+    path: ["prisma", "auth", "workspace"],
+    description: "Manage local authenticated workspaces",
+    examples: [
+      "prisma-cli auth workspace list",
+      "prisma-cli auth workspace use wksp_123",
+      "prisma-cli auth workspace logout wksp_123",
+    ],
+  },
+  {
+    id: "auth.workspace.list",
+    path: ["prisma", "auth", "workspace", "list"],
+    description: "List locally authenticated workspaces",
+    examples: [
+      "prisma-cli auth workspace list",
+      "prisma-cli auth workspace list --json",
+    ],
+  },
+  {
+    id: "auth.workspace.use",
+    path: ["prisma", "auth", "workspace", "use"],
+    description: "Switch the local CLI workspace",
+    examples: [
+      "prisma-cli auth workspace use wksp_123",
+      'prisma-cli auth workspace use "Acme Inc"',
+    ],
+  },
+  {
+    id: "auth.workspace.logout",
+    path: ["prisma", "auth", "workspace", "logout"],
+    description: "Remove one local OAuth workspace session",
+    examples: [
+      "prisma-cli auth workspace logout wksp_123",
+      'prisma-cli auth workspace logout "Acme Inc"',
+    ],
+  },
+  {
     id: "project",
     path: ["prisma", "project"],
     description: "Manage and inspect your Prisma projects",

--- a/packages/cli/src/shell/command-meta.ts
+++ b/packages/cli/src/shell/command-meta.ts
@@ -56,6 +56,7 @@ const DESCRIPTORS: CommandDescriptor[] = [
     description: "Manage local authenticated workspaces",
     examples: [
       "prisma-cli auth workspace list",
+      "prisma-cli auth workspace select",
       "prisma-cli auth workspace use wksp_123",
       "prisma-cli auth workspace logout wksp_123",
     ],
@@ -77,6 +78,12 @@ const DESCRIPTORS: CommandDescriptor[] = [
       "prisma-cli auth workspace use wksp_123",
       'prisma-cli auth workspace use "Acme Inc"',
     ],
+  },
+  {
+    id: "auth.workspace.select",
+    path: ["prisma", "auth", "workspace", "select"],
+    description: "Interactively select the local CLI workspace",
+    examples: ["prisma-cli auth workspace select"],
   },
   {
     id: "auth.workspace.logout",

--- a/packages/cli/src/shell/command-runner.ts
+++ b/packages/cli/src/shell/command-runner.ts
@@ -3,7 +3,12 @@ import { collectCommandDiagnostics } from "../lib/diagnostics";
 import type { CommandDescriptor } from "./command-meta";
 import { getCommandDescriptor } from "./command-meta";
 import { renderCommandDiagnostics } from "./diagnostics-output";
-import { authRequiredError, CliError, commandCanceledError } from "./errors";
+import {
+  authConfigInvalidError,
+  authRequiredError,
+  CliError,
+  commandCanceledError,
+} from "./errors";
 import { resolveGlobalFlags } from "./global-flags";
 import type { CommandSuccess } from "./output";
 import {
@@ -41,6 +46,13 @@ function toCliError(error: unknown, runtime: CliRuntime): CliError | null {
     return authRequiredError(["prisma-cli auth login"], {
       debug: error.message,
     });
+  }
+
+  if (
+    error instanceof Error &&
+    error.message.startsWith("PRISMA_SERVICE_TOKEN is set but empty")
+  ) {
+    return authConfigInvalidError(error.message);
   }
 
   return null;

--- a/packages/cli/src/shell/errors.ts
+++ b/packages/cli/src/shell/errors.ts
@@ -98,6 +98,18 @@ export function authRequiredError(
   });
 }
 
+export function authConfigInvalidError(message: string): CliError {
+  return new CliError({
+    code: "AUTH_CONFIG_INVALID",
+    domain: "auth",
+    summary: "Authentication configuration is invalid",
+    why: message,
+    fix: "Provide a valid PRISMA_SERVICE_TOKEN value, or unset the variable to use local OAuth login.",
+    exitCode: 1,
+    nextSteps: ["prisma-cli auth login"],
+  });
+}
+
 export function commandCanceledError(): CliError {
   return new CliError({
     code: "COMMAND_CANCELED",
@@ -118,6 +130,52 @@ export function workspaceRequiredError(): CliError {
     ["prisma-cli auth login"],
     "auth",
   );
+}
+
+export function workspaceSwitchUnavailableError(): CliError {
+  return new CliError({
+    code: "WORKSPACE_SWITCH_UNAVAILABLE",
+    domain: "auth",
+    summary: "Workspace switching is unavailable",
+    why: "PRISMA_SERVICE_TOKEN is set, so authenticated commands use that token instead of local OAuth workspaces.",
+    fix: "Unset PRISMA_SERVICE_TOKEN to switch between local OAuth workspaces, or use a token for the workspace you want.",
+    exitCode: 1,
+    nextSteps: ["unset PRISMA_SERVICE_TOKEN", "prisma-cli auth workspace list"],
+  });
+}
+
+export function workspaceNotAuthenticatedError(workspaceRef: string): CliError {
+  return new CliError({
+    code: "WORKSPACE_NOT_AUTHENTICATED",
+    domain: "auth",
+    summary: "Workspace is not authenticated",
+    why: `No stored OAuth session matched "${workspaceRef}".`,
+    fix: "Run prisma-cli auth login and authorize that workspace, then switch to it.",
+    meta: {
+      workspaceRef,
+    },
+    exitCode: 1,
+    nextSteps: ["prisma-cli auth workspace list", "prisma-cli auth login"],
+  });
+}
+
+export function workspaceAmbiguousError(
+  workspaceRef: string,
+  matches: Array<{ id: string; name: string; credentialWorkspaceId: string }>,
+): CliError {
+  return new CliError({
+    code: "WORKSPACE_AMBIGUOUS",
+    domain: "auth",
+    summary: "Workspace name is ambiguous",
+    why: `Multiple authenticated workspaces matched "${workspaceRef}".`,
+    fix: "Run prisma-cli auth workspace list and switch by workspace id.",
+    meta: {
+      workspaceRef,
+      matches,
+    },
+    exitCode: 2,
+    nextSteps: ["prisma-cli auth workspace list"],
+  });
 }
 
 export function featureUnavailableError(

--- a/packages/cli/src/types/auth.ts
+++ b/packages/cli/src/types/auth.ts
@@ -24,3 +24,30 @@ export interface AuthStateResult {
   workspace: AuthWorkspace | null;
   credential: AuthCredential | null;
 }
+
+export interface AuthWorkspaceSession {
+  id: string;
+  name: string;
+  credentialWorkspaceId: string | null;
+  active: boolean;
+  source: "oauth" | "service_token";
+  switchable: boolean;
+  lastSeenAt: string | null;
+}
+
+export interface AuthWorkspaceListResult {
+  authSource: "oauth" | "service_token" | "none";
+  activeWorkspace: AuthWorkspace | null;
+  workspaces: AuthWorkspaceSession[];
+}
+
+export interface AuthWorkspaceUseResult {
+  previousWorkspace: AuthWorkspace | null;
+  workspace: AuthWorkspace;
+}
+
+export interface AuthWorkspaceLogoutResult {
+  workspace: AuthWorkspace;
+  wasActive: boolean;
+  activeWorkspace: AuthWorkspace | null;
+}

--- a/packages/cli/src/use-cases/auth.ts
+++ b/packages/cli/src/use-cases/auth.ts
@@ -1,4 +1,9 @@
-import { usageError } from "../shell/errors";
+import {
+  authRequiredError,
+  usageError,
+  workspaceAmbiguousError,
+  workspaceNotAuthenticatedError,
+} from "../shell/errors";
 import type { AuthProviderId, AuthStateResult } from "../types/auth";
 import type {
   AuthUseCases,
@@ -29,6 +34,124 @@ export function createAuthUseCases(
     logout: async () => {
       await dependencies.sessionGateway.clearAuthSession();
       return resolveCurrentAuthState(dependencies);
+    },
+    listWorkspaces: async () => {
+      const session = await dependencies.sessionGateway.readAuthSession();
+      if (!session) {
+        return {
+          authSource: "none",
+          activeWorkspace: null,
+          workspaces: [],
+        };
+      }
+
+      const workspaces = dependencies.identityGateway.listUserWorkspaces(
+        session.userId,
+      );
+      const activeWorkspace =
+        workspaces.find((workspace) => workspace.id === session.workspaceId) ??
+        null;
+
+      return {
+        authSource: "oauth",
+        activeWorkspace,
+        workspaces: workspaces.map((workspace) => ({
+          ...workspace,
+          credentialWorkspaceId: workspace.id,
+          active: workspace.id === session.workspaceId,
+          source: "oauth" as const,
+          switchable: true,
+          lastSeenAt: null,
+        })),
+      };
+    },
+    useWorkspace: async (workspaceRef: string) => {
+      const session = await dependencies.sessionGateway.readAuthSession();
+      if (!session) {
+        throw authRequiredError(["prisma-cli auth login"]);
+      }
+
+      const ref = workspaceRef.trim();
+      const workspaces = dependencies.identityGateway.listUserWorkspaces(
+        session.userId,
+      );
+      const matches = workspaces.filter(
+        (workspace) => workspace.id === ref || workspace.name === ref,
+      );
+
+      if (matches.length === 0) {
+        throw workspaceNotAuthenticatedError(workspaceRef);
+      }
+
+      if (matches.length > 1) {
+        throw workspaceAmbiguousError(
+          workspaceRef,
+          matches.map((workspace) => ({
+            id: workspace.id,
+            name: workspace.name,
+            credentialWorkspaceId: workspace.id,
+          })),
+        );
+      }
+
+      const selected = matches[0];
+      const previousWorkspace =
+        dependencies.identityGateway.getWorkspace(session.workspaceId) ?? null;
+      await dependencies.sessionGateway.writeAuthSession({
+        ...session,
+        workspaceId: selected.id,
+      });
+
+      return {
+        previousWorkspace,
+        workspace: selected,
+      };
+    },
+    logoutWorkspace: async (workspaceRef: string) => {
+      const session = await dependencies.sessionGateway.readAuthSession();
+      if (!session) {
+        throw workspaceNotAuthenticatedError(workspaceRef);
+      }
+
+      const ref = workspaceRef.trim();
+      const workspaces = dependencies.identityGateway.listUserWorkspaces(
+        session.userId,
+      );
+      const matches = workspaces.filter(
+        (workspace) => workspace.id === ref || workspace.name === ref,
+      );
+
+      if (matches.length === 0) {
+        throw workspaceNotAuthenticatedError(workspaceRef);
+      }
+
+      if (matches.length > 1) {
+        throw workspaceAmbiguousError(
+          workspaceRef,
+          matches.map((workspace) => ({
+            id: workspace.id,
+            name: workspace.name,
+            credentialWorkspaceId: workspace.id,
+          })),
+        );
+      }
+
+      const workspace = matches[0];
+      const wasActive = workspace.id === session.workspaceId;
+      const activeWorkspace = wasActive
+        ? null
+        : (dependencies.identityGateway.getWorkspace(session.workspaceId) ??
+          null);
+
+      if (wasActive) {
+        await dependencies.sessionGateway.clearAuthSession();
+      }
+
+      return {
+        workspace,
+        wasActive,
+        activeWorkspace,
+      };
     },
     listProviders: async () => dependencies.identityGateway.listProviders(),
     resolveProvider: async (providerId) => {

--- a/packages/cli/src/use-cases/auth.ts
+++ b/packages/cli/src/use-cases/auth.ts
@@ -4,7 +4,11 @@ import {
   workspaceAmbiguousError,
   workspaceNotAuthenticatedError,
 } from "../shell/errors";
-import type { AuthProviderId, AuthStateResult } from "../types/auth";
+import type {
+  AuthProviderId,
+  AuthStateResult,
+  AuthWorkspace,
+} from "../types/auth";
 import type {
   AuthUseCases,
   IdentityGateway,
@@ -75,8 +79,8 @@ export function createAuthUseCases(
       const workspaces = dependencies.identityGateway.listUserWorkspaces(
         session.userId,
       );
-      const matches = workspaces.filter(
-        (workspace) => workspace.id === ref || workspace.name === ref,
+      const matches = workspaces.filter((workspace) =>
+        workspaceMatchesRef(workspace, ref),
       );
 
       if (matches.length === 0) {
@@ -117,8 +121,8 @@ export function createAuthUseCases(
       const workspaces = dependencies.identityGateway.listUserWorkspaces(
         session.userId,
       );
-      const matches = workspaces.filter(
-        (workspace) => workspace.id === ref || workspace.name === ref,
+      const matches = workspaces.filter((workspace) =>
+        workspaceMatchesRef(workspace, ref),
       );
 
       if (matches.length === 0) {
@@ -227,6 +231,12 @@ export function createAuthUseCases(
       return workspace;
     },
   };
+}
+
+function workspaceMatchesRef(workspace: AuthWorkspace, ref: string): boolean {
+  return (
+    workspace.id === ref || workspace.name.toLowerCase() === ref.toLowerCase()
+  );
 }
 
 async function resolveCurrentAuthState(

--- a/packages/cli/src/use-cases/contracts.ts
+++ b/packages/cli/src/use-cases/contracts.ts
@@ -3,6 +3,9 @@ import type {
   AuthStateResult,
   AuthUser,
   AuthWorkspace,
+  AuthWorkspaceListResult,
+  AuthWorkspaceLogoutResult,
+  AuthWorkspaceUseResult,
 } from "../types/auth";
 import type { BranchListResult, BranchRole } from "../types/branch";
 import type { ProjectSummary } from "../types/project";
@@ -110,6 +113,9 @@ export interface AuthUseCases {
   whoami(): Promise<AuthStateResult>;
   login(selection: LoginSelection): Promise<AuthStateResult>;
   logout(): Promise<AuthStateResult>;
+  listWorkspaces(): Promise<AuthWorkspaceListResult>;
+  useWorkspace(workspaceRef: string): Promise<AuthWorkspaceUseResult>;
+  logoutWorkspace(workspaceRef: string): Promise<AuthWorkspaceLogoutResult>;
   listProviders(): Promise<ProviderInfo[]>;
   resolveProvider(providerId: string): Promise<ProviderInfo>;
   listUsersForProvider(providerId: AuthProviderId): Promise<IdentityUser[]>;

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -2890,6 +2890,69 @@ describe("app controller", () => {
     });
   });
 
+  it("returns LOCAL_PROJECT_WORKSPACE_MISMATCH when deploy pin belongs to another workspace", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+    const listApps = vi.fn();
+    const deployApp = vi.fn();
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
+        withBranchDatabaseProviderDefaults({
+          resolveBranch: createResolveBranch(),
+          listApps,
+          deployApp,
+          listDeployments: vi.fn(),
+          showDeployment: vi.fn(),
+        }),
+      ),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import(
+      "./helpers"
+    );
+    const { runAppDeploy } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    await writeLocalPin(cwd, {
+      workspaceId: "ws_other",
+      projectId: "proj_123",
+    });
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      isTTY: false,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await expect(
+      runAppDeploy(context, undefined, {
+        framework: "hono",
+      }),
+    ).rejects.toMatchObject({
+      code: "LOCAL_PROJECT_WORKSPACE_MISMATCH",
+      domain: "project",
+      meta: {
+        pinPath: ".prisma/local.json",
+        pinnedWorkspaceId: "ws_other",
+        pinnedProjectId: "proj_123",
+        activeWorkspaceId: "ws_123",
+      },
+      nextSteps: [
+        "prisma-cli auth workspace use ws_other",
+        "prisma-cli project list",
+        "prisma-cli project link <id-or-name>",
+      ],
+    });
+    expect(listApps).not.toHaveBeenCalled();
+    expect(deployApp).not.toHaveBeenCalled();
+  });
+
   it("returns LOCAL_STATE_STALE when the pinned project is gone", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
     const listApps = vi.fn();

--- a/packages/cli/tests/auth-ops.test.ts
+++ b/packages/cli/tests/auth-ops.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 afterEach(() => {
@@ -18,6 +21,18 @@ function mockFileTokenStorage(getTokens: ReturnType<typeof vi.fn>) {
   return vi.fn().mockImplementation(function FileTokenStorageMock() {
     return { getTokens };
   });
+}
+
+async function createTempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "prisma-cli-auth-ops-"));
+}
+
+async function writeAuthFile(
+  authFilePath: string,
+  tokens: unknown[],
+): Promise<void> {
+  await fs.mkdir(path.dirname(authFilePath), { recursive: true });
+  await fs.writeFile(authFilePath, JSON.stringify({ tokens }, null, 2));
 }
 
 describe("readAuthState", () => {
@@ -83,6 +98,77 @@ describe("readAuthState", () => {
         name: null,
       },
     });
+  });
+
+  it("caches resolved workspace metadata in real token storage", async () => {
+    const tempDir = await createTempDir();
+    const authFilePath = path.join(tempDir, "auth.json");
+    await writeAuthFile(authFilePath, [
+      {
+        workspaceId: "cmmxlp7ae1251zyfs8mdpnavm",
+        token: encodeJwt({ sub: "user:usr_123" }),
+        refreshToken: "refresh-token",
+      },
+    ]);
+    const requireComputeAuth = vi.fn().mockResolvedValue({
+      GET: vi.fn().mockImplementation((pathName: string) => {
+        if (pathName === "/v1/me") {
+          return {
+            data: {
+              data: {
+                user: {
+                  id: "usr_123",
+                  email: "luan@example.com",
+                  name: "Luan",
+                },
+                workspace: {
+                  id: "wksp_cmmxlp7ae1251zyfs8mdpnavm",
+                  name: "Sandpit",
+                },
+                credential: {
+                  type: "oauth",
+                  id: null,
+                  name: null,
+                },
+              },
+            },
+          };
+        }
+
+        throw new Error(`Unexpected path ${pathName}`);
+      }),
+    });
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+
+    const { readAuthState } = await import("../src/lib/auth/auth-ops");
+    const { FileTokenStorage } = await import("../src/adapters/token-storage");
+
+    await expect(
+      readAuthState({
+        PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+      } as NodeJS.ProcessEnv),
+    ).resolves.toMatchObject({
+      authenticated: true,
+      workspace: {
+        id: "wksp_cmmxlp7ae1251zyfs8mdpnavm",
+        name: "Sandpit",
+      },
+    });
+
+    await expect(
+      new FileTokenStorage({
+        PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+      } as NodeJS.ProcessEnv).listWorkspaces(),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        credentialWorkspaceId: "cmmxlp7ae1251zyfs8mdpnavm",
+        id: "wksp_cmmxlp7ae1251zyfs8mdpnavm",
+        name: "Sandpit",
+      }),
+    ]);
   });
 
   it("normalizes the workspace id to the canonical API id and returns the user email", async () => {

--- a/packages/cli/tests/auth-real-mode.test.ts
+++ b/packages/cli/tests/auth-real-mode.test.ts
@@ -193,6 +193,86 @@ describe("real auth mode", () => {
     });
   });
 
+  it("lists cached OAuth workspaces while a service token is active", async () => {
+    const readAuthState = vi.fn().mockResolvedValue({
+      authenticated: true,
+      provider: null,
+      user: null,
+      workspace: {
+        id: "wksp_service",
+        name: "Service Workspace",
+      },
+      credential: {
+        type: "service_token",
+        id: "itgr_ci",
+        name: "ci-deploys-prod",
+      },
+    });
+
+    vi.doMock("../src/lib/auth/auth-ops", () => ({
+      performLogin: vi.fn(),
+      readAuthState,
+      performLogout: vi.fn(),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import(
+      "./helpers"
+    );
+    const { FileTokenStorage } = await import("../src/adapters/token-storage");
+    const { runAuthWorkspaceList } = await import("../src/controllers/auth");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const authFilePath = path.join(cwd, "auth.json");
+    const env = {
+      ...process.env,
+      PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+      PRISMA_SERVICE_TOKEN: "service-token",
+    };
+    const storage = new FileTokenStorage(env);
+    await storage.setTokens({
+      workspaceId: "cmmxworkspace1",
+      accessToken: "access-token-1",
+      refreshToken: "refresh-token-1",
+    });
+    await storage.rememberWorkspace("cmmxworkspace1", {
+      id: "wksp_cmmxworkspace1",
+      name: "Acme Inc",
+    });
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      env,
+    });
+
+    const result = await runAuthWorkspaceList(context);
+
+    expect(result.result).toMatchObject({
+      authSource: "service_token",
+      activeWorkspace: {
+        id: "wksp_service",
+        name: "Service Workspace",
+      },
+      workspaces: [
+        {
+          id: "wksp_service",
+          name: "Service Workspace",
+          active: true,
+          source: "service_token",
+          switchable: false,
+        },
+        {
+          id: "wksp_cmmxworkspace1",
+          name: "Acme Inc",
+          credentialWorkspaceId: "cmmxworkspace1",
+          active: false,
+          source: "oauth",
+          switchable: false,
+        },
+      ],
+    });
+  });
+
   it("omits empty provider and workspace rows in auth output", async () => {
     const { createTempCwd, createTestCommandContext } = await import(
       "./helpers"

--- a/packages/cli/tests/auth-usecases.test.ts
+++ b/packages/cli/tests/auth-usecases.test.ts
@@ -53,6 +53,26 @@ describe("auth use cases", () => {
     });
   });
 
+  it("switches workspace by name case-insensitively", async () => {
+    const { gateways, readState } = await createUseCaseGateways({
+      authSession: {
+        provider: "github",
+        userId: "usr_123",
+        workspaceId: "ws_123",
+      },
+    });
+    const useCases = createAuthUseCases(gateways);
+
+    await expect(useCases.useWorkspace("prisma labs")).resolves.toMatchObject({
+      workspace: {
+        id: "ws_456",
+        name: "Prisma Labs",
+      },
+    });
+
+    expect(readState().authSession?.workspaceId).toBe("ws_456");
+  });
+
   it("clears the session on logout", async () => {
     const { gateways, readState } = await createUseCaseGateways({
       authSession: {

--- a/packages/cli/tests/auth.test.ts
+++ b/packages/cli/tests/auth.test.ts
@@ -155,6 +155,21 @@ describe("auth commands", () => {
       },
     });
 
+    const humanList = await executeCli({
+      argv: ["auth", "workspace", "list"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+    const humanListOutput = stripAnsi(humanList.stderr);
+
+    expect(humanList.exitCode).toBe(0);
+    expect(humanList.stdout).toBe("");
+    expect(humanListOutput).toContain("auth source:  local OAuth");
+    expect(humanListOutput).toContain("name         id      status");
+    expect(humanListOutput).toContain("Acme Inc     ws_123  active");
+    expect(humanListOutput).toContain("Prisma Labs  ws_456");
+
     const use = await executeCli({
       argv: ["auth", "workspace", "use", "ws_456", "--json"],
       cwd,
@@ -187,6 +202,94 @@ describe("auth commands", () => {
     expect(JSON.parse(whoami.stdout).result.workspace).toEqual({
       id: "ws_456",
       name: "Prisma Labs",
+    });
+  });
+
+  it("interactively selects a mock workspace", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+
+    await executeCli({
+      argv: [
+        "auth",
+        "login",
+        "--provider",
+        "github",
+        "--user",
+        "usr_123",
+        "--workspace",
+        "ws_123",
+      ],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+
+    const result = await executeCli({
+      argv: ["auth", "workspace", "select"],
+      cwd,
+      stateDir,
+      fixturePath,
+      isTTY: true,
+      stdinText: "\u001B[B\r",
+    });
+    const stderr = stripAnsi(result.stderr);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("");
+    expect(stderr).toContain("Select a workspace");
+    expect(stderr).toContain("Prisma Labs (ws_456)");
+
+    const whoami = await executeCli({
+      argv: ["auth", "whoami", "--json"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+    expect(JSON.parse(whoami.stdout).result.workspace).toEqual({
+      id: "ws_456",
+      name: "Prisma Labs",
+    });
+  });
+
+  it("returns a usage error for non-interactive workspace select with multiple workspaces", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+
+    await executeCli({
+      argv: [
+        "auth",
+        "login",
+        "--provider",
+        "github",
+        "--user",
+        "usr_123",
+        "--workspace",
+        "ws_123",
+      ],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+
+    const result = await executeCli({
+      argv: ["auth", "workspace", "select", "--json"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: false,
+      command: "auth.workspace.select",
+      error: {
+        code: "USAGE_ERROR",
+        domain: "auth",
+        summary: "Interactive workspace selection unavailable",
+      },
+      nextSteps: ["prisma-cli auth workspace list"],
     });
   });
 

--- a/packages/cli/tests/auth.test.ts
+++ b/packages/cli/tests/auth.test.ts
@@ -314,6 +314,105 @@ describe("auth commands", () => {
     ]);
   });
 
+  it("logs out one real OAuth workspace while PRISMA_SERVICE_TOKEN is set", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const authFilePath = path.join(cwd, "auth.json");
+    await writeAuthFile(authFilePath, [
+      {
+        workspaceId: "cmmxworkspace1",
+        token: "access-token-1",
+        refreshToken: "refresh-token-1",
+      },
+      {
+        workspaceId: "cmmxworkspace2",
+        token: "access-token-2",
+        refreshToken: "refresh-token-2",
+      },
+    ]);
+    const storage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+    await storage.rememberWorkspace("cmmxworkspace1", {
+      id: "wksp_cmmxworkspace1",
+      name: "Acme Inc",
+    });
+    await storage.rememberWorkspace("cmmxworkspace2", {
+      id: "wksp_cmmxworkspace2",
+      name: "Prisma Labs",
+    });
+    await storage.useWorkspace("wksp_cmmxworkspace1");
+
+    const result = await executeCli({
+      argv: ["auth", "workspace", "logout", "wksp_cmmxworkspace2", "--json"],
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+        PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+        PRISMA_SERVICE_TOKEN: "service-token",
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: true,
+      command: "auth.workspace.logout",
+      result: {
+        workspace: {
+          id: "wksp_cmmxworkspace2",
+          name: "Prisma Labs",
+        },
+        wasActive: false,
+        activeWorkspace: {
+          id: "wksp_cmmxworkspace1",
+          name: "Acme Inc",
+        },
+      },
+    });
+    await expect(storage.getTokens()).resolves.toMatchObject({
+      workspaceId: "cmmxworkspace1",
+    });
+    await expect(storage.listWorkspaces()).resolves.toEqual([
+      expect.objectContaining({
+        credentialWorkspaceId: "cmmxworkspace1",
+        active: true,
+      }),
+    ]);
+  });
+
+  it("returns WORKSPACE_NOT_AUTHENTICATED for workspace logout when no cached workspace matches", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const authFilePath = path.join(cwd, "auth.json");
+
+    const result = await executeCli({
+      argv: ["auth", "workspace", "logout", "wksp_missing", "--json"],
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+        PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+        PRISMA_SERVICE_TOKEN: "service-token",
+      },
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: false,
+      command: "auth.workspace.logout",
+      error: {
+        code: "WORKSPACE_NOT_AUTHENTICATED",
+        domain: "auth",
+        meta: {
+          workspaceRef: "wksp_missing",
+        },
+      },
+    });
+  });
+
   it("supports auth logout --workspace as a shortcut for workspace logout", async () => {
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");
@@ -457,6 +556,60 @@ describe("auth commands", () => {
     expect(JSON.parse(result.stdout)).toMatchObject({
       ok: false,
       command: "auth.workspace.use",
+      error: {
+        code: "WORKSPACE_AMBIGUOUS",
+        domain: "auth",
+        meta: {
+          workspaceRef: "Acme Inc",
+        },
+      },
+    });
+  });
+
+  it("returns WORKSPACE_AMBIGUOUS for workspace logout when a cached workspace name is duplicated", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const authFilePath = path.join(cwd, "auth.json");
+    await writeAuthFile(authFilePath, [
+      {
+        workspaceId: "workspace-1",
+        token: "access-token-1",
+        refreshToken: "refresh-token-1",
+      },
+      {
+        workspaceId: "workspace-2",
+        token: "access-token-2",
+        refreshToken: "refresh-token-2",
+      },
+    ]);
+    const storage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+    await storage.rememberWorkspace("workspace-1", {
+      id: "wksp_workspace1",
+      name: "Acme Inc",
+    });
+    await storage.rememberWorkspace("workspace-2", {
+      id: "wksp_workspace2",
+      name: "Acme Inc",
+    });
+
+    const result = await executeCli({
+      argv: ["auth", "workspace", "logout", "Acme Inc", "--json"],
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+        PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+        PRISMA_SERVICE_TOKEN: undefined,
+      },
+    });
+
+    expect(result.exitCode).toBe(2);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: false,
+      command: "auth.workspace.logout",
       error: {
         code: "WORKSPACE_AMBIGUOUS",
         domain: "auth",

--- a/packages/cli/tests/auth.test.ts
+++ b/packages/cli/tests/auth.test.ts
@@ -1,10 +1,20 @@
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import stripAnsi from "strip-ansi";
 import { describe, expect, it } from "vitest";
 
+import { FileTokenStorage } from "../src/adapters/token-storage";
 import { createTempCwd, executeCli } from "./helpers";
 
 const fixturePath = path.resolve("fixtures/mock-api.json");
+
+async function writeAuthFile(
+  authFilePath: string,
+  tokens: unknown[],
+): Promise<void> {
+  await mkdir(path.dirname(authFilePath), { recursive: true });
+  await writeFile(authFilePath, JSON.stringify({ tokens }, null, 2));
+}
 
 describe("auth commands", () => {
   it("shows the signed-out empty state for whoami", async () => {
@@ -87,6 +97,426 @@ describe("auth commands", () => {
       warnings: [],
       nextSteps: [],
       nextActions: [],
+    });
+  });
+
+  it("lists and switches mock workspaces for the current session", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+
+    await executeCli({
+      argv: [
+        "auth",
+        "login",
+        "--provider",
+        "github",
+        "--user",
+        "usr_123",
+        "--workspace",
+        "ws_123",
+      ],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+
+    const list = await executeCli({
+      argv: ["auth", "workspace", "list", "--json"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+
+    expect(list.exitCode).toBe(0);
+    expect(JSON.parse(list.stdout)).toMatchObject({
+      ok: true,
+      command: "auth.workspace.list",
+      result: {
+        context: {
+          authSource: "oauth",
+          activeWorkspaceId: "ws_123",
+          activeWorkspaceName: "Acme Inc",
+        },
+        items: [
+          {
+            id: "ws_123",
+            name: "Acme Inc",
+            status: "active",
+            switchable: true,
+          },
+          {
+            id: "ws_456",
+            name: "Prisma Labs",
+            status: null,
+            switchable: true,
+          },
+        ],
+        count: 2,
+      },
+    });
+
+    const use = await executeCli({
+      argv: ["auth", "workspace", "use", "ws_456", "--json"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+
+    expect(use.exitCode).toBe(0);
+    expect(JSON.parse(use.stdout)).toMatchObject({
+      ok: true,
+      command: "auth.workspace.use",
+      result: {
+        previousWorkspace: {
+          id: "ws_123",
+          name: "Acme Inc",
+        },
+        workspace: {
+          id: "ws_456",
+          name: "Prisma Labs",
+        },
+      },
+    });
+
+    const whoami = await executeCli({
+      argv: ["auth", "whoami", "--json"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+    expect(JSON.parse(whoami.stdout).result.workspace).toEqual({
+      id: "ws_456",
+      name: "Prisma Labs",
+    });
+  });
+
+  it("switches real OAuth storage by canonical workspace id", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const authFilePath = path.join(cwd, "auth.json");
+    await writeAuthFile(authFilePath, [
+      {
+        workspaceId: "cmmxworkspace1",
+        token: "access-token-1",
+        refreshToken: "refresh-token-1",
+      },
+      {
+        workspaceId: "cmmxworkspace2",
+        token: "access-token-2",
+        refreshToken: "refresh-token-2",
+      },
+    ]);
+    const storage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+    await storage.rememberWorkspace("cmmxworkspace1", {
+      id: "wksp_cmmxworkspace1",
+      name: "Acme Inc",
+    });
+    await storage.rememberWorkspace("cmmxworkspace2", {
+      id: "wksp_cmmxworkspace2",
+      name: "Prisma Labs",
+    });
+    await storage.useWorkspace("wksp_cmmxworkspace1");
+
+    const result = await executeCli({
+      argv: ["auth", "workspace", "use", "wksp_cmmxworkspace2", "--json"],
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+        PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+        PRISMA_SERVICE_TOKEN: undefined,
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: true,
+      command: "auth.workspace.use",
+      result: {
+        previousWorkspace: {
+          id: "wksp_cmmxworkspace1",
+          name: "Acme Inc",
+        },
+        workspace: {
+          id: "wksp_cmmxworkspace2",
+          name: "Prisma Labs",
+        },
+      },
+    });
+    await expect(storage.getTokens()).resolves.toMatchObject({
+      workspaceId: "cmmxworkspace2",
+    });
+  });
+
+  it("logs out one real OAuth workspace by canonical workspace id", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const authFilePath = path.join(cwd, "auth.json");
+    await writeAuthFile(authFilePath, [
+      {
+        workspaceId: "cmmxworkspace1",
+        token: "access-token-1",
+        refreshToken: "refresh-token-1",
+      },
+      {
+        workspaceId: "cmmxworkspace2",
+        token: "access-token-2",
+        refreshToken: "refresh-token-2",
+      },
+    ]);
+    const storage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+    await storage.rememberWorkspace("cmmxworkspace1", {
+      id: "wksp_cmmxworkspace1",
+      name: "Acme Inc",
+    });
+    await storage.rememberWorkspace("cmmxworkspace2", {
+      id: "wksp_cmmxworkspace2",
+      name: "Prisma Labs",
+    });
+    await storage.useWorkspace("wksp_cmmxworkspace2");
+
+    const result = await executeCli({
+      argv: ["auth", "workspace", "logout", "wksp_cmmxworkspace2", "--json"],
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+        PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+        PRISMA_SERVICE_TOKEN: undefined,
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: true,
+      command: "auth.workspace.logout",
+      result: {
+        workspace: {
+          id: "wksp_cmmxworkspace2",
+          name: "Prisma Labs",
+        },
+        wasActive: true,
+        activeWorkspace: null,
+      },
+    });
+    await expect(storage.getTokens()).resolves.toBeNull();
+    await expect(storage.listWorkspaces()).resolves.toEqual([
+      expect.objectContaining({
+        credentialWorkspaceId: "cmmxworkspace1",
+        active: false,
+      }),
+    ]);
+  });
+
+  it("supports auth logout --workspace as a shortcut for workspace logout", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const authFilePath = path.join(cwd, "auth.json");
+    await writeAuthFile(authFilePath, [
+      {
+        workspaceId: "cmmxworkspace1",
+        token: "access-token-1",
+        refreshToken: "refresh-token-1",
+      },
+      {
+        workspaceId: "cmmxworkspace2",
+        token: "access-token-2",
+        refreshToken: "refresh-token-2",
+      },
+    ]);
+    const storage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+    await storage.rememberWorkspace("cmmxworkspace1", {
+      id: "wksp_cmmxworkspace1",
+      name: "Acme Inc",
+    });
+    await storage.rememberWorkspace("cmmxworkspace2", {
+      id: "wksp_cmmxworkspace2",
+      name: "Prisma Labs",
+    });
+    await storage.useWorkspace("wksp_cmmxworkspace1");
+
+    const result = await executeCli({
+      argv: ["auth", "logout", "--workspace", "wksp_cmmxworkspace2", "--json"],
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+        PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+        PRISMA_SERVICE_TOKEN: undefined,
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: true,
+      command: "auth.workspace.logout",
+      result: {
+        workspace: {
+          id: "wksp_cmmxworkspace2",
+          name: "Prisma Labs",
+        },
+        wasActive: false,
+        activeWorkspace: {
+          id: "wksp_cmmxworkspace1",
+          name: "Acme Inc",
+        },
+      },
+    });
+    await expect(storage.getTokens()).resolves.toMatchObject({
+      workspaceId: "cmmxworkspace1",
+    });
+    await expect(storage.listWorkspaces()).resolves.toEqual([
+      expect.objectContaining({
+        credentialWorkspaceId: "cmmxworkspace1",
+        active: true,
+      }),
+    ]);
+  });
+
+  it("returns WORKSPACE_NOT_AUTHENTICATED when no cached workspace matches", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const authFilePath = path.join(cwd, "auth.json");
+
+    const result = await executeCli({
+      argv: ["auth", "workspace", "use", "wksp_missing", "--json"],
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+        PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+        PRISMA_SERVICE_TOKEN: undefined,
+      },
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: false,
+      command: "auth.workspace.use",
+      error: {
+        code: "WORKSPACE_NOT_AUTHENTICATED",
+        domain: "auth",
+        meta: {
+          workspaceRef: "wksp_missing",
+        },
+      },
+    });
+  });
+
+  it("returns WORKSPACE_AMBIGUOUS when a cached workspace name is duplicated", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const authFilePath = path.join(cwd, "auth.json");
+    await writeAuthFile(authFilePath, [
+      {
+        workspaceId: "workspace-1",
+        token: "access-token-1",
+        refreshToken: "refresh-token-1",
+      },
+      {
+        workspaceId: "workspace-2",
+        token: "access-token-2",
+        refreshToken: "refresh-token-2",
+      },
+    ]);
+    const storage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+    await storage.rememberWorkspace("workspace-1", {
+      id: "wksp_workspace1",
+      name: "Acme Inc",
+    });
+    await storage.rememberWorkspace("workspace-2", {
+      id: "wksp_workspace2",
+      name: "Acme Inc",
+    });
+
+    const result = await executeCli({
+      argv: ["auth", "workspace", "use", "Acme Inc", "--json"],
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+        PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+        PRISMA_SERVICE_TOKEN: undefined,
+      },
+    });
+
+    expect(result.exitCode).toBe(2);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: false,
+      command: "auth.workspace.use",
+      error: {
+        code: "WORKSPACE_AMBIGUOUS",
+        domain: "auth",
+        meta: {
+          workspaceRef: "Acme Inc",
+        },
+      },
+    });
+  });
+
+  it("blocks workspace switching when PRISMA_SERVICE_TOKEN is set", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+
+    const result = await executeCli({
+      argv: ["auth", "workspace", "use", "wksp_123", "--json"],
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+        PRISMA_SERVICE_TOKEN: "service-token",
+      },
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: false,
+      command: "auth.workspace.use",
+      error: {
+        code: "WORKSPACE_SWITCH_UNAVAILABLE",
+        domain: "auth",
+      },
+    });
+  });
+
+  it("returns a structured auth config error when PRISMA_SERVICE_TOKEN is empty", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+
+    const result = await executeCli({
+      argv: ["auth", "whoami", "--json"],
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+        PRISMA_SERVICE_TOKEN: "  ",
+      },
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: false,
+      command: "auth.whoami",
+      error: {
+        code: "AUTH_CONFIG_INVALID",
+        domain: "auth",
+      },
     });
   });
 

--- a/packages/cli/tests/project.test.ts
+++ b/packages/cli/tests/project.test.ts
@@ -566,7 +566,7 @@ describe("project commands", () => {
         },
       },
       nextSteps: [
-        "prisma-cli auth login",
+        "prisma-cli auth workspace use ws_other",
         "prisma-cli project list",
         "prisma-cli project link <id-or-name>",
       ],

--- a/packages/cli/tests/token-storage.test.ts
+++ b/packages/cli/tests/token-storage.test.ts
@@ -3,7 +3,10 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { FileTokenStorage } from "../src/adapters/token-storage";
+import {
+  FileTokenStorage,
+  getAuthContextFilePath,
+} from "../src/adapters/token-storage";
 import { createTempCwd } from "./helpers";
 
 async function writeAuthFile(
@@ -15,6 +18,376 @@ async function writeAuthFile(
 }
 
 describe("FileTokenStorage", () => {
+  it("migrates an existing single-workspace auth file to an active workspace context", async () => {
+    const cwd = await createTempCwd();
+    const authFilePath = path.join(cwd, "auth.json");
+    await writeAuthFile(authFilePath, [
+      {
+        workspaceId: "workspace-1",
+        token: "access-token",
+        refreshToken: "refresh-token",
+      },
+    ]);
+
+    const storage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+
+    await expect(storage.getTokens()).resolves.toEqual({
+      workspaceId: "workspace-1",
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+    });
+
+    await expect(
+      fs
+        .readFile(getAuthContextFilePath(authFilePath), "utf8")
+        .then(JSON.parse),
+    ).resolves.toMatchObject({
+      activeWorkspaceId: "workspace-1",
+    });
+  });
+
+  it("uses the active workspace context instead of the latest stored credential", async () => {
+    const cwd = await createTempCwd();
+    const authFilePath = path.join(cwd, "auth.json");
+    await writeAuthFile(authFilePath, [
+      {
+        workspaceId: "workspace-1",
+        token: "access-token-1",
+        refreshToken: "refresh-token-1",
+      },
+      {
+        workspaceId: "workspace-2",
+        token: "access-token-2",
+        refreshToken: "refresh-token-2",
+      },
+    ]);
+
+    const storage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+
+    await storage.useWorkspace("workspace-1");
+
+    await expect(storage.getTokens()).resolves.toEqual({
+      workspaceId: "workspace-1",
+      accessToken: "access-token-1",
+      refreshToken: "refresh-token-1",
+    });
+  });
+
+  it("does not reactivate another workspace when refresh stores updated tokens", async () => {
+    const cwd = await createTempCwd();
+    const authFilePath = path.join(cwd, "auth.json");
+    const env = {
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv;
+    await writeAuthFile(authFilePath, [
+      {
+        workspaceId: "workspace-1",
+        token: "access-token-1",
+        refreshToken: "refresh-token-1",
+      },
+      {
+        workspaceId: "workspace-2",
+        token: "access-token-2",
+        refreshToken: "refresh-token-2",
+      },
+    ]);
+
+    const storage = new FileTokenStorage(env);
+    await storage.useWorkspace("workspace-2");
+
+    const refreshStorage = new FileTokenStorage(env, undefined, {
+      activateOnSetTokens: false,
+    });
+    await refreshStorage.setTokens({
+      workspaceId: "workspace-1",
+      accessToken: "new-access-token-1",
+      refreshToken: "new-refresh-token-1",
+    });
+
+    await expect(storage.getTokens()).resolves.toEqual({
+      workspaceId: "workspace-2",
+      accessToken: "access-token-2",
+      refreshToken: "refresh-token-2",
+    });
+    await expect(storage.listWorkspaces()).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          credentialWorkspaceId: "workspace-1",
+          active: false,
+        }),
+        expect.objectContaining({
+          credentialWorkspaceId: "workspace-2",
+          active: true,
+        }),
+      ]),
+    );
+  });
+
+  it("keeps a workspace switch ordered after an in-flight refresh write", async () => {
+    const cwd = await createTempCwd();
+    const authFilePath = path.join(cwd, "auth.json");
+    const env = {
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv;
+    await writeAuthFile(authFilePath, [
+      {
+        workspaceId: "workspace-1",
+        token: "access-token-1",
+        refreshToken: "refresh-token-1",
+      },
+      {
+        workspaceId: "workspace-2",
+        token: "access-token-2",
+        refreshToken: "refresh-token-2",
+      },
+    ]);
+
+    const switchStorage = new FileTokenStorage(env);
+    await switchStorage.useWorkspace("workspace-1");
+
+    const refreshStorage = new FileTokenStorage(env, undefined, {
+      activateOnSetTokens: false,
+      lockSetTokens: false,
+    });
+    let releaseRefresh!: () => void;
+    let markRefreshStarted!: () => void;
+    const refreshReleased = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+    const refreshStarted = new Promise<void>((resolve) => {
+      markRefreshStarted = resolve;
+    });
+
+    const refresh = refreshStorage.withRefreshLock(async () => {
+      await refreshStorage.setTokens({
+        workspaceId: "workspace-1",
+        accessToken: "new-access-token-1",
+        refreshToken: "new-refresh-token-1",
+      });
+      markRefreshStarted();
+      await refreshReleased;
+    });
+    await refreshStarted;
+
+    const switchWorkspace = switchStorage.useWorkspace("workspace-2");
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    await expect(switchStorage.getTokens()).resolves.toEqual({
+      workspaceId: "workspace-1",
+      accessToken: "new-access-token-1",
+      refreshToken: "new-refresh-token-1",
+    });
+
+    releaseRefresh();
+    await Promise.all([refresh, switchWorkspace]);
+
+    await expect(switchStorage.getTokens()).resolves.toEqual({
+      workspaceId: "workspace-2",
+      accessToken: "access-token-2",
+      refreshToken: "refresh-token-2",
+    });
+  });
+
+  it("switches by cached canonical workspace id", async () => {
+    const cwd = await createTempCwd();
+    const authFilePath = path.join(cwd, "auth.json");
+    await writeAuthFile(authFilePath, [
+      {
+        workspaceId: "cmmxworkspace1",
+        token: "access-token-1",
+        refreshToken: "refresh-token-1",
+      },
+      {
+        workspaceId: "cmmxworkspace2",
+        token: "access-token-2",
+        refreshToken: "refresh-token-2",
+      },
+    ]);
+
+    const storage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+
+    await storage.rememberWorkspace("cmmxworkspace2", {
+      id: "wksp_cmmxworkspace2",
+      name: "Acme Inc",
+    });
+    await storage.useWorkspace("wksp_cmmxworkspace2");
+
+    await expect(storage.getTokens()).resolves.toMatchObject({
+      workspaceId: "cmmxworkspace2",
+    });
+  });
+
+  it("clears every stored workspace token on logout", async () => {
+    const cwd = await createTempCwd();
+    const authFilePath = path.join(cwd, "auth.json");
+    await writeAuthFile(authFilePath, [
+      {
+        workspaceId: "workspace-1",
+        token: "access-token-1",
+        refreshToken: "refresh-token-1",
+      },
+      {
+        workspaceId: "workspace-2",
+        token: "access-token-2",
+        refreshToken: "refresh-token-2",
+      },
+    ]);
+
+    const storage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+
+    await storage.clearTokens();
+
+    await expect(storage.getTokens()).resolves.toBeNull();
+    await expect(
+      fs.readFile(authFilePath, "utf8").then(JSON.parse),
+    ).resolves.toEqual({ tokens: [] });
+    await expect(
+      fs.stat(getAuthContextFilePath(authFilePath)),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("logs out an inactive workspace without changing the active workspace", async () => {
+    const cwd = await createTempCwd();
+    const authFilePath = path.join(cwd, "auth.json");
+    await writeAuthFile(authFilePath, [
+      {
+        workspaceId: "workspace-1",
+        token: "access-token-1",
+        refreshToken: "refresh-token-1",
+      },
+      {
+        workspaceId: "workspace-2",
+        token: "access-token-2",
+        refreshToken: "refresh-token-2",
+      },
+    ]);
+
+    const storage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+    await storage.useWorkspace("workspace-1");
+
+    await expect(storage.logoutWorkspace("workspace-2")).resolves.toEqual({
+      workspace: expect.objectContaining({
+        credentialWorkspaceId: "workspace-2",
+      }),
+      wasActive: false,
+      activeWorkspace: expect.objectContaining({
+        credentialWorkspaceId: "workspace-1",
+      }),
+    });
+
+    await expect(storage.getTokens()).resolves.toEqual({
+      workspaceId: "workspace-1",
+      accessToken: "access-token-1",
+      refreshToken: "refresh-token-1",
+    });
+    await expect(
+      fs.readFile(authFilePath, "utf8").then(JSON.parse),
+    ).resolves.toEqual({
+      tokens: [
+        {
+          workspaceId: "workspace-1",
+          token: "access-token-1",
+          refreshToken: "refresh-token-1",
+        },
+      ],
+    });
+  });
+
+  it("logs out the active workspace without falling through to another workspace", async () => {
+    const cwd = await createTempCwd();
+    const authFilePath = path.join(cwd, "auth.json");
+    await writeAuthFile(authFilePath, [
+      {
+        workspaceId: "workspace-1",
+        token: "access-token-1",
+        refreshToken: "refresh-token-1",
+      },
+      {
+        workspaceId: "workspace-2",
+        token: "access-token-2",
+        refreshToken: "refresh-token-2",
+      },
+    ]);
+
+    const storage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+    await storage.useWorkspace("workspace-2");
+
+    await expect(storage.logoutWorkspace("workspace-2")).resolves.toEqual({
+      workspace: expect.objectContaining({
+        credentialWorkspaceId: "workspace-2",
+      }),
+      wasActive: true,
+      activeWorkspace: null,
+    });
+
+    await expect(storage.getTokens()).resolves.toBeNull();
+    await expect(storage.listWorkspaces()).resolves.toEqual([
+      expect.objectContaining({
+        credentialWorkspaceId: "workspace-1",
+        active: false,
+      }),
+    ]);
+  });
+
+  it("clears only the active matching workspace when refresh invalidation wins the race", async () => {
+    const cwd = await createTempCwd();
+    const authFilePath = path.join(cwd, "auth.json");
+    await writeAuthFile(authFilePath, [
+      {
+        workspaceId: "workspace-1",
+        token: "access-token-1",
+        refreshToken: "refresh-token-1",
+      },
+      {
+        workspaceId: "workspace-2",
+        token: "access-token-2",
+        refreshToken: "refresh-token-2",
+      },
+    ]);
+
+    const storage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+    await storage.useWorkspace("workspace-2");
+
+    await storage.clearTokensIfCurrent({
+      workspaceId: "workspace-2",
+      accessToken: "access-token-2",
+      refreshToken: "refresh-token-2",
+    });
+
+    await expect(
+      fs.readFile(authFilePath, "utf8").then(JSON.parse),
+    ).resolves.toEqual({
+      tokens: [
+        {
+          workspaceId: "workspace-1",
+          token: "access-token-1",
+          refreshToken: "refresh-token-1",
+        },
+      ],
+    });
+    await expect(storage.getTokens()).resolves.toBeNull();
+    await expect(storage.listWorkspaces()).resolves.toEqual([
+      expect.objectContaining({
+        credentialWorkspaceId: "workspace-1",
+        active: false,
+      }),
+    ]);
+  });
+
   it("clears tokens only when they still match the caller's stale view", async () => {
     const cwd = await createTempCwd();
     const authFilePath = path.join(cwd, "auth.json");

--- a/packages/cli/tests/token-storage.test.ts
+++ b/packages/cli/tests/token-storage.test.ts
@@ -113,6 +113,21 @@ describe("FileTokenStorage", () => {
     });
   });
 
+  it("propagates unexpected auth context read errors", async () => {
+    const cwd = await createTempCwd();
+    const authFilePath = path.join(cwd, "auth.json");
+    await writeAuthFile(authFilePath, []);
+    await fs.mkdir(getAuthContextFilePath(authFilePath), { recursive: true });
+
+    const storage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+
+    await expect(storage.listWorkspaces()).rejects.toMatchObject({
+      code: expect.any(String),
+    });
+  });
+
   it("does not reactivate another workspace when refresh stores updated tokens", async () => {
     const cwd = await createTempCwd();
     const authFilePath = path.join(cwd, "auth.json");
@@ -253,6 +268,37 @@ describe("FileTokenStorage", () => {
       name: "Acme Inc",
     });
     await storage.useWorkspace("wksp_cmmxworkspace2");
+
+    await expect(storage.getTokens()).resolves.toMatchObject({
+      workspaceId: "cmmxworkspace2",
+    });
+  });
+
+  it("switches by cached workspace name case-insensitively", async () => {
+    const cwd = await createTempCwd();
+    const authFilePath = path.join(cwd, "auth.json");
+    await writeAuthFile(authFilePath, [
+      {
+        workspaceId: "cmmxworkspace1",
+        token: "access-token-1",
+        refreshToken: "refresh-token-1",
+      },
+      {
+        workspaceId: "cmmxworkspace2",
+        token: "access-token-2",
+        refreshToken: "refresh-token-2",
+      },
+    ]);
+
+    const storage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+
+    await storage.rememberWorkspace("cmmxworkspace2", {
+      id: "wksp_cmmxworkspace2",
+      name: "Acme Inc",
+    });
+    await storage.useWorkspace("acme inc");
 
     await expect(storage.getTokens()).resolves.toMatchObject({
       workspaceId: "cmmxworkspace2",

--- a/packages/cli/tests/token-storage.test.ts
+++ b/packages/cli/tests/token-storage.test.ts
@@ -336,6 +336,63 @@ describe("FileTokenStorage", () => {
     ).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("orders full logout after in-flight refresh work", async () => {
+    const cwd = await createTempCwd();
+    const authFilePath = path.join(cwd, "auth.json");
+    await writeAuthFile(authFilePath, [
+      {
+        workspaceId: "workspace-1",
+        token: "access-token-1",
+        refreshToken: "refresh-token-1",
+      },
+    ]);
+
+    const env = {
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv;
+    const refreshStorage = new FileTokenStorage(env);
+    const logoutStorage = new FileTokenStorage(env);
+    let releaseRefresh!: () => void;
+    let markRefreshStarted!: () => void;
+    const refreshStarted = new Promise<void>((resolve) => {
+      markRefreshStarted = resolve;
+    });
+    const refreshReleased = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+
+    const refresh = refreshStorage.withRefreshLock(async () => {
+      markRefreshStarted();
+      await refreshReleased;
+    });
+    await refreshStarted;
+
+    const logout = logoutStorage.clearTokens();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    await expect(
+      fs.readFile(authFilePath, "utf8").then(JSON.parse),
+    ).resolves.toEqual({
+      tokens: [
+        {
+          workspaceId: "workspace-1",
+          token: "access-token-1",
+          refreshToken: "refresh-token-1",
+        },
+      ],
+    });
+
+    releaseRefresh();
+    await Promise.all([refresh, logout]);
+
+    await expect(
+      fs.readFile(authFilePath, "utf8").then(JSON.parse),
+    ).resolves.toEqual({ tokens: [] });
+    await expect(
+      fs.stat(getAuthContextFilePath(authFilePath)),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("logs out an inactive workspace without changing the active workspace", async () => {
     const cwd = await createTempCwd();
     const authFilePath = path.join(cwd, "auth.json");

--- a/packages/cli/tests/token-storage.test.ts
+++ b/packages/cli/tests/token-storage.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
   FileTokenStorage,
   getAuthContextFilePath,
+  RefreshLockTimeoutError,
 } from "../src/adapters/token-storage";
 import { createTempCwd } from "./helpers";
 
@@ -74,6 +75,41 @@ describe("FileTokenStorage", () => {
       workspaceId: "workspace-1",
       accessToken: "access-token-1",
       refreshToken: "refresh-token-1",
+    });
+  });
+
+  it("recovers from a malformed auth context file by migrating to the latest valid credential", async () => {
+    const cwd = await createTempCwd();
+    const authFilePath = path.join(cwd, "auth.json");
+    await writeAuthFile(authFilePath, [
+      {
+        workspaceId: "workspace-1",
+        token: "access-token-1",
+        refreshToken: "refresh-token-1",
+      },
+      {
+        workspaceId: "workspace-2",
+        token: "access-token-2",
+        refreshToken: "refresh-token-2",
+      },
+    ]);
+    await fs.writeFile(getAuthContextFilePath(authFilePath), "{ nope");
+
+    const storage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+
+    await expect(storage.getTokens()).resolves.toEqual({
+      workspaceId: "workspace-2",
+      accessToken: "access-token-2",
+      refreshToken: "refresh-token-2",
+    });
+    await expect(
+      fs
+        .readFile(getAuthContextFilePath(authFilePath), "utf8")
+        .then(JSON.parse),
+    ).resolves.toMatchObject({
+      activeWorkspaceId: "workspace-2",
     });
   });
 
@@ -174,7 +210,7 @@ describe("FileTokenStorage", () => {
     await refreshStarted;
 
     const switchWorkspace = switchStorage.useWorkspace("workspace-2");
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await new Promise((resolve) => setImmediate(resolve));
 
     await expect(switchStorage.getTokens()).resolves.toEqual({
       workspaceId: "workspace-1",
@@ -301,6 +337,61 @@ describe("FileTokenStorage", () => {
         },
       ],
     });
+  });
+
+  it("logs out one of three workspaces without changing the surviving active workspace", async () => {
+    const cwd = await createTempCwd();
+    const authFilePath = path.join(cwd, "auth.json");
+    await writeAuthFile(authFilePath, [
+      {
+        workspaceId: "workspace-1",
+        token: "access-token-1",
+        refreshToken: "refresh-token-1",
+      },
+      {
+        workspaceId: "workspace-2",
+        token: "access-token-2",
+        refreshToken: "refresh-token-2",
+      },
+      {
+        workspaceId: "workspace-3",
+        token: "access-token-3",
+        refreshToken: "refresh-token-3",
+      },
+    ]);
+
+    const storage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+    await storage.useWorkspace("workspace-2");
+
+    await expect(storage.logoutWorkspace("workspace-1")).resolves.toEqual({
+      workspace: expect.objectContaining({
+        credentialWorkspaceId: "workspace-1",
+      }),
+      wasActive: false,
+      activeWorkspace: expect.objectContaining({
+        credentialWorkspaceId: "workspace-2",
+      }),
+    });
+
+    await expect(storage.getTokens()).resolves.toEqual({
+      workspaceId: "workspace-2",
+      accessToken: "access-token-2",
+      refreshToken: "refresh-token-2",
+    });
+    await expect(storage.listWorkspaces()).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          credentialWorkspaceId: "workspace-2",
+          active: true,
+        }),
+        expect.objectContaining({
+          credentialWorkspaceId: "workspace-3",
+          active: false,
+        }),
+      ]),
+    );
   });
 
   it("logs out the active workspace without falling through to another workspace", async () => {
@@ -450,7 +541,7 @@ describe("FileTokenStorage", () => {
       events.push("second:end");
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await new Promise((resolve) => setImmediate(resolve));
     expect(events).toEqual(["first:start"]);
 
     releaseFirst();
@@ -500,6 +591,46 @@ describe("FileTokenStorage", () => {
     controller.abort(reason);
 
     await expect(second).rejects.toBe(reason);
+    releaseFirst();
+    await first;
+  });
+
+  it("fails loudly when waiting for the refresh lock times out", async () => {
+    const cwd = await createTempCwd();
+    const authFilePath = path.join(cwd, "auth.json");
+    const firstStorage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+    const secondStorage = new FileTokenStorage(
+      {
+        PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+      } as NodeJS.ProcessEnv,
+      undefined,
+      {
+        lockRetryMs: 1,
+        lockStaleMs: 10_000,
+        lockWaitTimeoutMs: 5,
+      },
+    );
+    let releaseFirst!: () => void;
+    const firstReleased = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let markFirstStarted!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+
+    const first = firstStorage.withRefreshLock(async () => {
+      markFirstStarted();
+      await firstReleased;
+    });
+    await firstStarted;
+
+    await expect(
+      secondStorage.withRefreshLock(async () => undefined),
+    ).rejects.toBeInstanceOf(RefreshLockTimeoutError);
+
     releaseFirst();
     await first;
   });


### PR DESCRIPTION
## Summary
- add local multi-workspace OAuth session support with active workspace selection
- add auth workspace list/use/logout commands plus auth logout --workspace shortcut
- keep service-token precedence explicit while showing cached OAuth workspaces
- improve project mismatch guidance to switch workspaces instead of re-login

## Verification
- pnpm --filter @prisma/cli test -- auth.test.ts auth-real-mode.test.ts token-storage.test.ts
- pnpm --filter @prisma/cli exec tsc --noEmit
- pnpm --recursive exec tsc --noEmit
- pnpm lint
- git diff --check