### PR TITLE
feat(auth): merge workspace picker into use

### DIFF
--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -456,16 +456,20 @@ prisma-cli auth workspace list
 prisma-cli auth workspace list --json
 ```
 
-## `prisma-cli auth workspace use <id-or-name>`
+## `prisma-cli auth workspace use [id-or-name]`
 
 Purpose:
 
-- switch the local CLI workspace
+- switch or interactively select the local CLI workspace
 
 Behavior:
 
-- requires a stored OAuth session for the target workspace
-- accepts the cached workspace id, credential workspace id, or cached workspace name case-insensitively
+- with `[id-or-name]`, requires a stored OAuth session for the target workspace
+- with `[id-or-name]`, accepts the cached workspace id, credential workspace id, or cached workspace name case-insensitively
+- without `[id-or-name]`, lists locally authenticated OAuth workspaces in an interactive picker when prompting is available
+- without `[id-or-name]`, shows the workspace name and workspace id for each interactive choice
+- without `[id-or-name]`, selects the only local OAuth workspace without prompting when exactly one is available
+- without `[id-or-name]`, fails in non-interactive mode when more than one local OAuth workspace is available
 - changes local CLI context only; it does not mutate a remote resource
 - fails with `WORKSPACE_SWITCH_UNAVAILABLE` when `PRISMA_SERVICE_TOKEN` is set
 - fails with `WORKSPACE_NOT_AUTHENTICATED` when no cached OAuth session matches
@@ -474,29 +478,9 @@ Behavior:
 Examples:
 
 ```bash
+prisma-cli auth workspace use
 prisma-cli auth workspace use wksp_123
 prisma-cli auth workspace use "Acme Inc"
