### PR TITLE
feat(cli): add --branch to app remove to scope teardown to one branch

### DIFF
--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -2228,16 +2228,18 @@ prisma-cli app rollback
 prisma-cli app rollback --app hello-world --to dep_123
 ```
 
-## `prisma-cli app remove [app] --app <name> -y --yes`
+## `prisma-cli app remove [app] --app <name> --branch <name> -y --yes`
 
 Purpose:
 
-- remove the app from the current branch
+- remove the app, and every deployment it owns, from the resolved branch
 
 Behavior:
 
 - requires auth and project context
-- resolves the selected app
+- resolves the selected app on the resolved branch
+- `--branch <name>` scopes the removal to that branch, honored as-is; an empty value is rejected rather than inferred
+- without `--branch`, the branch is inferred (active Git branch, else the project's default production branch), so automation that must not touch production should always pass `--branch`
 - requires confirmation unless `-y` or `--yes` is passed
 - clears local selected app state when the removed app was selected
 
@@ -2246,4 +2248,5 @@ Examples:
 ```bash
 prisma-cli app remove --app hello-world
 prisma-cli app remove --app hello-world --yes
+prisma-cli app remove --app hello-world --branch feature/foo --yes
 ```

--- a/packages/cli/src/commands/app/index.ts
+++ b/packages/cli/src/commands/app/index.ts
@@ -835,18 +835,21 @@ function createRemoveCommand(runtime: CliRuntime): Command {
       "App target from prisma.compute.ts when the config defines multiple apps",
     )
     .addOption(new Option("--app <name>", "App name"))
-    .addOption(new Option("--project <id-or-name>", "Project id or name"));
+    .addOption(new Option("--project <id-or-name>", "Project id or name"))
+    .addOption(new Option("--branch <name>", "Branch name"));
   addGlobalFlags(command);
 
   command.action(async (configTarget: string | undefined, options) => {
     const appName = (options as { app?: string }).app;
     const projectRef = (options as { project?: string }).project;
+    const branchName = (options as { branch?: string }).branch;
 
     await runCommand<AppRemoveResult>(
       runtime,
       "app.remove",
       options as Record<string, unknown>,
-      (context) => runAppRemove(context, appName, projectRef, configTarget),
+      (context) =>
+        runAppRemove(context, appName, projectRef, configTarget, branchName),
       {
         renderHuman: (context, descriptor, result) =>
           renderAppRemove(context, descriptor, result),

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -2055,9 +2055,22 @@ export async function runAppRemove(
   // removal to a specific branch instead of relying on implicit Git-branch
   // resolution, which falls back to the production branch when it can't read a
   // local branch. Without --branch, keep the existing inferred resolution.
-  const branch = branchName
-    ? await resolveDeployBranch(context, branchName)
-    : undefined;
+  // Reject an explicitly supplied empty --branch rather than letting it fall
+  // through to inference — the caller asked to scope the removal, so a blank
+  // value is a mistake, not a request for the default branch.
+  if (branchName !== undefined && branchName.trim() === "") {
+    throw usageError(
+      "The --branch value cannot be empty",
+      "app remove scopes the removal to the given branch; an empty --branch would silently fall back to the inferred (possibly production) branch.",
+      "Pass a non-empty branch name, e.g. --branch <branch>, or omit --branch to use the inferred branch.",
+      ["prisma-cli app remove --app <name> --branch <branch>"],
+      "app",
+    );
+  }
+  const branch =
+    branchName !== undefined
+      ? await resolveDeployBranch(context, branchName)
+      : undefined;
   const { provider, target, projectId } =
     await requireProviderAndProjectContext(context, projectRef, {
       branch,

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -2040,6 +2040,7 @@ export async function runAppRemove(
   appName: string | undefined,
   projectRef?: string,
   configTarget?: string,
+  branchName?: string,
 ): Promise<CommandSuccess<AppRemoveResult>> {
   ensurePreviewAppMode(context);
 
@@ -2049,8 +2050,17 @@ export async function runAppRemove(
     "remove",
   );
   appName = appName ?? compute.configAppName;
+  // Removing an app destroys every deployment in the *resolved branch*. Thread
+  // an explicit --branch through so callers (e.g. PR-teardown CI) can scope the
+  // removal to a specific branch instead of relying on implicit Git-branch
+  // resolution, which falls back to the production branch when it can't read a
+  // local branch. Without --branch, keep the existing inferred resolution.
+  const branch = branchName
+    ? await resolveDeployBranch(context, branchName)
+    : undefined;
   const { provider, target, projectId } =
     await requireProviderAndProjectContext(context, projectRef, {
+      branch,
       commandName: "app remove",
       projectDir: compute.projectDir,
     });

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -2035,6 +2035,12 @@ export async function runAppRollback(
   };
 }
 
+/**
+ * Removes an app and every deployment it owns in the resolved branch.
+ *
+ * @param branchName Scopes the removal to this branch. When omitted the branch
+ * is inferred from the local Git branch, falling back to the production branch.
+ */
 export async function runAppRemove(
   context: CommandContext,
   appName: string | undefined,
@@ -2050,14 +2056,7 @@ export async function runAppRemove(
     "remove",
   );
   appName = appName ?? compute.configAppName;
-  // Removing an app destroys every deployment in the *resolved branch*. Thread
-  // an explicit --branch through so callers (e.g. PR-teardown CI) can scope the
-  // removal to a specific branch instead of relying on implicit Git-branch
-  // resolution, which falls back to the production branch when it can't read a
-  // local branch. Without --branch, keep the existing inferred resolution.
-  // Reject an explicitly supplied empty --branch rather than letting it fall
-  // through to inference — the caller asked to scope the removal, so a blank
-  // value is a mistake, not a request for the default branch.
+  // A blank --branch must not fall through to inference, which can reach production.
   if (branchName !== undefined && branchName.trim() === "") {
     throw usageError(
       "The --branch value cannot be empty",

--- a/packages/cli/src/shell/command-meta.ts
+++ b/packages/cli/src/shell/command-meta.ts
@@ -639,10 +639,11 @@ const DESCRIPTORS: CommandDescriptor[] = [
   {
     id: "app.remove",
     path: ["prisma", "app", "remove"],
-    description: "Remove the app from the current branch",
+    description: "Remove the app from the resolved branch",
     examples: [
       "prisma-cli app remove --app hello-world",
       "prisma-cli app remove --app hello-world --yes",
+      "prisma-cli app remove --app hello-world --branch feature/foo --yes",
     ],
   },
   {

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -6893,6 +6893,81 @@ describe("app controller", () => {
     );
   });
 
+  it("app remove forwards --branch from the parsed command through to the provider", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+    const listApps = vi.fn().mockResolvedValue([
+      {
+        id: "app_1",
+        name: "hello-world",
+        region: "eu-central-1",
+        liveDeploymentId: null,
+      },
+    ]);
+    const removeApp = vi.fn().mockResolvedValue({
+      id: "app_1",
+      name: "hello-world",
+    });
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
+        withBranchDatabaseProviderDefaults({
+          resolveBranch: createResolveBranch(),
+          createProject: vi.fn(),
+          listApps,
+          removeApp,
+          promoteDeployment: vi.fn(),
+          deployApp: vi.fn(),
+          listDeployments: vi.fn(),
+          showDeployment: vi.fn(),
+        }),
+      ),
+    }));
+
+    const { createAppCommand } = await import("../src/commands/app");
+    const { createTempCwd, createTestCommandContext } = await import(
+      "./helpers"
+    );
+    const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir: path.join(cwd, ".state"),
+      flags: {
+        yes: true,
+      },
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    const app = createAppCommand(context.runtime);
+    await app.parseAsync(
+      [
+        "remove",
+        "--app",
+        "hello-world",
+        "--branch",
+        "pr-42",
+        "--yes",
+        "--json",
+      ],
+      { from: "user" },
+    );
+
+    // Proves the whole chain: commander parses --branch, createRemoveCommand
+    // forwards options.branch to runAppRemove, and the controller scopes the
+    // lookup to that branch. Dropping the forwarding falls back to the inferred
+    // branch and fails this assertion.
+    expect(listApps).toHaveBeenCalledWith(
+      "proj_123",
+      expect.objectContaining({ branchName: "pr-42" }),
+    );
+  });
+
   it("remove prompts for confirmation in interactive mode", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
     const listApps = vi.fn().mockResolvedValue([

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -6958,10 +6958,6 @@ describe("app controller", () => {
       { from: "user" },
     );
 
-    // Proves the whole chain: commander parses --branch, createRemoveCommand
-    // forwards options.branch to runAppRemove, and the controller scopes the
-    // lookup to that branch. Dropping the forwarding falls back to the inferred
-    // branch and fails this assertion.
     expect(listApps).toHaveBeenCalledWith(
       "proj_123",
       expect.objectContaining({ branchName: "pr-42" }),

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -6824,6 +6824,75 @@ describe("app controller", () => {
     });
   });
 
+  it("remove rejects an explicitly empty --branch instead of inferring a branch", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+    const listApps = vi.fn();
+    const removeApp = vi.fn();
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
+        withBranchDatabaseProviderDefaults({
+          resolveBranch: createResolveBranch(),
+          createProject: vi.fn(),
+          listApps,
+          removeApp,
+          promoteDeployment: vi.fn(),
+          deployApp: vi.fn(),
+          listDeployments: vi.fn(),
+          showDeployment: vi.fn(),
+        }),
+      ),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import(
+      "./helpers"
+    );
+    const { runAppRemove } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      flags: {
+        yes: true,
+      },
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await expect(
+      runAppRemove(context, "hello-world", undefined, undefined, "   "),
+    ).rejects.toThrow(/branch value cannot be empty/i);
+    expect(listApps).not.toHaveBeenCalled();
+    expect(removeApp).not.toHaveBeenCalled();
+  });
+
+  it("app remove registers a --branch option (regression guard for the CLI wiring)", async () => {
+    const { createAppCommand } = await import("../src/commands/app");
+    const { createTempCwd, createTestCommandContext } = await import(
+      "./helpers"
+    );
+    const cwd = await createTempCwd();
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir: path.join(cwd, ".state"),
+    });
+
+    const app = createAppCommand(context.runtime);
+    const remove = app.commands.find((command) => command.name() === "remove");
+
+    expect(remove).toBeDefined();
+    expect(remove?.options.some((option) => option.long === "--branch")).toBe(
+      true,
+    );
+  });
+
   it("remove prompts for confirmation in interactive mode", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
     const listApps = vi.fn().mockResolvedValue([

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -6761,6 +6761,69 @@ describe("app controller", () => {
     ).resolves.toBeNull();
   });
 
+  it("remove scopes the app lookup to an explicit --branch", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+    const listApps = vi.fn().mockResolvedValue([
+      {
+        id: "app_1",
+        name: "hello-world",
+        region: "eu-central-1",
+        liveDeploymentId: null,
+      },
+    ]);
+    const removeApp = vi.fn().mockResolvedValue({
+      id: "app_1",
+      name: "hello-world",
+    });
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
+        withBranchDatabaseProviderDefaults({
+          resolveBranch: createResolveBranch(),
+          createProject: vi.fn(),
+          listApps,
+          removeApp,
+          promoteDeployment: vi.fn(),
+          deployApp: vi.fn(),
+          listDeployments: vi.fn(),
+          showDeployment: vi.fn(),
+        }),
+      ),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import(
+      "./helpers"
+    );
+    const { runAppRemove } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      flags: {
+        yes: true,
+      },
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    await runAppRemove(context, "hello-world", undefined, undefined, "pr-42");
+
+    expect(listApps).toHaveBeenCalledWith(
+      "proj_123",
+      expect.objectContaining({ branchName: "pr-42" }),
+    );
+    expect(removeApp).toHaveBeenCalledWith("app_1", {
+      signal: context.runtime.signal,
+    });
+  });
+
   it("remove prompts for confirmation in interactive mode", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
     const listApps = vi.fn().mockResolvedValue([

--- a/packages/cli/tests/app.test.ts
+++ b/packages/cli/tests/app.test.ts
@@ -254,10 +254,13 @@ describe("app commands", () => {
 
     expect(removeHelp.exitCode).toBe(0);
     expect(removeHelp.stderr).toContain(
-      "Remove the app from the current branch",
+      "Remove the app from the resolved branch",
     );
     expect(removeHelp.stderr).toContain(
       "$ prisma-cli app remove --app hello-world",
+    );
+    expect(removeHelp.stderr).toContain(
+      "$ prisma-cli app remove --app hello-world --branch feature/foo --yes",
     );
   });
 


### PR DESCRIPTION
## Why

`app remove` destroys **every deployment in the resolved branch**. But it had **no `--branch` flag** — it inferred the branch from the local Git branch and, when it couldn't read one, **fell back to the production branch (`main`)**:

```ts
const gitBranch = await readLocalGitBranch(context.runtime.cwd);
if (gitBranch) return { name: gitBranch, ... };
return { name: "main", annotation: "default" };   // silent production fallback
```

A PR-teardown CI job that fakes a `.git/HEAD` to convey the PR branch (because there was no other lever) could therefore silently resolve to production and tear down the **live** app. This is exactly the mechanism behind a production incident on 2026-07-20 where `app remove --app build-runner` / `--app github-webhook` stopped the live production deployments.

## What

- Add `--branch <name>` to `app remove`, mirroring `app deploy`. Callers scope the removal to a specific branch instead of relying on implicit Git resolution.
- Without `--branch`, the existing inferred resolution is unchanged (no behavior change for current users).

The consuming CI workflow (`pdp-control-plane` `pr-closed.yaml`) will pass `--branch "$PR_BRANCH"` explicitly, so teardown can never resolve to production.

## Follow-up (not in this PR)

Consider hardening `app remove` itself to refuse an **inferred** (non-`--branch`) production target in non-interactive mode, so the silent `main` fallback can't tear down production even without a `--branch`-aware caller. Left out here to avoid changing existing no-`--branch` behavior/tests.

## Tests

- New: `remove scopes the app lookup to an explicit --branch` (asserts `listApps` is scoped to the passed branch).
- Full `app-controller` suite green (103 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)