### PR TITLE
feat(app): add --no-promote for promotionless deploys

### DIFF
--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -1012,7 +1012,7 @@ prisma-cli app run --build-type bun --entry server.ts --port 3000
 prisma-cli app run api
 ```
 
-## `prisma-cli app deploy [app] --project <id-or-name> --create-project <name> --app <name> --branch <name> --framework <nextjs|nuxt|astro|hono|nestjs|tanstack-start|custom|bun> --entry <path> --http-port <port> --region <region> --env <name=value|file> --db --no-db --prod`
+## `prisma-cli app deploy [app] --project <id-or-name> --create-project <name> --app <name> --branch <name> --framework <nextjs|nuxt|astro|hono|nestjs|tanstack-start|custom|bun> --entry <path> --http-port <port> --region <region> --env <name=value|file> --db --no-db --prod --no-promote`
 
 Purpose:
 
@@ -1053,7 +1053,7 @@ same reasons they are excluded today.
 - the `[app]` argument selects an `apps` target by key:
   - without an `[app]` argument, a command run from inside a target's `root` selects that target, so `cd apps/api && prisma-cli app deploy` deploys `api`; the deepest matching root wins and an ambiguous tie selects nothing
   - with multiple `apps` entries, no `[app]` argument, and no target inferred from the invocation directory, deploy deploys every target sequentially in declaration order — the config declares the system, and a bare `prisma-cli app deploy` ships it
-  - deploying all targets rejects per-app inputs (`--app`, `--framework`, `--entry`, `--http-port`, `--region`, `--env`, `PRISMA_APP_ID`) with a usage error; project- and branch-level flags (`--project`, `--create-project`, `--branch`, `--db`, `--no-db`, `--prod`, `--yes`) apply to the whole run, with `--create-project` creating and binding the Project once before the first target
+  - deploying all targets rejects per-app inputs (`--app`, `--framework`, `--entry`, `--http-port`, `--region`, `--env`, `PRISMA_APP_ID`) with a usage error; project- and branch-level flags (`--project`, `--create-project`, `--branch`, `--db`, `--no-db`, `--prod`, `--no-promote`, `--yes`) apply to the whole run, with `--create-project` creating and binding the Project once before the first target
   - a deploy-all run stops at the first failure and reports the targets already live; `--json` output aggregates one full deploy result per target
   - `app build` and `app run` still require a target in multi-app configs and fail with `COMPUTE_CONFIG_TARGET_REQUIRED` (a dev server cannot run N apps at once; build keeps the same shape)
   - an `[app]` argument that matches no target fails with `COMPUTE_CONFIG_TARGET_UNKNOWN`
@@ -1120,6 +1120,8 @@ Behavior:
 - resolves or creates app context inside the resolved branch from `--app`, `PRISMA_APP_ID`, `package.json#name`, or current directory name
 - auto-promotes the first production deploy for an App without `--prod`
 - requires `--prod` for subsequent deploys to a production Branch; `--yes` only skips the confirmation prompt when `--prod` is also present
+- supports `--no-promote` to build a new deployment without promoting it to live: the previous deployment keeps serving, and the new deployment is reachable only at its own candidate URL until a later `app promote <deployment-id>` makes it live
+- `--no-promote` never replaces the live deployment, so it bypasses the production gate: `app deploy --no-promote` on a production Branch builds a candidate without `--prod` and without confirmation. It is the CI build-then-verify path — build the candidate, health-check its URL, then `app promote`
 - does not prompt when there is no real choice; zero matching apps creates the inferred app
 - writes `.prisma/local.json` after Project binding succeeds and before build/deploy starts, so retries after a failed deploy do not repeat setup
 - before asking `Customize build settings? (y/N)`, previews the detected framework and runtime so the user can see the defaults they are accepting or changing
@@ -1135,6 +1137,7 @@ Behavior:
 - after setup, deploy prints `Deploying to <Project> / <Branch> / <App>`; later deploys print a compact target header such as `Deploying ./j1 to j1 / main / j1`
 - deploy progress uses short stage copy (`Building locally...`, `Built <size>`, `Uploading...`, `Uploaded`, `Deploying...`, `Deployed`) and never prints `Status: running` or `Deployment is running at ...`
 - success human output prints `Live in <duration>`, the URL on its own line, and `Logs   prisma-cli app logs`
