### PR TITLE
feat(cli): support custom compute build config

### DIFF
--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -902,7 +902,7 @@ prisma-cli app build --build-type nestjs
 prisma-cli app build --build-type tanstack-start
 prisma-cli app build --build-type bun --entry server.ts
 prisma-cli app build api
-prisma-cli app build svelte
+prisma-cli app build frontend
 ```
 
 ## `prisma-cli app run [app] --entry <path> --build-type <auto|bun|nextjs> --port <port>`
@@ -994,8 +994,8 @@ export default defineComputeConfig({
   apps: {
     web: { root: "apps/web", framework: "nextjs" },
     worker: { root: "apps/worker", framework: "bun", entry: "src/index.ts" },
-    svelte: {
-      root: "apps/svelte",
+    frontend: {
+      root: "apps/frontend",
       framework: "custom",
       build: {
         command: "npm run build",

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -1065,7 +1065,7 @@ Behavior:
 - `--env DATABASE_URL=...`, `--env DIRECT_URL=...`, or the same keys loaded from an env file suppress automatic database prompting; combining those database env vars with `--db` is rejected
 - maps user-facing framework names to deploy build strategies
 - does not accept `--build-command` or `--output-directory`; custom build settings live in the `build` block of `prisma.compute.ts`
-- deploys arbitrary framework output with `framework: "custom"` when the config provides a build command, output directory, and built entrypoint
+- deploys arbitrary framework output with `framework: "custom"` when the config provides a built output directory and entrypoint; `build.command` is optional for prebuilt artifacts
 - uses `src/index.ts` as the Hono deploy entrypoint when the app has no `package.json#main` or `package.json#module` and that file exists
 - supports vanilla Bun apps with `--framework bun` using `package.json#main` or `package.json#module`, or with `--entry <path>`
 - treats `--entry <path>` without `--framework` as a Bun app deploy

--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -879,7 +879,7 @@ Examples:
 prisma-cli database connection remove conn_123 --confirm conn_123
 ```
 
-## `prisma-cli app build [app] --entry <path> --build-type <auto|bun|nextjs|nuxt|astro|tanstack-start>`
+## `prisma-cli app build [app] --entry <path> --build-type <auto|bun|nextjs|nuxt|astro|nestjs|tanstack-start|custom>`
 
 Purpose:
 
@@ -889,7 +889,7 @@ Behavior:
 
 - resolves the optional `[app]` target, app root, framework, and entrypoint from `prisma.compute.ts` exactly like `app deploy`; explicit `--entry` and a non-`auto` `--build-type` override the config
 - detects supported project shapes when `--build-type auto` is used and no config framework applies
-- supports Bun, Next.js, Nuxt, Astro, and TanStack Start app builds in the beta package
+- supports Bun, Next.js, Nuxt, Astro, NestJS, TanStack Start, and custom artifact app builds in the beta package
 - fails with `USAGE_ERROR` when framework detection is ambiguous
 
 Examples:
@@ -898,9 +898,11 @@ Examples:
 prisma-cli app build --build-type nextjs
 prisma-cli app build --build-type nuxt
 prisma-cli app build --build-type astro
+prisma-cli app build --build-type nestjs
 prisma-cli app build --build-type tanstack-start
 prisma-cli app build --build-type bun --entry server.ts
 prisma-cli app build api
+prisma-cli app build svelte
 ```
 
 ## `prisma-cli app run [app] --entry <path> --build-type <auto|bun|nextjs> --port <port>`
