### PR TITLE
Pre-set the root version to 8.0.0-rc.1 (merge before #130)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "prisma-cli",
+  "version": "8.0.0-rc.1",
   "private": true,
   "engines": {
     "node": ">=22.13.0"


### PR DESCRIPTION
One field: the root `package.json` gains `version: 8.0.0-rc.1`.

Today's workflows never read the root version, so this merge publishes nothing beyond the routine dev build. Its purpose is sequencing: #130 adopts prisma/prisma's publish machinery **verbatim**, where any root-version change on `main` ships a release to `latest`. With this field pre-set, #130's merge shows no version change and publishes only a dev build — the first real release then happens through a deliberate `chore(release)` bump PR (see the `publish-npm-version` skill landing in #130).

**Merge order matters: this PR first, then #130.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)