+- with `--no-promote`, success human output instead prints `Built <deployment-id> in <duration> (not promoted)`, the candidate URL on its own line, a note that the live deployment is unchanged, and a `Promote   prisma-cli app promote <deployment-id>` next step
 - accepts repeated `--env NAME=VALUE` flags and dotenv file paths such as `--env .env`
 - supports `--db` to create a new empty Prisma Postgres database and write `DATABASE_URL` and `DIRECT_URL` through the existing `project env` storage; the CLI never runs schema or migration commands — applying the schema stays with the user's own tooling
 - `--db` is the opinionated single-database path: it creates **one** branch database and exposes `DATABASE_URL`/`DIRECT_URL` as branch-scoped env vars, so every app on the branch shares it. In a multi-app deploy-all run the database is created once (on the first target) and reused by the rest; the run never creates a database per app. Per-app or per-service database topologies are explicit-configuration territory — set each app's database env vars yourself rather than relying on `--db` to infer app-to-database ownership
@@ -1176,6 +1179,7 @@ prisma-cli app deploy --no-db
 prisma-cli app deploy --framework nextjs --http-port 3000
 prisma-cli app deploy --branch feat-login --framework hono --http-port 3000
 prisma-cli app deploy --prod --yes
+prisma-cli app deploy --no-promote
 prisma-cli app deploy --framework bun --entry src/server.ts --http-port 3000
 prisma-cli app deploy --entry src/server.ts --http-port 3000
 prisma-cli app deploy web

--- a/packages/cli/src/commands/app/index.ts
+++ b/packages/cli/src/commands/app/index.ts
@@ -247,7 +247,13 @@ function createDeployCommand(runtime: CliRuntime): Command {
       ),
     )
     .addOption(new Option("--no-db", "Skip database setup"))