@@ -925,7 +927,7 @@ prisma-cli app run --build-type bun --entry server.ts --port 3000
 prisma-cli app run api
 ```
 
-## `prisma-cli app deploy [app] --project <id-or-name> --create-project <name> --app <name> --branch <name> --framework <nextjs|nuxt|astro|hono|tanstack-start|bun> --entry <path> --http-port <port> --env <name=value|file> --db --no-db --prod`
+## `prisma-cli app deploy [app] --project <id-or-name> --create-project <name> --app <name> --branch <name> --framework <nextjs|nuxt|astro|hono|nestjs|tanstack-start|custom|bun> --entry <path> --http-port <port> --env <name=value|file> --db --no-db --prod`
 
 Purpose:
 
@@ -943,8 +945,9 @@ Compute config file (`prisma.compute.ts`):
   - `apps` — a multi-app or monorepo repository, keyed by deploy target name
 - each app accepts `name`, `root`, `framework`, `entry`, `httpPort`, `env`, and `build`:
   - `env` is a dotenv file path, or `{ file, vars }` with file path(s) and inline assignments
-  - `build` is `{ command, outputDirectory }`; both fields are optional and `command: null` skips the build step
-  - `build` applies to frameworks whose preview build consumes committed settings (`nextjs`, `hono`, `tanstack-start`, `bun`); `nuxt` and `astro` builds run their framework CLI automatically, so a `build` block with those frameworks is a validation error (`BUILD_SETTINGS_UNSUPPORTED` when only detected at deploy time)
+  - `build` is `{ command, outputDirectory, entrypoint }`; all fields are optional except where a framework requires enough information to stage a runnable artifact, and `command: null` skips the build step
+  - `build.entrypoint` is the built artifact entrypoint when `outputDirectory` is set, and is the source entrypoint for Bun/Hono configs that do not set an output directory
+  - `framework: "custom"` deploys a prebuilt or custom-built artifact and requires `build.outputDirectory` and `build.entrypoint`
 - when `build` is present, the compute config owns build settings for that app: fields it sets override framework defaults, fields it omits are inferred; without a `build` block, settings are inferred entirely, with their sources shown
 - the compute config does not declare databases in the current beta; database setup stays on the `--db`/`--no-db` flags (a future project-level `database` field is the reserved growth path, since databases are branch resources shared by every app on the branch)
 
@@ -991,6 +994,15 @@ export default defineComputeConfig({
   apps: {
     web: { root: "apps/web", framework: "nextjs" },
     worker: { root: "apps/worker", framework: "bun", entry: "src/index.ts" },
+    svelte: {
+      root: "apps/svelte",
+      framework: "custom",
+      build: {
+        command: "npm run build",
+        outputDirectory: "build",
+        entrypoint: "handler.js",
+      },
+    },
   },
 });
 ```
@@ -1030,6 +1042,7 @@ Behavior:
   - build commands run with every `node_modules/.bin` between the app and the repository or workspace root on `PATH`, so hoisted workspace binaries resolve
   - otherwise `Build Command` falls back to the framework default, such as `next build`
   - `Output Directory` is a literal framework output path, such as `.next/standalone`, `.output`, or `.`
+  - `Entrypoint` is shown when the config or framework settings provide a concrete built artifact entrypoint
 - `prisma.app.json` is legacy and never read or written; a leftover file that matches the resolved settings produces a deletion warning, an unparsable one is ignored with a warning, and one with custom values fails with `BUILD_SETTINGS_MIGRATION_REQUIRED` including the exact `build` block to move into `prisma.compute.ts`
 - after setup, deploy prints `Deploying to <Project> / <Branch> / <App>`; later deploys print a compact target header such as `Deploying ./j1 to j1 / main / j1`
 - deploy progress uses short stage copy (`Building locally...`, `Built <size>`, `Uploading...`, `Uploaded`, `Deploying...`, `Deployed`) and never prints `Status: running` or `Deployment is running at ...`
@@ -1052,6 +1065,7 @@ Behavior:
 - `--env DATABASE_URL=...`, `--env DIRECT_URL=...`, or the same keys loaded from an env file suppress automatic database prompting; combining those database env vars with `--db` is rejected
 - maps user-facing framework names to deploy build strategies
 - does not accept `--build-command` or `--output-directory`; custom build settings live in the `build` block of `prisma.compute.ts`
+- deploys arbitrary framework output with `framework: "custom"` when the config provides a build command, output directory, and built entrypoint
 - uses `src/index.ts` as the Hono deploy entrypoint when the app has no `package.json#main` or `package.json#module` and that file exists
 - supports vanilla Bun apps with `--framework bun` using `package.json#main` or `package.json#module`, or with `--entry <path>`
 - treats `--entry <path>` without `--framework` as a Bun app deploy

