### PR TITLE
fix(cli): don't assume newest deployment is live in promote resolution

### DIFF
--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -3097,6 +3097,14 @@ function requireDeploymentForApp(
   });
 }
 
+/**
+ * Resolves the app's live deployment from the app pointer, the provider's live
+ * flag, then locally cached state.
+ *
+ * @returns the live deployment id, or null when no authoritative signal exists.
+ * Callers must treat null as "not known to be live" rather than assuming the
+ * newest deployment is live.
+ */
 async function resolveCurrentLiveDeploymentId(
   context: CommandContext,
   projectId: string,
@@ -3126,11 +3134,6 @@ async function resolveCurrentLiveDeploymentId(
     return knownLiveDeploymentId;
   }
 
-  // No authoritative live signal (app pointer, provider flag, or local state):
-  // report "no known live deployment" rather than assuming the newest one is
-  // live. Guessing newest-is-live makes a promote treat its own freshly created
-  // candidate as already-live and skip the endpoint rebind, so an app whose live
-  // pointer was cleared never gets re-bound and stays unreachable.
   return null;
 }
 

--- a/packages/cli/src/controllers/app.ts
+++ b/packages/cli/src/controllers/app.ts
@@ -3126,7 +3126,12 @@ async function resolveCurrentLiveDeploymentId(
     return knownLiveDeploymentId;
   }
 
-  return deployments[0]?.id ?? null;
+  // No authoritative live signal (app pointer, provider flag, or local state):
+  // report "no known live deployment" rather than assuming the newest one is
+  // live. Guessing newest-is-live makes a promote treat its own freshly created
+  // candidate as already-live and skip the endpoint rebind, so an app whose live
+  // pointer was cleared never gets re-bound and stays unreachable.
+  return null;
 }
 
 function buildAppShowNextSteps(

--- a/packages/cli/tests/app-controller.test.ts
+++ b/packages/cli/tests/app-controller.test.ts
@@ -5912,6 +5912,79 @@ describe("app controller", () => {
     ]);
   });
 
+  it("promote rebinds instead of assuming the newest deployment is live when there is no authoritative live signal", async () => {
+    const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
+    const listApps = vi.fn().mockResolvedValue([
+      {
+        id: "app_1",
+        name: "hello-world",
+        region: "eu-west-3",
+        liveDeploymentId: null,
+      },
+    ]);
+    const listDeployments = vi.fn().mockResolvedValue({
+      app: {
+        id: "app_1",
+        name: "hello-world",
+        region: "eu-west-3",
+        liveDeploymentId: null,
+      },
+      deployments: [
+        {
+          id: "dep_2",
+          status: "running",
+          url: "https://preview-2.prisma.app",
+          createdAt: "2026-04-11T12:00:00.000Z",
+          live: false,
+        },
+      ],
+    });
+    const promoteDeployment = vi.fn().mockResolvedValue(undefined);
+
+    vi.doMock("../src/lib/auth/guard", () => ({
+      requireComputeAuth,
+    }));
+    vi.doMock("../src/lib/app/app-provider", () => ({
+      createAppProvider: vi.fn(() =>
+        withBranchDatabaseProviderDefaults({
+          resolveBranch: createResolveBranch(),
+          createProject: vi.fn(),
+          listApps,
+          promoteDeployment,
+          deployApp: vi.fn(),
+          listDeployments,
+          showDeployment: vi.fn(),
+        }),
+      ),
+    }));
+
+    const { createTempCwd, createTestCommandContext } = await import(
+      "./helpers"
+    );
+    const { runAppPromote } = await import("../src/controllers/app");
+    const cwd = await createTempCwd();
+    await writeLocalPin(cwd, { workspaceId: "ws_123", projectId: "proj_123" });
+    const stateDir = path.join(cwd, ".state");
+    const { context } = await createTestCommandContext({
+      cwd,
+      stateDir,
+      env: {
+        ...process.env,
+        PRISMA_CLI_MOCK_FIXTURE_PATH: undefined,
+      },
+    });
+
+    const result = await runAppPromote(context, "dep_2", "hello-world");
+
+    expect(promoteDeployment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId: "app_1",
+        deploymentId: "dep_2",
+      }),
+    );
+    expect(result.warnings).toEqual([]);
+  });
+
   it("rollback chooses the previous deployment when no explicit target is provided", async () => {
     const requireComputeAuth = vi.fn().mockResolvedValue(createProjectClient());
     const listApps = vi.fn().mockResolvedValue([


### PR DESCRIPTION
## Why

`resolveCurrentLiveDeploymentId` fell back to `deployments[0]` (the **newest** deployment) when no authoritative live signal was available (`app.liveDeploymentId`, the provider `live` flag, or local known-live state):

```ts
return deployments[0]?.id ?? null;
```

During `app promote`, this made a **freshly created candidate** look like it was *already live*, so promote emitted "The selected deployment is already live for this app." and **skipped the endpoint rebind**. An app whose live pointer had been cleared (e.g. its live deployment was stopped) therefore never got re-bound — every subsequent deploy hit the same false "already live" and left the app unreachable.

This was the second half of a production incident on 2026-07-20: after the live deployments of build-runner/github-webhook were stopped (clearing `latestDeploymentId`), each CI redeploy's promote step read the null pointer, hit this fallback, and skipped the rebind — turning a transient stop into a ~1h outage.

## What

Return `null` instead of guessing the newest. "Unknown live deployment" now means **not already-live**, so promote proceeds and rebinds the endpoint.

## Tests

- New: `promote rebinds instead of assuming the newest deployment is live when there is no authoritative live signal`.
- Full `app-controller` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)