-    .addOption(new Option("--prod", "Confirm intent to deploy to production"));
+    .addOption(new Option("--prod", "Confirm intent to deploy to production"))
+    .addOption(
+      new Option(
+        "--no-promote",
+        "Build the new deployment without promoting it to live (promote later with app promote <id>)",
+      ),
+    );
   addGlobalFlags(command);
 
   command.action(async (configTarget: string | undefined, options) => {
@@ -262,6 +268,7 @@ function createDeployCommand(runtime: CliRuntime): Command {
     const createProjectName = (options as { createProject?: string })
       .createProject;
     const prod = (options as { prod?: boolean }).prod;
+    const noPromote = (options as { promote?: boolean }).promote === false;
     const db = (options as { db?: boolean }).db;
     const hasDbConflict =
       hasFlag(runtime.argv, "--db") && hasFlag(runtime.argv, "--no-db");
@@ -291,6 +298,7 @@ function createDeployCommand(runtime: CliRuntime): Command {
           region,
           envAssignments,
           prod: prod === true,
+          noPromote,
           db,
           configTarget,
         });

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -387,6 +387,7 @@ interface AppDeployOptions {
   region?: string;
   envAssignments?: string[];
   prod?: boolean;
+  noPromote?: boolean;
   db?: boolean;
   configTarget?: string;
 }
@@ -739,16 +740,18 @@ async function runSingleAppDeploy(
   framework = customized.framework;
   runtime = customized.runtime;
 
-  const productionDeployGate = await enforceProductionDeployGate(
-    context,
-    provider,
-    {
-      appId: selectedApp.appId,
-      appName: selectedApp.displayName,
-      branchKind: target.branch.kind,
-      prod: options?.prod === true,
-    },
-  );
+  const noPromote = options?.noPromote === true;
+  // A promotionless deploy never replaces the live deployment, so the
+  // production-confirmation gate does not apply: --no-promote on the production
+  // branch builds a candidate without --prod.
+  const productionDeployGate = noPromote
+    ? { firstProductionDeploy: false }
+    : await enforceProductionDeployGate(context, provider, {
+        appId: selectedApp.appId,
+        appName: selectedApp.displayName,
+        branchKind: target.branch.kind,
+        prod: options?.prod === true,
+      });
 
   // Customization can switch from a Bun-compatible framework to one that
   // derives its entrypoint from build output, so validate --entry again after it.
@@ -801,6 +804,7 @@ async function runSingleAppDeploy(
       buildSettings: buildSettingsResolution.settings,
       portMapping,
       envVars,
+      skipPromote: noPromote,
       interaction: undefined,
       signal: context.runtime.signal,
       progress: createDeployProgress(
@@ -838,6 +842,7 @@ async function runSingleAppDeploy(
         name: deployResult.app.name,
       },
       deployment: deployResult.deployment,
+      promoted: deployResult.promoted,
       deploySettings: {
         config: {
           path: buildSettingsResolution.relativeConfigPath,
@@ -871,10 +876,15 @@ async function runSingleAppDeploy(
       ...legacyWarnings,
       ...branchDatabaseSetup.warnings,
     ],
-    nextSteps: [
-      "prisma-cli app list-deploys",
-      `prisma-cli app show-deploy ${deployResult.deployment.id}`,
-    ],
+    nextSteps: deployResult.promoted
+      ? [
+          "prisma-cli app list-deploys",
+          `prisma-cli app show-deploy ${deployResult.deployment.id}`,
+        ]
+      : [
+          `prisma-cli app promote ${deployResult.deployment.id}`,
+          `prisma-cli app show-deploy ${deployResult.deployment.id}`,
+        ],
   };
 }
 

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -823,11 +823,18 @@ async function runSingleAppDeploy(
     id: deployResult.app.id,
     name: deployResult.app.name,
   });
-  await context.stateStore.setKnownLiveDeployment(
-    projectId,
-    deployResult.app.id,
-    deployResult.deployment.id,
-  );
+  // With --no-promote the live deployment is unchanged, so cache the actually-live
+  // id (never the un-promoted candidate); skip when the app has nothing live yet.
+  const knownLiveDeploymentId = deployResult.promoted
+    ? deployResult.deployment.id
+    : deployResult.app.liveDeploymentId;
+  if (knownLiveDeploymentId) {
+    await context.stateStore.setKnownLiveDeployment(
+      projectId,
+      deployResult.app.id,
+      knownLiveDeploymentId,
+    );
+  }
 
   return {
     command: "app.deploy",

--- a/packages/cli/src/lib/app/app-provider.ts
+++ b/packages/cli/src/lib/app/app-provider.ts
@@ -65,7 +65,9 @@ export interface DeployRecord {
     id: string;
     status: string;
     url: string | null;
+    live: boolean;
   };
+  promoted: boolean;
 }
 
 export interface EnvRecord {
@@ -229,6 +231,7 @@ export interface AppProvider {
     buildSettings?: AppBuildSettings;
     portMapping?: PortMapping;
     envVars?: Record<string, string>;
+    skipPromote?: boolean;
     interaction?: unknown;
     signal?: AbortSignal;
     progress?: unknown;
@@ -511,6 +514,7 @@ export function createAppProvider(
         region: resolvedApp.region,
         portMapping: options.portMapping,
         envVars: options.envVars,
+        skipPromote: options.skipPromote,
         timeoutSeconds: 120,
         pollIntervalMs: 2000,
         interaction: options.interaction as never,
@@ -524,13 +528,18 @@ export function createAppProvider(
 
       const deployed = deployResult.value;
 
+      // On a promotionless deploy the SDK leaves appEndpointDomain null and the
+      // previous deployment serving live, so the live pointer stays on the old
+      // deployment and both URL expressions resolve to the candidate endpoint.
       return {
         projectId: deployed.projectId,
         app: {
           id: deployed.appId,
           name: deployed.appName,
           region: deployed.region ?? null,
-          liveDeploymentId: deployed.deploymentId,
+          liveDeploymentId: deployed.promoted
+            ? deployed.deploymentId
+            : deployed.previousDeploymentId,
           liveUrl: toAbsoluteUrl(deployed.appEndpointDomain ?? null),
         },
         deployment: {
@@ -541,7 +550,9 @@ export function createAppProvider(
               deployed.deploymentEndpointDomain ??
               null,
           ),
+          live: deployed.promoted,
         },
+        promoted: deployed.promoted,
       };
     },
 

--- a/packages/cli/src/presenters/app.ts
+++ b/packages/cli/src/presenters/app.ts
@@ -68,12 +68,33 @@ export function renderAppDeploy(
   const logsCommand = options?.logsTarget
     ? `prisma-cli app logs ${options.logsTarget}`
     : "prisma-cli app logs";
+  const headline = result.promoted
+    ? [
+        `Live in ${formatDuration(result.durationMs)}`,
+        ...(result.deployment.url
+          ? [context.ui.link(result.deployment.url)]
+          : []),
+      ]
+    : [
+        `Built ${result.deployment.id} in ${formatDuration(result.durationMs)} (not promoted)`,
+        ...(result.deployment.url
+          ? [context.ui.link(result.deployment.url)]
+          : []),
+        context.ui.dim("The live deployment is unchanged."),
+      ];
   const lines = [
-    `Live in ${formatDuration(result.durationMs)}`,
-    ...(result.deployment.url ? [context.ui.link(result.deployment.url)] : []),
+    ...headline,
     ...renderBranchDatabaseDeploySummary(context, result),
     "",
     ...renderDeployOutputRows(context.ui, [
+      ...(result.promoted
+        ? []
+        : [
+            {
+              label: "Promote",
+              value: `prisma-cli app promote ${result.deployment.id}`,
+            },
+          ]),
       { label: "Logs", value: logsCommand },
     ]),
     ...renderDeployResolvedContextBlock(context, result),

--- a/packages/cli/src/types/app.ts
+++ b/packages/cli/src/types/app.ts
@@ -75,7 +75,10 @@ export interface AppDeployResult {
     id: string;
     status: string;
     url: string | null;
+    live: boolean;
   };
+  /** Whether the new deployment was promoted to live. False for --no-promote. */
+  promoted: boolean;
   deploySettings: AppDeploySettings;
   durationMs: number;
   localPin?: {

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -6955,4 +6955,166 @@ describe("app controller", () => {
       "The app was removed remotely, but the local selected app state could not be cleared: disk full",
     ]);
   });
+
+  it("deploy --no-promote builds the candidate without promoting it", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+    const listApps = vi.fn().mockResolvedValue([
+      {
+        id: "app_1",
+        name: "hello-world",
+        region: "eu-west-3",
+        liveDeploymentId: "dep_live",
+        liveUrl: "https://hello-world.prisma.app",
+      },
+    ]);
+    const listDeployments = vi.fn();
+    const deployApp = vi.fn().mockResolvedValue({
+      projectId: "proj_123",
+      app: {
+        id: "app_1",
+        name: "hello-world",
+        region: "eu-west-3",
+        liveDeploymentId: "dep_live",
+        liveUrl: null,
+      },
+      deployment: {
+        id: "dep_candidate",
+        status: "running",
+        url: "https://dep-candidate.fra.prisma.build",
+        live: false,
+      },
+      promoted: false,
+    });
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
+        withBranchDatabaseProviderDefaults({
+          resolveBranch: createResolveBranch(),
+          listApps,
+          deployApp,
+          listDeployments,
+          showDeployment: vi.fn(),
+        }),
+      ),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import(
+      "./helpers"
+    );
+    const { runAppDeploy } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir: path.join(cwd, ".state"),
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    const result = asSingleDeployResult(
+      await runAppDeploy(context, "hello-world", {
+        projectRef: "proj_123",
+        framework: "hono",
+        noPromote: true,
+      }),
+    );
+
+    expect(deployApp).toHaveBeenCalledWith(
+      expect.objectContaining({ skipPromote: true }),
+    );
+    expect(result.result.promoted).toBe(false);
+    expect(result.result.deployment).toEqual({
+      id: "dep_candidate",
+      status: "running",
+      url: "https://dep-candidate.fra.prisma.build",
+      live: false,
+    });
+    expect(result.nextSteps).toEqual([
+      "prisma-cli app promote dep_candidate",
+      "prisma-cli app show-deploy dep_candidate",
+    ]);
+  });
+
+  it("deploy --no-promote on the production branch bypasses the production gate", async () => {
+    const requireComputeAuth = vi
+      .fn()
+      .mockResolvedValue(createProjectClient("proj_123", { isDefault: true }));
+    const listApps = vi.fn().mockResolvedValue([
+      {
+        id: "app_1",
+        name: "hello-world",
+        region: "eu-west-3",
+        liveDeploymentId: "dep_live",
+        liveUrl: "https://hello-world.prisma.app",
+      },
+    ]);
+    // The gate inspects existing deployments; --no-promote must not reach it.
+    const listDeployments = vi.fn();
+    const deployApp = vi.fn().mockResolvedValue({
+      projectId: "proj_123",
+      app: {
+        id: "app_1",
+        name: "hello-world",
+        region: "eu-west-3",
+        liveDeploymentId: "dep_live",
+        liveUrl: null,
+      },
+      deployment: {
+        id: "dep_candidate",
+        status: "running",
+        url: "https://dep-candidate.fra.prisma.build",
+        live: false,
+      },
+      promoted: false,
+    });
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
+        withBranchDatabaseProviderDefaults({
+          resolveBranch: createResolveBranch("production"),
+          listApps,
+          deployApp,
+          listDeployments,
+          showDeployment: vi.fn(),
+        }),
+      ),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import(
+      "./helpers"
+    );
+    const { runAppDeploy } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir: path.join(cwd, ".state"),
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    const result = asSingleDeployResult(
+      await runAppDeploy(context, "hello-world", {
+        projectRef: "proj_123",
+        branchName: "production",
+        framework: "hono",
+        noPromote: true,
+      }),
+    );
+
+    expect(result.result.branch.kind).toBe("production");
+    expect(result.result.promoted).toBe(false);
+    expect(listDeployments).not.toHaveBeenCalled();
+    expect(deployApp).toHaveBeenCalledWith(
+      expect.objectContaining({ skipPromote: true }),
+    );
+  });
 });

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -7037,6 +7037,11 @@ describe("app controller", () => {
       "prisma-cli app promote dep_candidate",
       "prisma-cli app show-deploy dep_candidate",
     ]);
+    // The un-promoted candidate must not be cached as the known-live deployment;
+    // the previously-live one keeps serving.
+    expect(
+      await context.stateStore.readKnownLiveDeployment("proj_123", "app_1"),
+    ).toBe("dep_live");
   });
 
   it("deploy --no-promote on the production branch bypasses the production gate", async () => {

--- a/packages/cli/tests/app-env-vars.test.ts
+++ b/packages/cli/tests/app-env-vars.test.ts
@@ -705,7 +705,100 @@ describe("app env vars", () => {
         envAssignments: ["DATABASE_URL=postgresql://example"],
         projectRef: "proj_123",
         prod: true,
+        noPromote: false,
       },
+    );
+  });
+
+  it("threads --no-promote and surfaces the candidate deployment in --json", async () => {
+    const runAppDeploy = vi.fn().mockResolvedValue({
+      command: "app.deploy",
+      result: {
+        workspace: { id: "ws_123", name: "Acme Inc" },
+        project: { id: "proj_123", name: "Acme Dashboard" },
+        branch: { id: "br_prod", name: "production", kind: "production" },
+        resolution: { projectSource: "explicit" },
+        app: { id: "app_1", name: "hello-world" },
+        deployment: {
+          id: "dep_candidate",
+          status: "running",
+          url: "https://dep-candidate.fra.prisma.build",
+          live: false,
+        },
+        promoted: false,
+        deploySettings: {
+          config: { path: null, status: "inferred" },
+          buildCommand: { value: null, source: null },
+          outputDirectory: { value: ".", source: null },
+          framework: {
+            key: "hono",
+            buildType: "bun",
+            name: "Hono",
+            source: "explicit",
+          },
+          entrypoint: "src/index.ts",
+          httpPort: 3000,
+          region: null,
+          envVars: [],
+        },
+        durationMs: 1234,
+      },
+      warnings: [],
+      nextSteps: ["prisma-cli app promote dep_candidate"],
+    });
+
+    vi.doMock("../src/controllers/app", async () => {
+      const actual = await vi.importActual<
+        typeof import("../src/controllers/app")
+      >("../src/controllers/app");
+      return {
+        ...actual,
+        runAppDeploy,
+      };
+    });
+
+    const { createTempCwd, executeCli } = await import("./helpers");
+    const cwd = await createTempCwd();
+    const stateDir = path.join(cwd, ".state");
+
+    const result = await executeCli({
+      argv: [
+        "app",
+        "deploy",
+        "--app",
+        "hello-world",
+        "--framework",
+        "hono",
+        "--project",
+        "proj_123",
+        "--no-promote",
+        "--json",
+      ],
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: true,
+      command: "app.deploy",
+      result: {
+        promoted: false,
+        deployment: {
+          id: "dep_candidate",
+          url: "https://dep-candidate.fra.prisma.build",
+          live: false,
+        },
+      },
+    });
+    expect(runAppDeploy).toHaveBeenCalledWith(
+      expect.anything(),
+      "hello-world",
+      expect.objectContaining({ noPromote: true }),
     );
   });
 });