--- a/docs/product/error-conventions.md
+++ b/docs/product/error-conventions.md
@@ -239,7 +239,7 @@ Recommended meanings:
 - `COMPUTE_CONFIG_TARGET_REQUIRED`: a multi-app compute config needs an `[app]` target and none was given or inferred
 - `COMPUTE_CONFIG_TARGET_UNKNOWN`: the `[app]` target matches no configured app
 - `BUILD_SETTINGS_MIGRATION_REQUIRED`: a legacy `prisma.app.json` contains custom build settings that must move into the `build` block of `prisma.compute.ts`
-- `BUILD_SETTINGS_UNSUPPORTED`: a compute config `build` block targets a framework whose strategy owns its build (nuxt, astro)
+- `BUILD_SETTINGS_UNSUPPORTED`: a compute config `build` block targets a framework whose SDK strategy does not consume committed build settings
 - `FRAMEWORK_NOT_DETECTED`: app deploy could not detect a supported Beta framework and no explicit framework/build type was provided
 - `DEPLOYMENT_NOT_FOUND`: requested deployment id does not exist
 - `NO_DEPLOYMENTS`: command resolved a branch or app but found no deployments

--- a/docs/product/resource-model.md
+++ b/docs/product/resource-model.md
@@ -104,7 +104,7 @@ Rules:
 - the runtime app service is scoped by branch in the platform model
 - the app may be selected or created as part of app deployment workflows
 - app selection is local CLI state when needed for the beta package
-- app build settings live in the `build` block of `prisma.compute.ts` (`command`, `outputDirectory`); `prisma.app.json` is legacy and no longer read
+- app build settings live in the `build` block of `prisma.compute.ts` (`command`, `outputDirectory`, `entrypoint`); `prisma.app.json` is legacy and no longer read
 
 ### Deployment
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.5.0",
-    "@prisma/compute-sdk": "^0.28.0",
+    "@prisma/compute-sdk": "^0.29.0",
     "@prisma/credentials-store": "^7.8.0",
     "@prisma/management-api-sdk": "^1.37.0",
     "better-result": "^2.9.2",

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -29,6 +29,7 @@ import {
   maybeSetupBranchDatabase,
 } from "../lib/app/branch-database-deploy";
 import {
+  APP_BUILD_TYPE_LABELS,
   APP_BUILD_TYPES,
   type AppBuildSettings,
   type AppBuildSettingsResolution,
@@ -845,7 +846,8 @@ async function runSingleAppDeploy(
           name: framework.displayName,
           source: framework.annotation,
         },
-        entrypoint: entrypoint ?? null,
+        entrypoint:
+          entrypoint ?? buildSettingsResolution.settings.entrypoint ?? null,
         httpPort: runtime.port,
         region: selectedApp.region ?? null,
         envVars: envVarNames(envVars),
@@ -4079,11 +4081,6 @@ function frameworkFromUserFacingValue(
   };
 }
 
