### PR TITLE
feat(cli): run app dev candidates through execa

### DIFF
--- a/packages/cli/src/lib/app/local-dev.ts
+++ b/packages/cli/src/lib/app/local-dev.ts
@@ -270,9 +270,7 @@ async function runWithFallback(
 /**
  * Runs one candidate to completion with inherited stdio, returning its exit
  * information, or "unavailable" when the binary does not exist so the ladder
- * can try the next candidate. execa spawns through cross-spawn, so Windows
- * `.cmd` shims (npx, `node_modules/.bin` entries) resolve via PATHEXT instead
- * of failing with a false ENOENT.
+ * can try the next candidate.
  */
 async function spawnCommand(
   candidate: CommandCandidate,
@@ -288,10 +286,9 @@ async function spawnCommand(
       signal: NodeJS.Signals | null;
     }
 > {
-  // The caller passes the full runtime env; extending over process.env again
-  // would let parent vars leak past a deliberate omission.
   const result = await execa(candidate.command, candidate.args, {
     cwd: options.cwd,
+    // The env is fully constructed by the caller; do not re-merge process.env.
     env: options.env,
     extendEnv: false,
     cancelSignal: options.signal,

--- a/packages/cli/src/lib/app/local-dev.ts
+++ b/packages/cli/src/lib/app/local-dev.ts
@@ -1,8 +1,9 @@
 // biome-ignore-all lint/performance/noAwaitInLoops: Local app detection and command fallbacks must short-circuit sequentially.
 // biome-ignore-all lint/performance/useTopLevelRegex: Existing package script regexes are kept inline for readability.
-import { type SpawnOptions, spawn } from "node:child_process";
 import { access } from "node:fs/promises";
 import path from "node:path";
+
+import { execa } from "execa";
 import type { AppBuildType, ResolvedAppBuildType } from "./build";
 import {
   readBunPackageEntrypoint,
@@ -74,17 +75,11 @@ export async function runLocalApp(options: {
   port: number;
   env: NodeJS.ProcessEnv;
   signal?: AbortSignal;
-  spawnImpl?: typeof spawn;
 }): Promise<LocalRunResult> {
-  const spawnImpl = options.spawnImpl ?? spawn;
-
   if (options.buildType === "nextjs") {
-    const localBin = path.join(
-      options.appPath,
-      "node_modules",
-      ".bin",
-      process.platform === "win32" ? "next.cmd" : "next",
-    );
+    // execa resolves Windows `.cmd` shims via PATHEXT (cross-spawn), so the
+    // extensionless bin path works on every platform.
+    const localBin = path.join(options.appPath, "node_modules", ".bin", "next");
     const command = await runWithFallback(
       [
         {
@@ -111,7 +106,6 @@ export async function runLocalApp(options: {
         },
         signal: options.signal,
       },
-      spawnImpl,
       "Could not find the Next.js CLI. Install it with `npm install next` or ensure npx/bunx is available.",
     );
 
@@ -146,7 +140,6 @@ export async function runLocalApp(options: {
       },
       signal: options.signal,
     },
-    spawnImpl,
     "Bun is required to run this app locally. Install it from https://bun.sh.",
   );
 
@@ -248,8 +241,11 @@ function hasDependency(
 }
 async function runWithFallback(
   candidates: CommandCandidate[],
-  options: SpawnOptions,
-  spawnImpl: typeof spawn,
+  options: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    signal?: AbortSignal;
+  },
   missingCommandMessage: string,
 ): Promise<{
   display: string;
@@ -257,45 +253,68 @@ async function runWithFallback(
   signal: NodeJS.Signals | null;
 }> {
   for (const candidate of candidates) {
-    try {
-      const result = await spawnCommand(candidate, options, spawnImpl);
-      return {
-        display: candidate.display,
-        exitCode: result.exitCode,
-        signal: result.signal,
-      };
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-        continue;
-      }
-
-      throw error;
+    const result = await spawnCommand(candidate, options);
+    if (result === "unavailable") {
+      continue;
     }
+    return {
+      display: candidate.display,
+      exitCode: result.exitCode,
+      signal: result.signal,
+    };
   }
 
   throw new Error(missingCommandMessage);
 }
 
-function spawnCommand(
+/**
+ * Runs one candidate to completion with inherited stdio, returning its exit
+ * information, or "unavailable" when the binary does not exist so the ladder
+ * can try the next candidate. execa spawns through cross-spawn, so Windows
+ * `.cmd` shims (npx, `node_modules/.bin` entries) resolve via PATHEXT instead
+ * of failing with a false ENOENT.
+ */
+async function spawnCommand(
   candidate: CommandCandidate,
-  options: SpawnOptions,
-  spawnImpl: typeof spawn,
-): Promise<{
-  exitCode: number;
-  signal: NodeJS.Signals | null;
-}> {
-  return new Promise((resolve, reject) => {
-    const child = spawnImpl(candidate.command, candidate.args, {
-      ...options,
-      stdio: "inherit",
-    });
-
-    child.once("error", reject);
-    child.once("exit", (code, signal) => {
-      resolve({
-        exitCode: code ?? 1,
-        signal,
-      });
-    });
+  options: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    signal?: AbortSignal;
+  },
+): Promise<
+  | "unavailable"
+  | {
+      exitCode: number;
+      signal: NodeJS.Signals | null;
+    }
+> {
+  // The caller passes the full runtime env; extending over process.env again
+  // would let parent vars leak past a deliberate omission.
+  const result = await execa(candidate.command, candidate.args, {
+    cwd: options.cwd,
+    env: options.env,
+    extendEnv: false,
+    cancelSignal: options.signal,
+    stdio: "inherit",
+    reject: false,
   });
+
+  if (result.code === "ENOENT") {
+    return "unavailable";
+  }
+  // Started but did not spawn cleanly for another reason (e.g. EACCES):
+  // surface it rather than misreporting it as an app exit.
+  if (
+    result.failed &&
+    result.exitCode === undefined &&
+    result.signal === undefined &&
+    !result.isCanceled
+  ) {
+    throw new Error(result.shortMessage, { cause: result.cause });
+  }
+
+  return {
+    exitCode: result.exitCode ?? 1,
+    signal: (result.signal ?? null) as NodeJS.Signals | null,
+  };
 }


### PR DESCRIPTION
Companion to [project-compute#106](https://github.com/prisma/project-compute/pull/106) (approved): the SDK's spawn layer moved to execa there; this migrates the one remaining Windows-broken spawn site in the CLI, the `app dev` launcher ladder in `lib/app/local-dev.ts`.

## Why

The ladder spawned candidates with raw `spawn` and no shell. On Windows, `npx` is a `.cmd` shim, which raw `spawn` cannot launch (only `.exe`/`.com` resolve), so the npx rung always failed with a false ENOENT and Next.js dev degraded to bunx-or-bust. There was even a hand-rolled `next.cmd` special case for the local-bin rung; execa (via cross-spawn, PATHEXT) makes that unnecessary, so it's gone.

execa is already a CLI dependency (`controllers/init.ts`, `controllers/agent.ts`), so no new ecosystem choice.

## Survey of remaining spawn sites (checked all of `packages/`)

- `lib/app/local-dev.ts`: migrated here.
- `shell/update-check.ts`: spawns `process.execPath` (an absolute path to the running Node binary) detached and unref'd. No PATH or shim resolution involved, no output handling, and execa adds nothing but risk around `unref` semantics. Left as is, deliberately.
- `adapters/git.ts`, `lib/git/local-status.ts`: `execFile("git", ...)`; `git.exe` resolves fine on Windows. Left as is.

## Behavior preserved

- Inherited stdio (the dev server streams straight to the terminal).
- ENOENT falls through to the next candidate; ladder exhaustion still throws the friendly install message.
- Exit code and termination signal are reported, and abort still surfaces as SIGTERM so the controller's cancel mapping (`AbortError`) is unchanged.
- Child env passed exactly (`extendEnv: false`).
- One deliberate improvement: a non-ENOENT spawn failure (e.g. EACCES) now surfaces with execa's readable message instead of a raw errno throw.
- Dropped the unused `spawnImpl` injection seam; nothing consumed it (tests mock `runLocalApp` itself).

## Testing

- Full suite: 45 files / 624 tests pass; typecheck and build clean.
- Live smoke of the migrated path: a real `bun --watch` app spawns, streams output, and terminates cleanly on abort (`SIGTERM` reported); an all-ENOENT ladder (empty PATH) produces the friendly message.