### PR TITLE
chore(cli): bump @prisma/compute-sdk to 0.34.0 (Windows PATH fix)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.5.0",
-    "@prisma/compute-sdk": "0.33.0",
+    "@prisma/compute-sdk": "0.34.0",
     "@prisma/credentials-store": "^7.8.0",
     "@prisma/management-api-sdk": "^1.46.0",
     "better-result": "^2.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
       '@prisma/compute-sdk':
-        specifier: 0.33.0
-        version: 0.33.0(@prisma/management-api-sdk@1.46.0)(rollup@4.62.2)
+        specifier: 0.34.0
+        version: 0.34.0(@prisma/management-api-sdk@1.46.0)(rollup@4.62.2)
       '@prisma/credentials-store':
         specifier: ^7.8.0
         version: 7.8.0
@@ -551,8 +551,8 @@ packages:
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
-  '@prisma/compute-sdk@0.33.0':
-    resolution: {integrity: sha512-lk+WOfh0km/HbqcOsFtGYUTkQjTzESZcR8q7FPX1xtuyp7ccoFNTGKhDqM5VJw6GLeQgCeZlkdAZXBtHRfN7Vw==}
+  '@prisma/compute-sdk@0.34.0':
+    resolution: {integrity: sha512-AmVOQIsct2eNJvm2SRx1Ut90/FzHdEG17SqdcvrhJLW1Zj0lGGBcxfp93evMoeP3KdReoV9gnmtDxfq3mI2z0Q==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@prisma/management-api-sdk': ^1.44.0
@@ -1932,7 +1932,7 @@ snapshots:
 
   '@oxc-project/types@0.127.0': {}
 
-  '@prisma/compute-sdk@0.33.0(@prisma/management-api-sdk@1.46.0)(rollup@4.62.2)':
+  '@prisma/compute-sdk@0.34.0(@prisma/management-api-sdk@1.46.0)(rollup@4.62.2)':
     dependencies:
       '@prisma/management-api-sdk': 1.46.0
       '@vercel/nft': 1.10.2(rollup@4.62.2)


### PR DESCRIPTION
Bumps `@prisma/compute-sdk` 0.33.0 -> 0.34.0 to pick up the Windows build fix ([project-compute#105](https://github.com/prisma/project-compute/pull/105), published as 0.34.0).

## What this fixes

On Windows, `prisma-cli app build` and `app deploy` failed immediately with `'bun' is not recognized as an internal or external command` even with Bun installed. The SDK's `buildCommandEnv` wrote a literal `PATH` key over Windows' `Path`-cased variable, forking a duplicate key whose bin-dirs-only value shadowed the real system PATH in the spawned build shell. 0.34.0 resolves the key case-insensitively and extends it in place.

Supersedes #115, which patched the same bug CLI-side; the root cause is SDK-owned.

## Notes

- The lockfile was still resolving compute-sdk 0.31.0 despite the 0.33.0 pin in `packages/cli/package.json`; this refresh brings the installed version in line with the manifest.
- Verified the published 0.34.0 tarball contains the fix, and the full CLI suite (45 files, 624 tests) plus build pass against it.
- Windows follow-ups tracked SDK-side: execa migration for the `.cmd` launcher ladder and a `windows-latest` CI leg.