-/**
- * The nuxt and astro strategies build with their framework CLI and stage
- * fixed output, so a compute config `build` block has nothing to apply to.
- * Erroring beats silently ignoring committed settings.
- */
 function assertConfigBackedBuildSettings(
   buildType: FrameworkBuildType,
 ): asserts buildType is ConfigBackedBuildType {
@@ -4185,6 +4182,15 @@ function maybeRenderDeployBuildSettings(
           value: settings.outputDirectory,
           origin: settings.outputDirectorySource ?? undefined,
         },
+        ...(settings.entrypoint
+          ? [
+              {
+                label: "Entrypoint",
+                value: settings.entrypoint,
+                origin: settings.entrypointSource ?? undefined,
+              },
+            ]
+          : []),
       ]).join("\n")}\n\n`,
   );
 }
@@ -4394,7 +4400,7 @@ function normalizeBuildType(
 
   throw usageError(
     `Unsupported build type "${requestedBuildType}"`,
-    `Only ${APP_BUILD_TYPES.join(", ")} are supported in the current preview.`,
+    `Only ${APP_BUILD_TYPE_LABELS} are supported in the current preview.`,
     "Pass a supported --build-type value.",
     getBuildTypeExamples("build"),
     "app",
@@ -4844,22 +4850,18 @@ function isAutoBuildDetectionError(error: unknown): boolean {
 }
 
 function formatBuildTypeName(buildType: AppBuildType): string {
-  switch (buildType) {
-    case "nextjs":
-      return "Next.js";
-    case "nuxt":
-      return "Nuxt";
-    case "astro":
-      return "Astro";
-    case "nestjs":
-      return "NestJS";
-    case "tanstack-start":
-      return "TanStack Start";
-    case "bun":
-      return "Bun";
-    case "auto":
-      return "Auto";
+  if (buildType === "auto") {
+    return "Auto";
   }
+
+  for (let index = FRAMEWORKS.length - 1; index >= 0; index -= 1) {
+    const framework = FRAMEWORKS[index];
+    if (framework?.buildType === buildType) {
+      return framework.displayName;
+    }
+  }
+
+  return buildType;
 }
 
 function removeFailedError(

--- a/packages/cli/src/lib/app/build-settings.ts
+++ b/packages/cli/src/lib/app/build-settings.ts
@@ -121,6 +121,7 @@ export async function resolveConfiguredAppBuildSettings(options: {
   configured: {
     command: string | null | undefined;
     outputDirectory: string | undefined;
+    entrypoint?: string | undefined;
   };
   /** Absolute path of the compute config file owning these settings. */
   configPath: string;

--- a/packages/cli/src/lib/app/build.ts
+++ b/packages/cli/src/lib/app/build.ts
@@ -4,10 +4,15 @@ import path from "node:path";
 import {
   type BuildArtifact,
   type BuildStrategy,
+  type BuildType,
   normalizeArtifactSymlinks,
   resolveBuildStrategy,
   stageStandaloneArtifact,
 } from "@prisma/compute-sdk";
+import {
+  FRAMEWORKS,
+  type FrameworkBuildType,
+} from "@prisma/compute-sdk/config";
 
 import type { AppBuildSettings } from "./build-settings";
 
@@ -25,22 +30,30 @@ export {
   resolveInferredAppBuildSettings,
 } from "./build-settings";
 
-export const APP_BUILD_TYPES = [
+export type AppBuildType = BuildType;
+export type ResolvedAppBuildType = FrameworkBuildType;
+
+export const RESOLVED_APP_BUILD_TYPES: readonly ResolvedAppBuildType[] = [
+  ...frameworkBuildTypesByLastOccurrence(),
+];
+
+export const APP_BUILD_TYPES: readonly AppBuildType[] = [
   "auto",
-  "bun",
-  "nextjs",
-  "nuxt",
-  "astro",
-  "nestjs",
-  "tanstack-start",
-] as const;
+  ...RESOLVED_APP_BUILD_TYPES,
+];
 
-export type AppBuildType = (typeof APP_BUILD_TYPES)[number];
-export type ResolvedAppBuildType = Exclude<AppBuildType, "auto">;
+export const APP_BUILD_TYPE_LABELS = APP_BUILD_TYPES.join(", ");
 
-export const RESOLVED_APP_BUILD_TYPES = APP_BUILD_TYPES.filter(
-  (buildType): buildType is ResolvedAppBuildType => buildType !== "auto",
-);
+function frameworkBuildTypesByLastOccurrence(): Set<FrameworkBuildType> {
+  const buildTypes = new Set<FrameworkBuildType>();
+  for (const framework of FRAMEWORKS) {
+    if (buildTypes.has(framework.buildType)) {
+      buildTypes.delete(framework.buildType);
+    }
+    buildTypes.add(framework.buildType);
+  }
+  return buildTypes;
+}
 
 export class AppBuildStrategy implements BuildStrategy {
   readonly #appPath: string;

--- a/packages/cli/src/types/app.ts
+++ b/packages/cli/src/types/app.ts
@@ -111,7 +111,14 @@ export interface AppShowResult {
 export interface AppBuildResult {
   directory: string;
   entrypoint: string | null;
-  buildType: "bun" | "nextjs" | "nuxt" | "astro" | "nestjs" | "tanstack-start";
+  buildType:
+    | "bun"
+    | "nextjs"
+    | "nuxt"
+    | "astro"
+    | "nestjs"
+    | "tanstack-start"
+    | "custom";
 }
 
 export interface AppShowDeployResult {

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -1682,6 +1682,102 @@ describe("app controller", () => {
     );
   });
 
+  it("uses and renders configured build entrypoints for custom deploys", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+    const listApps = vi.fn().mockResolvedValue([]);
+    const deployApp = vi.fn().mockResolvedValue({
+      projectId: "proj_123",
+      app: {
+        id: "app_new",
+        name: "frontend",
+        region: "eu-central-1",
+        liveDeploymentId: "dep_123",
+      },
+      deployment: {
+        id: "dep_123",
+        status: "running",
+        url: "https://frontend.prisma.app",
+      },
+    });
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
+        withBranchDatabaseProviderDefaults({
+          resolveBranch: createResolveBranch(),
+          listApps,
+          deployApp,
+          listDeployments: vi.fn(),
+          showDeployment: vi.fn(),
+        }),
+      ),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import(
+      "./helpers"
+    );
+    const { runAppDeploy } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    await writeFile(
+      path.join(cwd, "prisma.compute.ts"),
+      [
+        "export default {",
+        "  app: {",
+        '    name: "frontend",',
+        '    framework: "custom",',
+        "    build: {",
+        '      outputDirectory: "dist",',
+        '      entrypoint: "server.js",',
+        "    },",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    const { context, stderr } = await createTestCommandContext({
+      cwd,
+      stateDir: path.join(cwd, ".state"),
+      isTTY: false,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    const result = await runAppDeploy(context, undefined, {
+      projectRef: "proj_123",
+    });
+
+    expect(deployApp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appName: "frontend",
+        buildType: "custom",
+        entrypoint: undefined,
+        buildSettings: {
+          buildCommand: null,
+          buildCommandSource: null,
+          outputDirectory: "dist",
+          outputDirectorySource: "set by prisma.compute.ts",
+          entrypoint: "server.js",
+          entrypointSource: "set by prisma.compute.ts",
+        },
+      }),
+    );
+    expect(asSingleDeployResult(result).result.deploySettings).toMatchObject({
+      config: {
+        path: "prisma.compute.ts",
+        status: "config",
+      },
+      entrypoint: "server.js",
+    });
+    expect(stderr.buffer).toContain("Using prisma.compute.ts");
+    expect(stderr.buffer).toContain("Entrypoint");
+    expect(stderr.buffer).toContain("server.js");
+  });
+
   it("returns LOCAL_STATE_WRITE_FAILED when deploy cannot store the local binding", async () => {
     const requireComputeAuth = vi
       .fn()

--- a/packages/cli/tests/compute-config.test.ts
+++ b/packages/cli/tests/compute-config.test.ts
@@ -198,8 +198,8 @@ describe("normalizeComputeConfig", () => {
             framework: "hono",
             build: { command: null },
           },
-          svelte: {
-            root: "apps/svelte",
+          frontend: {
+            root: "apps/frontend",
             framework: "custom",
             build: {
               command: "npm run build",

--- a/packages/cli/tests/compute-config.test.ts
+++ b/packages/cli/tests/compute-config.test.ts
@@ -160,7 +160,7 @@ describe("normalizeComputeConfig", () => {
       "`apps.web.name` must be a non-empty string.",
     );
     expect(issues.join(" ")).toContain(
-      "`apps.web.framework` must be one of: nextjs, nuxt, astro, hono, nestjs, tanstack-start, bun.",
+      "`apps.web.framework` must be one of: nextjs, nuxt, astro, hono, nestjs, tanstack-start, custom, bun.",
     );
     expect(issues.join(" ")).toContain(
       "`apps.web.httpPort` must be an integer between 1 and 65535.",
@@ -171,19 +171,6 @@ describe("normalizeComputeConfig", () => {
     expect(issues.join(" ")).toContain(
       "`apps.web.env.vars.EMPTY` must be a non-empty string.",
     );
-  });
-
-  it("rejects build blocks for frameworks whose strategy owns the build", () => {
-    expect(
-      normalizeIssues({
-        app: { framework: "nuxt", build: { command: "nuxt build" } },
-      }).join(" "),
-    ).toContain("`app.build` is not supported with the nuxt framework");
-    expect(
-      normalizeIssues({
-        app: { framework: "astro", build: { outputDirectory: "dist" } },
-      }).join(" "),
-    ).toContain("`app.build` is not supported with the astro framework");
   });
 
   it("rejects roots that escape the config directory, including Windows drive-relative paths", () => {
@@ -211,6 +198,15 @@ describe("normalizeComputeConfig", () => {
             framework: "hono",
             build: { command: null },
           },
+          svelte: {
+            root: "apps/svelte",
+            framework: "custom",
+            build: {
+              command: "npm run build",
+              outputDirectory: "build",
+              entrypoint: "handler.js",
+            },
+          },
         },
       }),
     );
@@ -222,7 +218,19 @@ describe("normalizeComputeConfig", () => {
       },
     });
     expect(config.targets[1]).toMatchObject({
-      build: { command: null, outputDirectory: undefined },
+      build: {
+        command: null,
+        outputDirectory: undefined,
+        entrypoint: undefined,
+      },
+    });
+    expect(config.targets[2]).toMatchObject({
+      framework: "custom",
+      build: {
+        command: "npm run build",
+        outputDirectory: "build",
+        entrypoint: "handler.js",
+      },
     });
   });
 
@@ -247,7 +255,7 @@ describe("normalizeComputeConfig", () => {
     );
     expect(issues.join(" ")).toContain('Unknown key "db" in `apps.web`.');
     expect(issues.join(" ")).toContain(
-      "`apps.api.build` must set `command` and/or `outputDirectory`.",
+      "`apps.api.build` must set `command`, `outputDirectory`, and/or `entrypoint`.",
     );
   });
 
@@ -436,6 +444,7 @@ describe("mergeComputeLocalInputs", () => {
     expect(computeFrameworkToBuildType("tanstack-start")).toBe(
       "tanstack-start",
     );
+    expect(computeFrameworkToBuildType("custom")).toBe("custom");
   });
 
   it("uses config values when flags are absent or default", () => {

--- a/packages/cli/tests/compute-config.test.ts
+++ b/packages/cli/tests/compute-config.test.ts
@@ -198,6 +198,14 @@ describe("normalizeComputeConfig", () => {
             framework: "hono",
             build: { command: null },
           },
+          docs: {
+            root: "apps/docs",
+            framework: "astro",
+            build: {
+              command: "npm run build",
+              outputDirectory: "dist/server/",
+            },
+          },
           frontend: {
             root: "apps/frontend",
             framework: "custom",
@@ -225,6 +233,14 @@ describe("normalizeComputeConfig", () => {
       },
     });
     expect(config.targets[2]).toMatchObject({
+      framework: "astro",
+      build: {
+        command: "npm run build",
+        outputDirectory: "dist/server",
+        entrypoint: undefined,
+      },
+    });
+    expect(config.targets[3]).toMatchObject({
       framework: "custom",
       build: {
         command: "npm run build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
       '@prisma/compute-sdk':
-        specifier: ^0.28.0
-        version: 0.28.0(@prisma/management-api-sdk@1.37.0)(rollup@4.61.0)
+        specifier: ^0.29.0
+        version: 0.29.0(@prisma/management-api-sdk@1.37.0)(rollup@4.61.0)
       '@prisma/credentials-store':
         specifier: ^7.8.0
         version: 7.8.0
@@ -548,8 +548,8 @@ packages:
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
-  '@prisma/compute-sdk@0.28.0':
-    resolution: {integrity: sha512-Oy9E/Y3SrRezoVoXGFiZsWcXQOjO57inTNuIGkki9/CL7eMYqu10hdJEdoarlQPRFIqsYvJcUnHjISgfr5RaLA==}
+  '@prisma/compute-sdk@0.29.0':
+    resolution: {integrity: sha512-9AEXHx9VUDHmRJ3KuccF0r+lYEGXEjv4yxzObIj8OE7+fBt2Khol8rGioBt6YdUkMqImf6U3NbWj7KVX9tfQjQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@prisma/management-api-sdk': '>=1.36.0'
@@ -1838,7 +1838,7 @@ snapshots:
 
   '@oxc-project/types@0.127.0': {}
 
-  '@prisma/compute-sdk@0.28.0(@prisma/management-api-sdk@1.37.0)(rollup@4.61.0)':
+  '@prisma/compute-sdk@0.29.0(@prisma/management-api-sdk@1.37.0)(rollup@4.61.0)':
     dependencies:
       '@prisma/management-api-sdk': 1.37.0
       '@vercel/nft': 1.10.2(rollup@4.61.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,4 +5,4 @@ allowBuilds:
   esbuild: true
 
 minimumReleaseAgeExclude:
-  - '@prisma/compute-sdk@0.28.0'
+  - '@prisma/compute-sdk@0.29.0'


### PR DESCRIPTION
## Summary

Adds Prisma CLI support for custom Compute build config. This lets users describe how an app should be built and staged in `prisma.compute.ts` when the app does not fit one of the first-class framework strategies yet.

Companion PRs:

- prisma/project-compute#97
- prisma/pdp-control-plane#4310

The SDK support has been released, so this PR depends on `@prisma/compute-sdk@^0.29.0` and includes the lockfile update.

## What changed

- Uses the SDK framework registry for `app build --build-type` choices instead of duplicating the list in the CLI.
- Adds `custom` to CLI build result typing.
- Passes `prisma.compute.ts` `build.entrypoint` into configured build settings.
- Shows configured build entrypoints in deploy build-settings output.
- Reports the effective deploy entrypoint from configured build settings when no source `--entry` is used.
- Updates config tests for `custom`, framework-owned build blocks, and `build.entrypoint` normalization.
- Updates product docs for `build.entrypoint`, `framework: "custom"`, and custom artifact builds.

## User-facing behavior

A custom artifact can be deployed through `prisma.compute.ts` by providing:

- `framework: "custom"`
- `build.outputDirectory`
- `build.entrypoint`

`build.command` is optional. Omit it when the artifact is already built, or set it when the CLI should run a build before staging the artifact.

Example single-app config:

```ts
import { defineComputeConfig } from "@prisma/compute-sdk/config";