-```
-
-## `prisma-cli auth workspace select`
-
-Purpose:
-
-- interactively switch the local CLI workspace
-
-Behavior:
-
-- lists locally authenticated OAuth workspaces in an interactive picker
-- shows the workspace name and workspace id for each choice
-- changes local CLI context only; it does not mutate a remote resource
-- fails with `WORKSPACE_SWITCH_UNAVAILABLE` when `PRISMA_SERVICE_TOKEN` is set
-- when exactly one local OAuth workspace is available, selects it without prompting
-- fails in non-interactive mode when more than one local OAuth workspace is available
-
-Examples:
-
-```bash
-prisma-cli auth workspace select
 ```
 
 ## `prisma-cli auth workspace logout <id-or-name>`

--- a/packages/cli/src/commands/auth/index.ts
+++ b/packages/cli/src/commands/auth/index.ts
@@ -8,7 +8,6 @@ import {
   runAuthWhoAmI,
   runAuthWorkspaceList,
   runAuthWorkspaceLogout,
-  runAuthWorkspaceSelect,
   runAuthWorkspaceUse,
 } from "../../controllers/auth";
 import {
@@ -160,7 +159,6 @@ function createAuthWorkspaceCommand(runtime: CliRuntime): Command {
 
   workspace.addCommand(createAuthWorkspaceListCommand(runtime));
   workspace.addCommand(createAuthWorkspaceUseCommand(runtime));
-  workspace.addCommand(createAuthWorkspaceSelectCommand(runtime));
   workspace.addCommand(createAuthWorkspaceLogoutCommand(runtime));
 
   return workspace;
@@ -184,31 +182,6 @@ function createAuthWorkspaceListCommand(runtime: CliRuntime): Command {
         renderHuman: (context, descriptor, result) =>
           renderAuthWorkspaceList(context, descriptor, result),
         renderJson: (result) => serializeAuthWorkspaceList(result),
-      },
-    );
-  });
-
-  return command;
-}
-
-function createAuthWorkspaceSelectCommand(runtime: CliRuntime): Command {
-  const command = attachCommandDescriptor(
-    configureRuntimeCommand(new Command("select"), runtime),
-    "auth.workspace.select",
-  );
-
-  addGlobalFlags(command);
-
-  command.action(async (options) => {
-    await runCommand<AuthWorkspaceUseResult>(
-      runtime,
-      "auth.workspace.select",
-      options as Record<string, unknown>,
-      (context) => runAuthWorkspaceSelect(context),
-      {
-        renderHuman: (context, descriptor, result) =>
-          renderAuthWorkspaceUse(context, descriptor, result),
-        renderJson: (result) => serializeAuthWorkspaceUse(result),
       },
     );
   });
@@ -252,7 +225,7 @@ function createAuthWorkspaceUseCommand(runtime: CliRuntime): Command {
     "auth.workspace.use",
   );
 
-  command.argument("<id-or-name>", "Workspace id or exact name");
+  command.argument("[id-or-name]", "Workspace id or exact name");
   addGlobalFlags(command);
 
   command.action(async (workspaceRef, options) => {

--- a/packages/cli/src/controllers/auth.ts
+++ b/packages/cli/src/controllers/auth.ts
@@ -123,20 +123,15 @@ export async function runAuthWorkspaceUse(
   context: CommandContext,
   workspaceRef: string | undefined,
 ): Promise<CommandSuccess<AuthWorkspaceUseResult>> {
-  if (!workspaceRef?.trim()) {
-    throw usageError(
-      "Workspace required",
-      "auth workspace use needs a workspace id or cached workspace name.",
-      "Pass a workspace from prisma-cli auth workspace list.",
-      ["prisma-cli auth workspace list"],
-      "auth",
-    );
-  }
+  const trimmedWorkspaceRef = workspaceRef?.trim();
+  const selectedWorkspaceRef = trimmedWorkspaceRef
+    ? trimmedWorkspaceRef
+    : await selectWorkspaceSession(context);
 
   const result = isRealMode(context)
-    ? await useRealAuthWorkspace(context, workspaceRef)
+    ? await useRealAuthWorkspace(context, selectedWorkspaceRef)
     : await createAuthUseCases(createCliUseCaseGateways(context)).useWorkspace(
-        workspaceRef,
+        selectedWorkspaceRef,
       );
 
   return {
@@ -144,17 +139,6 @@ export async function runAuthWorkspaceUse(
     result,
     warnings: [],
     nextSteps: ["prisma-cli auth whoami", "prisma-cli project list"],
-  };
-}
-
-export async function runAuthWorkspaceSelect(
-  context: CommandContext,
-): Promise<CommandSuccess<AuthWorkspaceUseResult>> {
-  const workspaceRef = await selectWorkspaceSession(context);
-  const success = await runAuthWorkspaceUse(context, workspaceRef);
-  return {
-    ...success,
-    command: "auth.workspace.select",
   };
 }
 
@@ -396,7 +380,7 @@ async function selectWorkspaceSession(
   if (!canPrompt(context)) {
     throw usageError(
       "Interactive workspace selection unavailable",
-      "auth workspace select needs an interactive terminal when more than one workspace is available.",
+      "auth workspace use needs an interactive terminal when no workspace is provided and more than one workspace is available.",
       "Run prisma-cli auth workspace use <id-or-name> with a workspace from prisma-cli auth workspace list.",
       ["prisma-cli auth workspace list"],
       "auth",

--- a/packages/cli/src/shell/command-meta.ts
+++ b/packages/cli/src/shell/command-meta.ts
@@ -56,7 +56,7 @@ const DESCRIPTORS: CommandDescriptor[] = [
     description: "Manage local authenticated workspaces",
     examples: [
       "prisma-cli auth workspace list",
-      "prisma-cli auth workspace select",
+      "prisma-cli auth workspace use",
       "prisma-cli auth workspace use wksp_123",
       "prisma-cli auth workspace logout wksp_123",
     ],
@@ -75,15 +75,10 @@ const DESCRIPTORS: CommandDescriptor[] = [
     path: ["prisma", "auth", "workspace", "use"],
     description: "Switch the local CLI workspace",
     examples: [
+      "prisma-cli auth workspace use",
       "prisma-cli auth workspace use wksp_123",
       'prisma-cli auth workspace use "Acme Inc"',
     ],
-  },
-  {
-    id: "auth.workspace.select",
-    path: ["prisma", "auth", "workspace", "select"],
-    description: "Interactively select the local CLI workspace",
-    examples: ["prisma-cli auth workspace select"],
   },
   {
     id: "auth.workspace.logout",

--- a/packages/cli/tests/auth.test.ts
+++ b/packages/cli/tests/auth.test.ts
@@ -205,7 +205,7 @@ describe("auth commands", () => {
     });
   });
 
-  it("interactively selects a mock workspace", async () => {
+  it("trims an explicit workspace ref before switching", async () => {
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");
 
@@ -226,7 +226,51 @@ describe("auth commands", () => {
     });
 
     const result = await executeCli({
-      argv: ["auth", "workspace", "select"],
+      argv: ["auth", "workspace", "use", " ws_456 ", "--json"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: true,
+      command: "auth.workspace.use",
+      result: {
+        previousWorkspace: {
+          id: "ws_123",
+          name: "Acme Inc",
+        },
+        workspace: {
+          id: "ws_456",
+          name: "Prisma Labs",
+        },
+      },
+    });
+  });
+
+  it("interactively selects a mock workspace with no workspace argument", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+
+    await executeCli({
+      argv: [
+        "auth",
+        "login",
+        "--provider",
+        "github",
+        "--user",
+        "usr_123",
+        "--workspace",
+        "ws_123",
+      ],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+
+    const result = await executeCli({
+      argv: ["auth", "workspace", "use"],
       cwd,
       stateDir,
       fixturePath,
@@ -252,7 +296,7 @@ describe("auth commands", () => {
     });
   });
 
-  it("returns a usage error for non-interactive workspace select with multiple workspaces", async () => {
+  it("returns a usage error for non-interactive workspace use without an argument when multiple workspaces exist", async () => {
     const cwd = await createTempCwd();
     const stateDir = path.join(cwd, ".state");
 
@@ -273,7 +317,7 @@ describe("auth commands", () => {
     });
 
     const result = await executeCli({
-      argv: ["auth", "workspace", "select", "--json"],
+      argv: ["auth", "workspace", "use", "--json"],
       cwd,
       stateDir,
       fixturePath,
@@ -283,13 +327,58 @@ describe("auth commands", () => {
     expect(result.stderr).toBe("");
     expect(JSON.parse(result.stdout)).toMatchObject({
       ok: false,
-      command: "auth.workspace.select",
+      command: "auth.workspace.use",
       error: {
         code: "USAGE_ERROR",
         domain: "auth",
         summary: "Interactive workspace selection unavailable",
       },
       nextSteps: ["prisma-cli auth workspace list"],
+    });
+  });
+
+  it("selects the only mock workspace without prompting when no workspace argument is provided", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+
+    await executeCli({
+      argv: [
+        "auth",
+        "login",
+        "--provider",
+        "github",
+        "--user",
+        "usr_456",
+        "--workspace",
+        "ws_123",
+      ],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+
+    const result = await executeCli({
+      argv: ["auth", "workspace", "use", "--json"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: true,
+      command: "auth.workspace.use",
+      result: {
+        previousWorkspace: {
+          id: "ws_123",
+          name: "Acme Inc",
+        },
+        workspace: {
+          id: "ws_123",
+          name: "Acme Inc",
+        },
+      },
     });
   });
 
@@ -351,6 +440,55 @@ describe("auth commands", () => {
     });
     await expect(storage.getTokens()).resolves.toMatchObject({
       workspaceId: "cmmxworkspace2",
+    });
+  });
+
+  it("selects the only real OAuth workspace without prompting when no workspace argument is provided", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const authFilePath = path.join(cwd, "auth.json");
+    await writeAuthFile(authFilePath, [
+      {
+        workspaceId: "cmmxworkspace1",
+        token: "access-token-1",
+        refreshToken: "refresh-token-1",
+      },
+    ]);
+    const storage = new FileTokenStorage({
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+    } as NodeJS.ProcessEnv);
+    await storage.rememberWorkspace("cmmxworkspace1", {
+      id: "wksp_cmmxworkspace1",
+      name: "Acme Inc",
+    });
+
+    const result = await executeCli({
+      argv: ["auth", "workspace", "use", "--json"],
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+        PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+        PRISMA_SERVICE_TOKEN: undefined,
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: true,
+      command: "auth.workspace.use",
+      result: {
+        previousWorkspace: null,
+        workspace: {
+          id: "wksp_cmmxworkspace1",
+          name: "Acme Inc",
+        },
+      },
+    });
+    await expect(storage.getTokens()).resolves.toMatchObject({
+      workspaceId: "cmmxworkspace1",
     });
   });
 
@@ -829,6 +967,24 @@ describe("auth commands", () => {
     expect(result.stderr).not.toContain("--provider");
     expect(result.stderr).not.toContain("--user");
     expect(result.stderr).not.toContain("--workspace");
+  });
+
+  it("shows workspace use as optional and does not advertise workspace select", async () => {
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+
+    const result = await executeCli({
+      argv: ["auth", "workspace", "--help"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("use [id-or-name]");
+    expect(result.stderr).toContain("$ prisma-cli auth workspace use");
+    expect(result.stderr).not.toContain("select");
   });
 
   it("renders the TTY header block for auth whoami", async () => {


### PR DESCRIPTION
## Summary
- remove the separate auth workspace select command
- make auth workspace use accept an optional workspace id/name
- use no-arg auth workspace use for the interactive picker, with the existing single-workspace shortcut and non-interactive multi-workspace usage error
- update product docs, command metadata, and auth tests

## Tests
- pnpm --filter @prisma/cli test -- auth.test.ts
- pnpm --recursive exec tsc --noEmit
- pnpm lint