--- a/packages/cli/tests/app-presenter.test.ts
+++ b/packages/cli/tests/app-presenter.test.ts
@@ -69,7 +69,9 @@ function createDeployResult(): AppDeployResult {
       id: "dep_123",
       status: "running",
       url: "https://api.prisma.build",
+      live: true,
     },
+    promoted: true,
     deploySettings: {
       config: {
         path: null,
@@ -274,5 +276,57 @@ describe("app deploy presenter", () => {
       kind: "production",
     });
     expect(json.branch).not.toHaveProperty("id");
+  });
+
+  it("renders a promotionless deploy as built-not-live with a promote hint", async () => {
+    const { context } = await createTestCommandContext({});
+    const result: AppDeployResult = {
+      ...createDeployResult(),
+      deployment: {
+        id: "dep_candidate",
+        status: "running",
+        url: "https://dep-candidate.fra.prisma.build",
+        live: false,
+      },
+      promoted: false,
+    };
+
+    const lines = renderAppDeploy(
+      context,
+      getCommandDescriptor("app.deploy"),
+      result,
+    ).join("\n");
+
+    expect(lines).toContain("Built dep_candidate");
+    expect(lines).toContain("(not promoted)");
+    expect(lines).toContain("The live deployment is unchanged.");
+    expect(lines).toContain("https://dep-candidate.fra.prisma.build");
+    expect(lines).toContain("prisma-cli app promote dep_candidate");
+    expect(lines).not.toMatch(/^Live in/m);
+  });
+
+  it("keeps promoted status and candidate url in JSON serialization", () => {
+    const json = JSON.parse(
+      JSON.stringify(
+        serializeAppDeploy({
+          ...createDeployResult(),
+          deployment: {
+            id: "dep_candidate",
+            status: "running",
+            url: "https://dep-candidate.fra.prisma.build",
+            live: false,
+          },
+          promoted: false,
+        }),
+      ),
+    );
+
+    expect(json.promoted).toBe(false);
+    expect(json.deployment).toEqual({
+      id: "dep_candidate",
+      status: "running",
+      url: "https://dep-candidate.fra.prisma.build",
+      live: false,
+    });
   });
 });