export default defineComputeConfig({
  app: {
    name: "web",
    framework: "custom",
    httpPort: 3000,
    build: {
      command: "npm run build",
      outputDirectory: "dist",
      entrypoint: "server.js",
    },
  },
});
```

Users can then run:

```bash
prisma-cli app build
prisma-cli app deploy
```

Example prebuilt artifact config:

```ts
import { defineComputeConfig } from "@prisma/compute-sdk/config";

export default defineComputeConfig({
  app: {
    name: "web",
    framework: "custom",
    build: {
      outputDirectory: "dist",
      entrypoint: "server.js",
    },
  },
});
```

Example monorepo config:

```ts
import { defineComputeConfig } from "@prisma/compute-sdk/config";

export default defineComputeConfig({
  apps: {
    frontend: {
      root: "apps/frontend",
      framework: "custom",
      build: {
        command: "npm run build",
        outputDirectory: "dist",
        entrypoint: "server.js",
      },
    },
    api: {
      root: "apps/api",
      framework: "hono",
      entry: "src/index.ts",
    },
  },
});
```

```bash
prisma-cli app build frontend
prisma-cli app deploy frontend
```

## Validation

- `pnpm --filter @prisma/cli test`
- `pnpm --recursive exec tsc --noEmit`
- `pnpm lint`

`pnpm lint` exits 0 with existing warnings.
