### PR TITLE
fix(auth): hydrate workspace list names

### DIFF
--- a/packages/cli/src/adapters/token-storage.ts
+++ b/packages/cli/src/adapters/token-storage.ts
@@ -58,6 +58,7 @@ const EMPTY_AUTH_CONTEXT: AuthContextState = {
   activeWorkspaceId: null,
   workspaces: {},
 };
+const UNKNOWN_WORKSPACE_NAME = "Unknown workspace";
 
 export function getAuthContextFilePath(authFilePath: string): string {
   const extension = path.extname(authFilePath);
@@ -283,8 +284,8 @@ export class FileTokenStorage implements TokenStorage {
             : tokens.workspaceId;
         const name =
           typeof cached?.name === "string" && cached.name.trim().length > 0
-            ? cached.name.trim()
-            : id;
+            ? workspaceDisplayName(cached.name.trim(), tokens.workspaceId)
+            : UNKNOWN_WORKSPACE_NAME;
         const lastSeenAt =
           typeof cached?.lastSeenAt === "string" &&
           cached.lastSeenAt.trim().length > 0
@@ -299,6 +300,14 @@ export class FileTokenStorage implements TokenStorage {
           lastSeenAt,
         };
       });
+  }
+
+  async listWorkspaceTokens(): Promise<Tokens[]> {
+    this.signal?.throwIfAborted();
+    const credentials = await this.readCredentialsFromDisk();
+    return credentials
+      .map((credential) => storedCredentialToTokens(credential))
+      .filter((tokens): tokens is Tokens => tokens !== null);
   }
 
   async useWorkspace(workspaceRef: string): Promise<{
@@ -704,4 +713,8 @@ function workspaceMatchesRef(
 
 function stripWorkspacePrefix(value: string): string {
   return value.startsWith("wksp_") ? value.slice("wksp_".length) : value;
+}
+
+function workspaceDisplayName(name: string, credentialWorkspaceId: string) {
+  return name === credentialWorkspaceId ? UNKNOWN_WORKSPACE_NAME : name;
 }

--- a/packages/cli/src/controllers/auth.ts
+++ b/packages/cli/src/controllers/auth.ts
@@ -444,10 +444,7 @@ async function hydrateLocalAuthWorkspaces(
     );
     if (!tokens) continue;
 
-    const resolved = await resolveOAuthWorkspaceMetadata(
-      context,
-      tokens,
-    );
+    const resolved = await resolveOAuthWorkspaceMetadata(context, tokens);
     if (!resolved) continue;
 
     await rememberResolvedWorkspaceMetadata(context, storage, tokens, resolved);
@@ -496,7 +493,10 @@ async function resolveOAuthWorkspaceMetadata(
     context.runtime.signal,
     { activateOnSetTokens: false },
   );
-  const tokenStorage = createSingleWorkspaceTokenStorage(refreshStorage, tokens);
+  const tokenStorage = createSingleWorkspaceTokenStorage(
+    refreshStorage,
+    tokens,
+  );
   const sdk = createManagementApiSdk({
     clientId: CLIENT_ID,
     redirectUri: "http://localhost:0/auth/callback",

--- a/packages/cli/src/controllers/auth.ts
+++ b/packages/cli/src/controllers/auth.ts
@@ -1,4 +1,9 @@
 import {
+  createManagementApiSdk,
+  type TokenStorage,
+  type Tokens,
+} from "@prisma/management-api-sdk";
+import {
   FileTokenStorage,
   type StoredAuthWorkspace,
   WorkspaceSelectionError,
@@ -8,7 +13,11 @@ import {
   performLogout,
   readAuthState,
 } from "../lib/auth/auth-ops";
-import { SERVICE_TOKEN_ENV_VAR } from "../lib/auth/client";
+import {
+  CLIENT_ID,
+  getApiBaseUrl,
+  SERVICE_TOKEN_ENV_VAR,
+} from "../lib/auth/client";
 import {
   authRequiredError,
   usageError,
@@ -217,7 +226,11 @@ async function listRealAuthWorkspaces(
     context.runtime.env,
     context.runtime.signal,
   );
-  const localWorkspaces = await storage.listWorkspaces();
+  const localWorkspaces = await hydrateLocalAuthWorkspaces(
+    context,
+    storage,
+    await storage.listWorkspaces(),
+  );
 
   if (rawServiceToken !== undefined) {
     const authState = await readAuthState(
@@ -279,6 +292,11 @@ async function useRealAuthWorkspace(
     context.runtime.env,
     context.runtime.signal,
   );
+  await hydrateLocalAuthWorkspaces(
+    context,
+    storage,
+    await storage.listWorkspaces(),
+  );
 
   try {
     const result = await storage.useWorkspace(workspaceRef);
@@ -315,6 +333,11 @@ async function logoutRealAuthWorkspace(
   const storage = new FileTokenStorage(
     context.runtime.env,
     context.runtime.signal,
+  );
+  await hydrateLocalAuthWorkspaces(
+    context,
+    storage,
+    await storage.listWorkspaces(),
   );
 
   try {
@@ -397,6 +420,135 @@ async function selectWorkspaceSession(
   });
 
   return selected.id;
+}
+
+async function hydrateLocalAuthWorkspaces(
+  context: CommandContext,
+  storage: FileTokenStorage,
+  workspaces: StoredAuthWorkspace[],
+): Promise<StoredAuthWorkspace[]> {
+  const candidates = workspaces.filter(needsWorkspaceMetadataHydration);
+  if (candidates.length === 0) return workspaces;
+
+  const tokensByCredentialWorkspaceId = new Map(
+    (await storage.listWorkspaceTokens()).map((tokens) => [
+      tokens.workspaceId,
+      tokens,
+    ]),
+  );
+  let nextWorkspaces = workspaces;
+
+  for (const workspace of candidates) {
+    const tokens = tokensByCredentialWorkspaceId.get(
+      workspace.credentialWorkspaceId,
+    );
+    if (!tokens) continue;
+
+    const resolved = await resolveOAuthWorkspaceMetadata(
+      context,
+      tokens,
+    );
+    if (!resolved) continue;
+
+    await rememberResolvedWorkspaceMetadata(context, storage, tokens, resolved);
+    nextWorkspaces = nextWorkspaces.map((candidate) =>
+      candidate.credentialWorkspaceId === workspace.credentialWorkspaceId
+        ? {
+            ...candidate,
+            id: resolved.id,
+            name: resolved.name,
+            lastSeenAt: new Date().toISOString(),
+          }
+        : candidate,
+    );
+  }
+
+  return nextWorkspaces;
+}
+
+async function rememberResolvedWorkspaceMetadata(
+  context: CommandContext,
+  storage: FileTokenStorage,
+  tokens: Tokens,
+  resolved: { id: string; name: string },
+): Promise<void> {
+  try {
+    await storage.rememberWorkspace(tokens.workspaceId, resolved);
+  } catch {
+    context.runtime.signal?.throwIfAborted();
+  }
+}
+
+function needsWorkspaceMetadataHydration(workspace: StoredAuthWorkspace) {
+  return (
+    workspace.id === workspace.credentialWorkspaceId ||
+    workspace.name === "Unknown workspace" ||
+    workspace.name === workspace.credentialWorkspaceId
+  );
+}
+
+async function resolveOAuthWorkspaceMetadata(
+  context: CommandContext,
+  tokens: Tokens,
+): Promise<{ id: string; name: string } | null> {
+  const refreshStorage = new FileTokenStorage(
+    context.runtime.env,
+    context.runtime.signal,
+    { activateOnSetTokens: false },
+  );
+  const tokenStorage = createSingleWorkspaceTokenStorage(refreshStorage, tokens);
+  const sdk = createManagementApiSdk({
+    clientId: CLIENT_ID,
+    redirectUri: "http://localhost:0/auth/callback",
+    tokenStorage,
+    apiBaseUrl: getApiBaseUrl(context.runtime.env),
+  });
+
+  try {
+    const { data } = await sdk.client.GET("/v1/workspaces/{id}", {
+      params: { path: { id: tokens.workspaceId } },
+      signal: context.runtime.signal,
+    });
+    const id = stringOrNull(data?.data?.id) ?? tokens.workspaceId;
+    const name = stringOrNull(data?.data?.name) ?? id;
+
+    if (id === tokens.workspaceId && name === tokens.workspaceId) {
+      return null;
+    }
+
+    return { id, name };
+  } catch {
+    context.runtime.signal?.throwIfAborted();
+    return null;
+  }
+}
+
+function createSingleWorkspaceTokenStorage(
+  storage: FileTokenStorage,
+  initialTokens: Tokens,
+): TokenStorage {
+  let currentTokens: Tokens | null = initialTokens;
+
+  return {
+    getTokens: async () => currentTokens,
+    setTokens: async (tokens) => {
+      currentTokens = tokens;
+      await storage.setTokens(tokens);
+    },
+    clearTokens: async () => {
+      const tokens = currentTokens;
+      currentTokens = null;
+      if (tokens) {
+        await storage.clearTokensIfCurrent(tokens);
+      }
+    },
+  };
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
 }
 
 function toAuthWorkspace(workspace: StoredAuthWorkspace): AuthWorkspace {

--- a/packages/cli/tests/auth-real-mode.test.ts
+++ b/packages/cli/tests/auth-real-mode.test.ts
@@ -4,13 +4,17 @@ import stripAnsi from "strip-ansi";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { MockApi } from "../src/adapters/mock-api";
-import { renderAuthSuccess } from "../src/presenters/auth";
+import {
+  renderAuthSuccess,
+  renderAuthWorkspaceList,
+} from "../src/presenters/auth";
 import { getCommandDescriptor } from "../src/shell/command-meta";
 
 const fixturePath = path.resolve("fixtures/mock-api.json");
 
 afterEach(() => {
   vi.doUnmock("../src/lib/auth/auth-ops");
+  vi.doUnmock("@prisma/management-api-sdk");
   vi.resetModules();
   vi.restoreAllMocks();
 });
@@ -270,6 +274,231 @@ describe("real auth mode", () => {
           switchable: false,
         },
       ],
+    });
+  });
+
+  it("hydrates placeholder OAuth workspace metadata before rendering the workspace list", async () => {
+    const getWorkspace = vi.fn().mockResolvedValue({
+      data: {
+        data: {
+          id: "wksp_acme",
+          name: "Acme Inc",
+        },
+      },
+      response: { status: 200 },
+    });
+
+    vi.doMock("@prisma/management-api-sdk", () => ({
+      AuthError: class SDKAuthError extends Error {},
+      createManagementApiSdk: vi.fn().mockReturnValue({
+        client: { GET: getWorkspace },
+      }),
+    }));
+
+    const { FileTokenStorage } = await import("../src/adapters/token-storage");
+    const { createTempCwd, createTestCommandContext } = await import(
+      "./helpers"
+    );
+    const { runAuthWorkspaceList } = await import("../src/controllers/auth");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const authFilePath = path.join(cwd, "auth.json");
+    const env = {
+      ...process.env,
+      PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+      PRISMA_SERVICE_TOKEN: undefined,
+    };
+    const storage = new FileTokenStorage(env);
+    await storage.setTokens({
+      workspaceId: "cmmxlp7ae1251zyfs8mdpnavm",
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+    });
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      env,
+    });
+
+    const result = await runAuthWorkspaceList(context);
+    const output = stripAnsi(
+      renderAuthWorkspaceList(
+        context,
+        getCommandDescriptor("auth.workspace.list"),
+        result.result,
+      ).join("\n"),
+    );
+
+    expect(getWorkspace).toHaveBeenCalledWith(
+      "/v1/workspaces/{id}",
+      expect.objectContaining({
+        params: {
+          path: { id: "cmmxlp7ae1251zyfs8mdpnavm" },
+        },
+      }),
+    );
+    expect(result.result.workspaces).toEqual([
+      expect.objectContaining({
+        id: "wksp_acme",
+        name: "Acme Inc",
+        credentialWorkspaceId: "cmmxlp7ae1251zyfs8mdpnavm",
+        active: true,
+      }),
+    ]);
+    expect(output).toContain("Acme Inc  wksp_acme  active");
+    expect(output).not.toContain(
+      "cmmxlp7ae1251zyfs8mdpnavm  cmmxlp7ae1251zyfs8mdpnavm",
+    );
+    await expect(storage.listWorkspaces()).resolves.toEqual([
+      expect.objectContaining({
+        id: "wksp_acme",
+        name: "Acme Inc",
+      }),
+    ]);
+  });
+
+  it("keeps unresolved OAuth workspace sessions listable without using the credential id as the display name", async () => {
+    vi.doMock("@prisma/management-api-sdk", () => ({
+      AuthError: class SDKAuthError extends Error {},
+      createManagementApiSdk: vi.fn().mockReturnValue({
+        client: {
+          GET: vi.fn().mockResolvedValue({
+            data: null,
+            response: { status: 404 },
+          }),
+        },
+      }),
+    }));
+
+    const { FileTokenStorage } = await import("../src/adapters/token-storage");
+    const { createTempCwd, createTestCommandContext } = await import(
+      "./helpers"
+    );
+    const { runAuthWorkspaceList } = await import("../src/controllers/auth");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const authFilePath = path.join(cwd, "auth.json");
+    const env = {
+      ...process.env,
+      PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+      PRISMA_SERVICE_TOKEN: undefined,
+    };
+    const storage = new FileTokenStorage(env);
+    await storage.setTokens({
+      workspaceId: "cmmxlp7ae1251zyfs8mdpnavm",
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+    });
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      env,
+    });
+
+    const result = await runAuthWorkspaceList(context);
+    const output = stripAnsi(
+      renderAuthWorkspaceList(
+        context,
+        getCommandDescriptor("auth.workspace.list"),
+        result.result,
+      ).join("\n"),
+    );
+
+    expect(result.result.workspaces).toEqual([
+      expect.objectContaining({
+        id: "cmmxlp7ae1251zyfs8mdpnavm",
+        name: "Unknown workspace",
+        credentialWorkspaceId: "cmmxlp7ae1251zyfs8mdpnavm",
+      }),
+    ]);
+    expect(output).toContain(
+      "Unknown workspace  cmmxlp7ae1251zyfs8mdpnavm  active",
+    );
+    expect(output).not.toContain(
+      "cmmxlp7ae1251zyfs8mdpnavm  cmmxlp7ae1251zyfs8mdpnavm",
+    );
+  });
+
+  it("uses hydrated OAuth workspace names in the interactive workspace picker", async () => {
+    const workspaces = new Map([
+      [
+        "cmmxworkspace1",
+        {
+          id: "wksp_workspace1",
+          name: "Acme Inc",
+        },
+      ],
+      [
+        "cmmxworkspace2",
+        {
+          id: "wksp_workspace2",
+          name: "Prisma Labs",
+        },
+      ],
+    ]);
+    const getWorkspace = vi
+      .fn()
+      .mockImplementation(
+        (
+          _pathName: string,
+          request?: { params?: { path?: { id?: string } } },
+        ) => ({
+          data: {
+            data: workspaces.get(request?.params?.path?.id ?? ""),
+          },
+          response: { status: 200 },
+        }),
+      );
+
+    vi.doMock("@prisma/management-api-sdk", () => ({
+      AuthError: class SDKAuthError extends Error {},
+      createManagementApiSdk: vi.fn().mockReturnValue({
+        client: { GET: getWorkspace },
+      }),
+    }));
+
+    const { FileTokenStorage } = await import("../src/adapters/token-storage");
+    const { createTempCwd, executeCli } = await import("./helpers");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+    const authFilePath = path.join(cwd, "auth.json");
+    const env = {
+      ...process.env,
+      PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      PRISMA_COMPUTE_AUTH_FILE: authFilePath,
+      PRISMA_SERVICE_TOKEN: undefined,
+    };
+    const storage = new FileTokenStorage(env);
+    await storage.setTokens({
+      workspaceId: "cmmxworkspace1",
+      accessToken: "access-token-1",
+      refreshToken: "refresh-token-1",
+    });
+    await storage.setTokens({
+      workspaceId: "cmmxworkspace2",
+      accessToken: "access-token-2",
+      refreshToken: "refresh-token-2",
+    });
+    await storage.useWorkspace("cmmxworkspace1");
+
+    const result = await executeCli({
+      argv: ["auth", "workspace", "use"],
+      cwd,
+      stateDir,
+      env,
+      isTTY: true,
+      stdinText: "\u001B[B\r",
+    });
+    const stderr = stripAnsi(result.stderr);
+
+    expect(result.exitCode).toBe(0);
+    expect(stderr).toContain("Acme Inc (wksp_workspace1) active");
+    expect(stderr).toContain("Prisma Labs (wksp_workspace2)");
+    expect(stderr).not.toContain("cmmxworkspace1 (cmmxworkspace1)");
+    await expect(storage.getTokens()).resolves.toMatchObject({
+      workspaceId: "cmmxworkspace2",
     });
   });
 

--- a/packages/cli/tests/auth.test.ts
+++ b/packages/cli/tests/auth.test.ts
@@ -165,10 +165,9 @@ describe("auth commands", () => {
 
     expect(humanList.exitCode).toBe(0);
     expect(humanList.stdout).toBe("");
-    expect(humanListOutput).toContain("auth source:  local OAuth");
-    expect(humanListOutput).toContain("name         id      status");
-    expect(humanListOutput).toContain("Acme Inc     ws_123  active");
-    expect(humanListOutput).toContain("Prisma Labs  ws_456");
+    expect(humanListOutput).toBe(
+      "auth workspace list → Listing authenticated workspaces on this machine.\n\n│  auth source:  local OAuth\n│\n│  name         id      status\n│  Acme Inc     ws_123  active\n│  Prisma Labs  ws_456  \n",
+    );
 
     const use = await executeCli({
       argv: ["auth", "workspace", "use", "ws_456", "--json"],


### PR DESCRIPTION
## Overview
Fixes local OAuth workspace sessions that could render the credential workspace id as both the display name and id in `auth workspace list` and selection flows. The command now upgrades cached placeholder metadata when the Management API can resolve the workspace.

## Changes
- Adds best-effort hydration for local OAuth workspace metadata in `packages/cli/src/controllers/auth.ts` before list, use, and logout paths consume cached sessions.
- Updates `FileTokenStorage` in `packages/cli/src/adapters/token-storage.ts` so unresolved placeholder metadata falls back to `Unknown workspace` instead of treating the credential id as a display name.
- Preserves service-token precedence: `PRISMA_SERVICE_TOKEN` remains the active source while cached local OAuth sessions are still shown as non-switchable.
- Expands auth regression coverage for hydrated list output, unresolved fallback behavior, interactive picker labels, and compact table formatting consistency.

## Why
The presenter was faithfully rendering bad cached metadata, so masking only the table output would leave `auth workspace use` picker labels and name-based flows wrong. Hydrating at the storage/controller boundary repairs existing local state opportunistically while keeping the command usable when API lookup fails.

<img width="504" height="128" alt="auth_workspace_list" src="https://github.com/user-attachments/assets/c146ba4f-0e9e-4912-9481-404675412e2c" />