--- a/packages/cli/tests/app-provider.test.ts
+++ b/packages/cli/tests/app-provider.test.ts
@@ -363,6 +363,136 @@ describe("preview app provider", () => {
     );
   });
 
+  it("forwards skipPromote and maps a promotionless deploy to the candidate", async () => {
+    const deploy = vi.fn().mockResolvedValue({
+      isErr: () => false,
+      isOk: () => true,
+      value: {
+        projectId: "proj_123",
+        appId: "app_1",
+        appName: "hello-world",
+        region: "eu-central-1",
+        deploymentId: "dep_new",
+        deploymentEndpointDomain: "dep-new.fra.prisma.build",
+        appEndpointDomain: null,
+        promoted: false,
+        previousDeploymentId: "dep_live",
+        previousDeploymentAction: "still-active",
+      },
+    });
+    const AppBuildStrategy = mockAppBuildStrategy();
+
+    vi.doMock("../src/lib/app/build", () => ({
+      AppBuildStrategy,
+    }));
+    vi.doMock("@prisma/compute-sdk", () => ({
+      ApiError: { is: () => false },
+      ComputeClient: class {
+        deploy = deploy;
+      },
+    }));
+
+    const { createAppProvider } = await import("../src/lib/app/app-provider");
+
+    const provider = createAppProvider({} as never);
+    const cwd = path.resolve("/tmp/next-smoke");
+
+    const record = await provider.deployApp({
+      cwd,
+      projectId: "proj_123",
+      appId: "app_1",
+      appName: "hello-world",
+      buildType: "nextjs",
+      portMapping: { http: 3000 },
+      skipPromote: true,
+    });
+
+    expect(deploy).toHaveBeenCalledWith(
+      expect.objectContaining({ skipPromote: true }),
+    );
+    expect(record).toEqual({
+      projectId: "proj_123",
+      app: {
+        id: "app_1",
+        name: "hello-world",
+        region: "eu-central-1",
+        liveDeploymentId: "dep_live",
+        liveUrl: null,
+      },
+      deployment: {
+        id: "dep_new",
+        status: "running",
+        url: "https://dep-new.fra.prisma.build",
+        live: false,
+      },
+      promoted: false,
+    });
+  });
+
+  it("maps a promoted deploy to the live app URL", async () => {
+    const deploy = vi.fn().mockResolvedValue({
+      isErr: () => false,
+      isOk: () => true,
+      value: {
+        projectId: "proj_123",
+        appId: "app_1",
+        appName: "hello-world",
+        region: "eu-central-1",
+        deploymentId: "dep_new",
+        deploymentEndpointDomain: "dep-new.fra.prisma.build",
+        appEndpointDomain: "hello-world.fra.prisma.build",
+        promoted: true,
+        previousDeploymentId: "dep_live",
+        previousDeploymentAction: "stopped",
+      },
+    });
+    const AppBuildStrategy = mockAppBuildStrategy();
+
+    vi.doMock("../src/lib/app/build", () => ({
+      AppBuildStrategy,
+    }));
+    vi.doMock("@prisma/compute-sdk", () => ({
+      ApiError: { is: () => false },
+      ComputeClient: class {
+        deploy = deploy;
+      },
+    }));
+
+    const { createAppProvider } = await import("../src/lib/app/app-provider");
+
+    const provider = createAppProvider({} as never);
+
+    const record = await provider.deployApp({
+      cwd: path.resolve("/tmp/next-smoke"),
+      projectId: "proj_123",
+      appId: "app_1",
+      appName: "hello-world",
+      buildType: "nextjs",
+      portMapping: { http: 3000 },
+    });
+
+    expect(deploy).toHaveBeenCalledWith(
+      expect.objectContaining({ skipPromote: undefined }),
+    );
+    expect(record).toEqual({
+      projectId: "proj_123",
+      app: {
+        id: "app_1",
+        name: "hello-world",
+        region: "eu-central-1",
+        liveDeploymentId: "dep_new",
+        liveUrl: "https://hello-world.fra.prisma.build",
+      },
+      deployment: {
+        id: "dep_new",
+        status: "running",
+        url: "https://hello-world.fra.prisma.build",
+        live: true,
+      },
+      promoted: true,
+    });
+  });
+
   it("treats re-adding an existing custom domain as idempotent", async () => {
     const client = {
       GET: vi.fn().mockImplementation((pathName: string) => {


### PR DESCRIPTION
## What

Adds a `--no-promote` flag to `prisma-cli app deploy` — a **promotionless deployment** that builds a new deployment **without** flipping the live pointer. Deploy stays promote-by-default; this is strictly opt-in.

When `--no-promote` is set:

- The new deployment is built, started, and polled to `running`, but **not promoted**.
- The **previous** deployment keeps serving live (its own URL and the App's live pointer are unchanged).
- The new deployment is "built, not live" and reachable only at its **own candidate URL**.
- A later `prisma-cli app promote <deployment-id>` makes it live (existing command, unchanged).

`promote` / `rollback` / `list-deploys` / `show-deploy` / `domain` and deploy's default behavior are untouched.

## Why — the CI build-then-verify path

CI wants to build a candidate, **health-check it** against a stable URL, and only then flip production. Promote-on-build gives CI no window to verify before customers see the new code. `--no-promote` splits the two steps:

```bash
prisma-cli app deploy --no-promote --json   # build candidate, get deployment.url
#  → curl / smoke-test result.deployment.url (the candidate's own URL)
prisma-cli app promote <deployment-id>       # flip production once green
```

Because a promotionless deploy **never replaces the live deployment**, it **bypasses the production-confirmation gate** (`enforceProductionDeployGate` → `PROD_DEPLOY_REQUIRES_FLAG`): `app deploy --no-promote` on the **production** branch builds a candidate **without `--prod`** and without a confirmation prompt.

## Grounding — SDK already supports it (no SDK / management-api change)

`@prisma/compute-sdk` `ComputeClient.deploy(options)` accepts `skipPromote?: boolean` (`DeployOptions` in `compute-client.d.ts`). With `skipPromote: true`, `deploy()` builds + starts + polls to `running` and returns:

```
{ ..., deploymentId, deploymentEndpointDomain, appEndpointDomain: null,
  promoted: false, previousDeploymentId, previousDeploymentAction: "still-active", ... }
```

`deploymentEndpointDomain` is the candidate's own URL (what CI health-checks); on the promoted path the SDK instead returns `appEndpointDomain: <live url>, promoted: true`. This PR only wires the CLI onto that existing SDK behavior.

## Changes

- **`lib/app/app-provider.ts`** — `deployApp` accepts `skipPromote`, forwards it to `sdk.deploy(...)`, and maps the return by `deployed.promoted`. When not promoted: `app.liveDeploymentId = previousDeploymentId` (the still-live old deployment), `deployment.live = false`, `promoted = false`. `DeployRecord` gains `promoted` and `deployment.live`. (The `liveUrl` / `deployment.url` expressions are unchanged from before — `appEndpointDomain` is null on the not-promoted path, so they already resolve to the candidate endpoint.)
- **`controllers/app.ts`** — threads `noPromote` into `deployApp({ skipPromote })`; skips `enforceProductionDeployGate` when `noPromote` (treating `firstProductionDeploy` as false); surfaces `promoted` + `deployment.live`; `nextSteps` lead with `app promote <id>` when not promoted.
- **`commands/app/index.ts`** — adds the `--no-promote` Commander option (same `--no-*` negatable idiom as the existing `--no-db`; exposes `options.promote === false`) and threads `noPromote`.
- **`presenters/app.ts`** — human output gains a "built, not live" branch: `Built <id> in <duration> (not promoted)`, the candidate URL, a note that the live deployment is unchanged, and a `Promote` hint. The promoted path is unchanged.
- **`types/app.ts`** — `AppDeployResult` gains `promoted` and `deployment.live`. `--json` (`serializeAppDeploy`) surfaces `result.promoted` and the candidate `result.deployment.{id,url,live}` (field name `url` kept, so existing consumers reading `.result.deployment.url` get the candidate URL under `--no-promote`).
- **`docs/product/command-spec.md`** — documents the flag (signature, behavior, gate bypass, output, deploy-all propagation, example), per this package's doc-driven-development rule.

## Tests

Extended the existing suites (562 passing, +7 new):

- **provider**: `deployApp({ skipPromote: true })` forwards it to `sdk.deploy` and maps the promotionless return (candidate URL, `deployment.live: false`, `promoted: false`, live pointer stays on `previousDeploymentId`); plus the promoted mapping.
- **controller**: `--no-promote` calls `deployApp` with `skipPromote: true`, returns `promoted: false` + candidate URL + `deployment.live: false`, and `nextSteps` include `app promote <id>`; and `--no-promote` on the production branch **does not** call `listDeployments` (gate bypassed) and deploys without `--prod`.
- **CLI layer**: `--no-promote` threads `noPromote: true` into `runAppDeploy` and `--json` surfaces `promoted: false` + the candidate `deployment.url`.
- **presenter**: not-promoted human output (built-not-live + promote hint) and JSON shape.

`pnpm --filter @prisma/cli test` (562 pass), `tsc --noEmit`, and `biome check` all pass; CLI builds; `node dist/cli.js app deploy --help` shows `--no-promote`.

> Note: the CI rewrite in `pdp-control-plane` that consumes this flag is a separate follow-up, gated on the CLI release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)