### PR TITLE
feat(cli): require --confirm for bucket delete and document cascade deletion

### DIFF
--- a/docs/product/command-spec.md
+++ b/docs/product/command-spec.md
@@ -1344,21 +1344,22 @@ prisma-cli bucket create --name my-store
 prisma-cli bucket create --branch preview --json
 ```
 
-### `prisma-cli bucket delete <bucketId>`
+### `prisma-cli bucket delete <bucketId> --confirm <bucketId>`
 
 Purpose:
 
-- delete a bucket and all its access keys
+- permanently delete a bucket, all objects stored in it, and all its access keys
 
 Behavior:
 
 - requires auth
 - treats `<bucketId>` as the bucket id to delete
-- removes the bucket and all its access keys through the Management API
+- requires `--confirm <bucketId>` to match the positional argument exactly;
+  exits with code 2 and `CONFIRMATION_REQUIRED` if the flag is missing or
+  does not match
+- cascades the deletion through the Management API: all stored objects are
+  removed and then all access keys are revoked before the bucket is destroyed
 - fails with `BUCKET_NOT_FOUND` when the bucket id does not exist
-- deletion requires the bucket to be empty; deleting a bucket that still
-  contains objects currently fails with an internal Management API error
-  rather than a conflict error
 
 In `--json`, `result` uses this shape:
 
@@ -1371,8 +1372,8 @@ In `--json`, `result` uses this shape:
 Examples:
 
 ```bash
-prisma-cli bucket delete bkt_123
-prisma-cli bucket delete bkt_123 --json
+prisma-cli bucket delete bkt_123 --confirm bkt_123
+prisma-cli bucket delete bkt_123 --confirm bkt_123 --json
 ```
 
 ### `prisma-cli bucket key list <bucketId>`

--- a/docs/product/resource-model.md
+++ b/docs/product/resource-model.md
@@ -179,9 +179,10 @@ Rules:
   block on stdout: `S3_ENDPOINT`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`,
   `S3_BUCKET`
 - `bucket list` and `bucket key list` never print or return secret values
-- successful bucket deletion also revokes all of the bucket's access keys;
-  deletion requires the bucket to be empty and currently fails with an
-  internal Management API error when it is not
+- `bucket delete` cascades: all stored objects are removed and all access
+  keys are revoked before the bucket is destroyed; the command requires
+  `--confirm <bucket-id>` matching the positional argument to prevent
+  accidental data loss
 
 The beta package exposes:
 

--- a/packages/cli/src/commands/bucket/index.ts
+++ b/packages/cli/src/commands/bucket/index.ts
@@ -133,14 +133,19 @@ function createBucketDeleteCommand(runtime: CliRuntime): Command {
   );
 
   command.argument("<bucketId>", "Bucket id");
