### PR TITLE
Rule Q2: service run is dropped, so the commander shell dies with no exceptions

### DIFF
--- a/.drive/projects/prisma-cli-v8/specs/s2-overview.md
+++ b/.drive/projects/prisma-cli-v8/specs/s2-overview.md
@@ -79,12 +79,12 @@ can overrule before the affected dispatch runs.
   fails early instead. Default built to: sign-in structured error +
   `auth login` nextAction (consistent, agent-friendly). Ratify or
   reinstate auto-login as an engine feature.
-- **Q2 — `service run` child-exit passthrough.** The legacy command
-  passes the dev server's exit code through; session commands have no
-  exit-code channel; the same exception is already ruled for
-  Composer's S3. Decide: build the passthrough mechanism in S2c, or
-  defer `service run` to ride S3's mechanism (S2d then keeps a minimal
-  legacy path for it).
+- **Q2 — `service run`. RULED (operator, 2026-08-11): dropped.** It does
+  not port, and the engine does not grow a child-exit-code passthrough
+  for it. The command started a local dev server and passed its exit
+  code through, which is Composer's `dev`. Nothing of the commander
+  shell survives S2d on its account, and the removal joins the divergence
+  list alongside `service build` and `service deploy`.
 - **Q3 — `project env remove`'s `rm` alias** (the only alias in the
   tree) does not port. Ratify the drop or rule alias support.
 - **Q4 — config evaluation in the shipped bin.** The S1 loader

--- a/.drive/projects/prisma-cli-v8/specs/s2c-services.md
+++ b/.drive/projects/prisma-cli-v8/specs/s2c-services.md
@@ -28,16 +28,11 @@ inventory's step structure; SDK polling drives events through the
 injectable clock. `service remove`'s type-the-name confirmation ports
 to `prompt.consent` + its current flag per R-S2b-3.
 
-R-S2c-4 **`service run`** — PARKED (morning-questions ledger Q2). The
-legacy command passes the child dev-server's exit code through as the
-CLI's exit code; engine session commands have no exit-code channel,
-and the same passthrough exception is already ruled for Composer's
-S3 adoption. Decision needed: build the engine's child-status
-passthrough mechanism here (S2c) or defer `service run`'s port to
-ride S3's mechanism. DO NOT port `service run` until ruled; the
-legacy shell keeps serving it meanwhile (shell deletion is S2d — if
-Q2 resolves "defer to S3", S2d keeps a minimal legacy path for
-`service run` only, recorded there).
+R-S2c-4 **`service run`** — RULED (operator, 2026-08-11): DROPPED. It
+does not port and no engine child-exit-code passthrough is built for
+it. Starting a local dev server and passing its exit code through is
+Composer's `dev`. Divergence entry alongside `service build` and
+`service deploy`.
 
 R-S2c-5 **`service build`**: result command; local build; progress
 events from the SDK build reporter; no `ctx.api`.
@@ -58,11 +53,12 @@ rollback|remove`, `service domain add|show|remove|retry|wait`,
 `service env *` — NOTE: the inventory places env under `project env`
 (S2b) only; `app` has a `domain` subgroup and no `env` subgroup —
 scope follows the inventory. `build logs`, `agent
-install|update|status`, `feedback`. Parked: `service run` (Q2).
+install|update|status`, `feedback`. Dropped: `service run`,
+`service build`, `service deploy` (ruled; superseded by Composer).
 
 ## Out of scope
 
-`init`, shell deletion (S2d); `service run` until Q2; Composer (S3).
+`init`, shell deletion (S2d); Composer (S3).
 
 ## Acceptance
 
@@ -73,7 +69,7 @@ install|update|status`, `feedback`. Parked: `service run` (Q2).
       semantic tests (step/progress/status ordering).
 - [ ] Divergence list updated (rename class, stream-wrapper drop,
       consent/exit unifications, error-code map).
-- [ ] Q2 either ruled and implemented or still parked with the legacy
-      path intact and S2d's contract updated accordingly.
+- [x] Q2 ruled: `service run` dropped, so S2d deletes the commander
+      shell with no exceptions.
 - [ ] Legacy fixture tests for ported commands deleted; root
       verification green; PR ≥1k LOC; review loop run.

--- a/.drive/projects/prisma-cli-v8/specs/s2d-init-and-retirement.md
+++ b/.drive/projects/prisma-cli-v8/specs/s2d-init-and-retirement.md
@@ -58,8 +58,9 @@ go.
 
 R-S2d-5 **Grammar completeness check**: a build-time test asserts the
 mounted tree equals the S2 target grammar exactly (every inventory
-command minus ruled removals plus ruled renames; `service run` per
-Q2's outcome). This is the platform slice of the S7 grammar check.
+command minus ruled removals plus ruled renames; `service run` is
+a ruled removal, so nothing of the legacy shell survives on its
+account). This is the platform slice of the S7 grammar check.
 
 R-S2d-6 **Final parity review**: the cumulative S2 divergence list
 (S2a+S2b+S2c+S2d) is consolidated into one document for operator


### PR DESCRIPTION
```
prisma service run    →  gone. Use `composer dev`.
```

## The decision

**`service run` does not port, and the engine grows no child-exit-code passthrough for it** (operator, 2026-08-11). It joins `service build` and `service deploy` as a ruled removal.

## Why it was open

The command starts the app's dev server as a child process and passes that process's exit code through as its own. Engine session commands have no exit-code channel, so porting it meant building one — and the same exception was already ruled for Composer in S3. The question was whether to build that mechanism now or defer the command until S3 could carry it.

Neither, as it turns out. Starting a local dev server is what `composer dev` does, so there is nothing here worth porting or deferring.

## What this unblocks

S2d deletes the commander shell. Its contract said the grammar-completeness check would treat `service run` "per Q2's outcome", and that if the answer were "defer", the shell would have to keep a minimal path alive for that single command. That was the last thing standing between S2d and deleting the shell outright. It is now a ruled removal like the others, and nothing survives on its account.

Documentation only — the three slice contracts and the question ledger. No code changes; the command was never ported.