+  command.addOption(
+    new Option("--confirm <bucket-id>", "Exact bucket id to confirm deletion"),
+  );
   addGlobalFlags(command);
 
   command.action(async (bucketId: string, options) => {
+    const confirm = (options as { confirm?: string }).confirm;
+
     await runCommand<BucketDeleteResult>(
       runtime,
       "bucket.delete",
       options as Record<string, unknown>,
-      (context) => runBucketDelete(context, bucketId),
+      (context) => runBucketDelete(context, bucketId, { confirm }),
       {
         renderHuman: (context, descriptor, result) =>
           renderBucketDelete(context, descriptor, result),

--- a/packages/cli/src/controllers/bucket.ts
+++ b/packages/cli/src/controllers/bucket.ts
@@ -40,6 +40,10 @@ interface BucketCreateFlags extends BucketCommandFlags {
   name?: string;
 }
 
+interface BucketDeleteFlags {
+  confirm?: string;
+}
+
 interface BucketKeyCreateFlags {
   role?: string;
   name?: string;
@@ -118,6 +122,7 @@ export async function runBucketCreate(
 export async function runBucketDelete(
   context: CommandContext,
   bucketId: string,
+  flags: BucketDeleteFlags,
 ): Promise<CommandSuccess<BucketDeleteResult>> {
   const id = bucketId.trim();
   if (!id) {
@@ -129,6 +134,19 @@ export async function runBucketDelete(
       fix: "Pass the bucket id to delete.",
       exitCode: 2,
       nextSteps: ["prisma-cli bucket list"],
+    });
+  }
+
+  if (flags.confirm !== id) {
+    throw new CliError({
+      code: "CONFIRMATION_REQUIRED",
+      domain: "bucket",
+      summary: "Confirm bucket deletion",
+      why: "Deleting this bucket permanently removes all objects and access keys.",
+      fix: `Rerun with --confirm ${id}.`,
+      exitCode: 2,
+      nextSteps: [`prisma-cli bucket delete ${id} --confirm ${id}`],
+      meta: { expectedConfirm: id, receivedConfirm: flags.confirm ?? null },
     });
   }
 

--- a/packages/cli/tests/bucket.test.ts
+++ b/packages/cli/tests/bucket.test.ts
@@ -199,7 +199,7 @@ describe("bucket commands", () => {
     const { cwd, stateDir } = await setupLinkedProject();
 
     const result = await executeCli({
-      argv: ["bucket", "delete", "bkt_123", "--json"],
+      argv: ["bucket", "delete", "bkt_123", "--confirm", "bkt_123", "--json"],
       cwd,
       stateDir,
       fixturePath,
@@ -217,11 +217,57 @@ describe("bucket commands", () => {
     });
   });
 
+  it("requires --confirm matching the bucket id before deletion", async () => {
+    const { cwd, stateDir } = await setupLinkedProject();
+
+    const noConfirm = await executeCli({
+      argv: ["bucket", "delete", "bkt_123", "--json"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+    const noConfirmPayload = JSON.parse(noConfirm.stdout);
+
+    expect(noConfirm.exitCode).toBe(2);
+    expect(noConfirmPayload).toMatchObject({
+      ok: false,
+      command: "bucket.delete",
+      error: {
+        code: "CONFIRMATION_REQUIRED",
+        domain: "bucket",
+        meta: { expectedConfirm: "bkt_123", receivedConfirm: null },
+      },
+    });
+  });
+
+  it("rejects --confirm that does not match the bucket id", async () => {
+    const { cwd, stateDir } = await setupLinkedProject();
+
+    const wrongConfirm = await executeCli({
+      argv: ["bucket", "delete", "bkt_123", "--confirm", "bkt_456", "--json"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+    const wrongPayload = JSON.parse(wrongConfirm.stdout);
+
+    expect(wrongConfirm.exitCode).toBe(2);
+    expect(wrongPayload).toMatchObject({
+      ok: false,
+      command: "bucket.delete",
+      error: {
+        code: "CONFIRMATION_REQUIRED",
+        domain: "bucket",
+        meta: { expectedConfirm: "bkt_123", receivedConfirm: "bkt_456" },
+      },
+    });
+  });
+
   it("fails with BUCKET_NOT_FOUND when deleting an unknown bucket", async () => {
     const { cwd, stateDir } = await setupLinkedProject();
 
     const result = await executeCli({
-      argv: ["bucket", "delete", "bkt_999", "--json"],
+      argv: ["bucket", "delete", "bkt_999", "--confirm", "bkt_999", "--json"],
       cwd,
       stateDir,
       fixturePath,

--- a/packages/cli/tests/bucket.test.ts
+++ b/packages/cli/tests/bucket.test.ts
@@ -238,6 +238,17 @@ describe("bucket commands", () => {
         meta: { expectedConfirm: "bkt_123", receivedConfirm: null },
       },
     });
+
+    const list = await executeCli({
+      argv: ["bucket", "list", "--json"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+    const listPayload = JSON.parse(list.stdout);
+    expect(listPayload.result.items).toContainEqual(
+      expect.objectContaining({ id: "bkt_123" }),
+    );
   });
 
   it("rejects --confirm that does not match the bucket id", async () => {
@@ -261,6 +272,17 @@ describe("bucket commands", () => {
         meta: { expectedConfirm: "bkt_123", receivedConfirm: "bkt_456" },
       },
     });
+
+    const list = await executeCli({
+      argv: ["bucket", "list", "--json"],
+      cwd,
+      stateDir,
+      fixturePath,
+    });
+    const listPayload = JSON.parse(list.stdout);
+    expect(listPayload.result.items).toContainEqual(
+      expect.objectContaining({ id: "bkt_123" }),
+    );
   });
 
   it("fails with BUCKET_NOT_FOUND when deleting an unknown bucket", async () => {


### PR DESCRIPTION
## Purpose of change

Bucket deletion now cascades (the Management API force-deletes all stored objects and revokes all access keys), so the CLI must guard against accidental data loss with the same `--confirm <id>` gate that `database remove` already uses.

## What's changed and why

- **`controllers/bucket.ts`**: `runBucketDelete` now accepts a `BucketDeleteFlags` parameter with `confirm?: string`. Before calling the provider it checks `flags.confirm !== id` and throws `CONFIRMATION_REQUIRED` (exit 2) with `meta: { expectedConfirm, receivedConfirm }` — matching the `database remove` error shape exactly.
- **`commands/bucket/index.ts`**: `createBucketDeleteCommand` wires a `--confirm <bucket-id>` option and passes it through to the controller.
- **`tests/bucket.test.ts`**: Updated the two existing delete tests to include `--confirm`; added tests for missing confirm (null `receivedConfirm`) and mismatched confirm.
- **`docs/product/command-spec.md`**: `bucket delete` heading now shows `--confirm <bucketId>`; behavior section replaces the empty-bucket limitation note with cascade semantics and the confirmation requirement.
- **`docs/product/resource-model.md`**: Object Store section updated to describe cascade deletion and the `--confirm` guard.

## Testing notes / Before-after

**Before**: `prisma-cli bucket delete bkt_123` succeeded immediately.
**After**: same command exits 2 with `CONFIRMATION_REQUIRED`; must pass `--confirm bkt_123`.

Verify manually:
1. `prisma-cli bucket delete bkt_123` → exit 2, error `CONFIRMATION_REQUIRED`
2. `prisma-cli bucket delete bkt_123 --confirm bkt_456` → exit 2, `receivedConfirm: "bkt_456"`
3. `prisma-cli bucket delete bkt_123 --confirm bkt_123` → exit 0, success

**Notes for reviewers:**
- The cascade behavior (`force=true` on the Tigris partner API) is gated on a pdp-control-plane PR landing first. The CLI change is safe to merge independently — it guards deletion regardless of whether the platform side has landed.
- Breaking change: any script passing `bucket delete <id>` without `--confirm` will now exit 2. This is intentional and matches `database remove` precedent.
- `bucket key delete` does **not** get a `--confirm` flag — keys are individually revocable and don't cascade to other resources, so the guard would be disproportionate.