### PR TITLE
Ctrl-C exits 130 because the engine says so, not because a command invented a dead child

### DIFF
--- a/.drive/projects/prisma-cli-v8/assets/engine/engine-interface-draft.ts
+++ b/.drive/projects/prisma-cli-v8/assets/engine/engine-interface-draft.ts
@@ -47,6 +47,13 @@
  * methods" rule is absolute — no sanctioned exception.
  * exitWithChildStatus(child, opts?) takes { nextActions? }, rendered
  * to stderr before the exit (R-S3-4's reproduce hint).
+ * Amended 2026-08-11 (operator ruling) — SIGNAL SETTLEMENT IS THE
+ * ENGINE'S: a run a delivered signal terminated settles 128+signal
+ * from the engine's own record of that signal, whatever its handler
+ * returns (EXIT CODES below). exitWithChildStatus gains its second
+ * fence in consequence: the child result must be one the engine
+ * produced from a real spawn, so no handler can reach a signal exit
+ * code by describing a child that never existed.
  *
  * THE MODEL, in one analogy (operator, 2026-08-09): commands settle like
  * promises. A command can COMPLETE — and its completion can be
@@ -132,6 +139,22 @@
  * signal fires context.signal and awaits teardown (settling 130/143);
  * a second exits immediately through the runtime's exit proxy — the
  * engine ends the process only ever via Runtime.exit.
+ *
+ * The signal codes are the ENGINE's to settle, from its own record of
+ * the signal it delivered, and never from anything a handler returns
+ * (operator ruling, 2026-08-11). A run a delivered signal terminated
+ * settles 128 + that signal's number for BOTH command kinds —
+ * including the handler that caught context.signal, cleaned up, and
+ * returned successfully. The exit code states how the RUN ended, not
+ * how well the cleanup went, so a session that shuts down cleanly on
+ * Ctrl-C settles 130 while still reporting a completed envelope. No
+ * handler can author these codes: documented codes stop at 99, and
+ * the child-status bypass refuses a child result the engine did not
+ * produce. Two codes are exempt, because neither was this CLI's to
+ * state in the first place, and both pass through verbatim: a real
+ * child's status (the child owned the terminal and the signal reached
+ * it too — that is why exitWithChildStatus reports 128+signal itself)
+ * and a server command's protocol conclusion.
  */
 
 // ————————————————————————————————————————————————————————————————————————
@@ -667,8 +690,10 @@ export interface ChildStatusSettlement {
 /** The sanctioned "exit with the child's status verbatim" outcome:
  *  returned inside ok(...), it settles through the no-envelope bypass
  *  server commands already have — and ONLY from a command that
- *  declares maySpawn; anywhere else it is a construction error (the
- *  bypass is fenced, not merely documented). A signal-killed child
+ *  declares maySpawn, with the ChildResult that command's own
+ *  ctx.spawn returned; anywhere else, or with a child result the
+ *  engine never produced, it is a construction error (the bypass is
+ *  fenced, not merely documented). A signal-killed child
  *  settles 128 + the signal number for the portable signals; an
  *  unknown signal, or an adapter that cannot say how the child ended,
  *  settles 1 — unknown is never success. `nextActions` (a failed
@@ -1099,10 +1124,11 @@ export declare function defineCommand<
  * S3 amendments: a session supports json mode — the event stream is
  * its json surface — UNLESS it declares maySpawn, in which case it
  * rejects --json as soon as the command is known. A session that
- * returns ok(undefined)
- * exits 0; one that returns ok(exitWithChildStatus(child)) exits with
- * the child's status, which is the ONLY way a session settles
- * non-zero without erroring.
+ * returns ok(undefined) exits 0 — or 130/143 when a delivered signal
+ * ended the run, which the engine settles from its own record (EXIT
+ * CODES); one that returns ok(exitWithChildStatus(child)) exits with
+ * the child's status. Those are the two ways a session settles
+ * non-zero without erroring, and neither is a code the handler picks.
  */
 export interface SessionCommandDefinition<
   TFlags extends Record<string, FlagSpec<unknown>> = {},

--- a/.drive/projects/prisma-cli-v8/deferred.md
+++ b/.drive/projects/prisma-cli-v8/deferred.md
@@ -75,11 +75,13 @@ Nothing here is tracked outside this file.
   next deploy. Full citations in `assets/s3/composer-inventory.md`
   §4a and D2's report.
 
-## Composer's public surface — operator-informed, no action pending
+## Composer's public surface — ruled, closed
 
 - **`ExtensionDescriptor.preflight` moved to method syntax** so an
   extension can type its input against its own client (the injected
   management client arrives there under S3's in-process credential
   leg). Consistent with `ContainerDescriptor` in the same file;
-  loosens parameter checking for extension authors. Kept, per the
-  operator's non-objection 2026-08-11.
+  loosens parameter checking for extension authors. RULED KEPT
+  (operator, 2026-08-11). No further action; the change ships with
+  S3 and needs a divergence entry only if it breaks a published
+  extension, which it does not.

--- a/.drive/projects/prisma-cli-v8/deferred.md
+++ b/.drive/projects/prisma-cli-v8/deferred.md
@@ -1,0 +1,85 @@
+# Deferred and follow-up items — prisma-cli-v8
+
+Work identified during a slice that is not part of that slice's
+contract. Each entry: what, why it was deferred, where it lands.
+Nothing here is tracked outside this file.
+
+## Owned by S3/D4 (the slice's closing dispatch)
+
+- **`dev` settles 130 through a fabricated child result.** Session
+  commands hard-code exit 0, and the child-status bypass is the only
+  non-zero path, so `dev` hands it `{exitCode: null, signal:
+  "SIGINT"}` for a child that never existed. The engine already
+  records the delivered signal (the #136 latch) and can settle
+  128+signal from its own record, which removes the fiction.
+  Operator-informed 2026-08-11; engine fix planned in D4 so the
+  tandem release publishes engine and composer together.
+- **`loadAppConfigDiagnostics()` is called by nothing.** D2 rewrote
+  composer's config loading to return diagnostics instead of
+  throwing (contract R-S3-2), but `pipeline.ts` still calls the
+  throwing `loadAppConfig`, so the rewrite is currently dead code —
+  and the effect-resolution check that moved into it never runs.
+- **`check:npm-effect-resolution` fixes are unverified.** D3 updated
+  three assertions (help proves the family mounted; the adversarial
+  `deploy` gets a service token because the credential check now
+  precedes the tree check; `--help` must survive a broken dependency
+  tree because the family's static graph is alchemy-free). The check
+  performs real npm installs, so it needs network to run.
+- **The engine pin moves off `0.0.3`** to whatever the tandem release
+  publishes, in both composer manifests.
+- **Contract corrections at closure**: ledger Q2 (main's #135 dropped
+  `service run` outright, so S3 no longer "closes" it by building the
+  mechanism — the mechanism exists, the command does not), and the
+  coverage-ledger rows for "refresh under long runs" and "config
+  sections" (see contract §10).
+
+## Owned by whoever lands the next engine change
+
+- **S3's SPI amendment vs credential-manager rev 6.** #136 recorded
+  the spawn path's credential read against rev 5's surface and then
+  adapted to rev 6's `activeCredentialStorage()` during the rebase.
+  If rev 6's storage surface reshapes again, the single named
+  consumer (`packages/cli-engine/src/execution/spawn.ts`) moves with
+  it. Recorded in `assets/engine/credential-manager-design.md`.
+- **`--tail` validation is wider than the recorded divergence.** The
+  engine's `flag.number` accepts negatives and non-integers; legacy
+  `composer log --tail` rejected both. Either the flag gains
+  validation or the divergence entry widens.
+
+## Upstream, not ours to land
+
+- **alchemy-run/node-utils#6** (scope exit hooks to owned locks) is
+  open. Vendored as a pnpm patch in composer
+  (`patches/@alchemy.run__node-utils@0.0.5.patch`, applied to both
+  `lib/lockfile.js` and `src/lockfile.ts` because the exports map
+  sends bun to `src/`). **Delete the patch when the release chain
+  delivers**: node-utils release → alchemy's exact-pin bump →
+  composer's alchemy bump. Exit condition recorded in
+  `skills-contrib/upgrade-alchemy-effect/SKILL.md` in the composer
+  repo.
+- **Alchemy's `sync` reports permanent drift on Composer resources.**
+  `Deployment.read` returns `previewDomain` while `reconcile`
+  persists `appEndpointDomain`; `Sync.ts` deep-equals live against
+  stored attributes, so every `alchemy sync` would report drift and
+  "repair" forever. The deploy path is unaffected (it plans on props
+  only — see the S8 note below), so this is a courtesy report to the
+  maintainer, not a blocker.
+
+## Answered, feeding a later slice
+
+- **S8's planner question is settled** (D2's read of alchemy
+  `2.0.0-beta.67`): the deploy path plans on **props only** and never
+  compares attributes, so Composer's domain-field mismatch causes no
+  per-run redeploy. S8's promote/rollback/start/stop design does not
+  have to defend against Alchemy reverting imperative changes on the
+  next deploy. Full citations in `assets/s3/composer-inventory.md`
+  §4a and D2's report.
+
+## Composer's public surface — operator-informed, no action pending
+
+- **`ExtensionDescriptor.preflight` moved to method syntax** so an
+  extension can type its input against its own client (the injected
+  management client arrives there under S3's in-process credential
+  leg). Consistent with `ContainerDescriptor` in the same file;
+  loosens parameter checking for extension authors. Kept, per the
+  operator's non-objection 2026-08-11.

--- a/.drive/projects/prisma-cli-v8/deferred.md
+++ b/.drive/projects/prisma-cli-v8/deferred.md
@@ -6,14 +6,6 @@ Nothing here is tracked outside this file.
 
 ## Owned by S3/D4 (the slice's closing dispatch)
 
-- **`dev` settles 130 through a fabricated child result.** Session
-  commands hard-code exit 0, and the child-status bypass is the only
-  non-zero path, so `dev` hands it `{exitCode: null, signal:
-  "SIGINT"}` for a child that never existed. The engine already
-  records the delivered signal (the #136 latch) and can settle
-  128+signal from its own record, which removes the fiction.
-  Operator-informed 2026-08-11; engine fix planned in D4 so the
-  tandem release publishes engine and composer together.
 - **`loadAppConfigDiagnostics()` is called by nothing.** D2 rewrote
   composer's config loading to return diagnostics instead of
   throwing (contract R-S3-2), but `pipeline.ts` still calls the

--- a/.drive/projects/prisma-cli-v8/specs/s3-composer.md
+++ b/.drive/projects/prisma-cli-v8/specs/s3-composer.md
@@ -37,6 +37,8 @@ const child = await ctx.spawn({ command, args, cwd, env });
   RECORDS delivered signals; on child exit it replays them into its
   normal ladder (one recorded → `ctx.signal` aborts as if just
   delivered; two+ → abort fires and the next signal force-exits).
+  A replayed signal is a delivered signal like any other, so the
+  run settles from the engine's record the same way (below).
   The latch never advances past what the user pressed; no
   force-exit path skips handler cleanup that has not had a turn.
   The engine always outlives the child. SIGTERM (no native path to
@@ -75,13 +77,26 @@ const child = await ctx.spawn({ command, args, cwd, env });
   envelope stays absent) — which uses the settlement bypass server
   commands already have (no envelope; a signal-killed child
   settles 128+signal; an unknown termination settles 1, never 0).
-  The bypass is FENCED: settling it from a command that does not
-  declare `maySpawn` is a construction error. The session kind's
-  settlement is amended to permit non-zero through this path
-  (today `settleSessionCompleted` hard-codes 0), and the
-  session-kind "always supports json" guarantee is amended: a
-  command that may spawn rejects `--json` at PARSE time (delegated
-  terminal output cannot be framed; stated in help).
+  The bypass is FENCED twice, each a construction error: settling
+  it from a command that does not declare `maySpawn`, and settling
+  it with a child result the engine did not itself produce from a
+  real spawn (amended 2026-08-11 — see the exit-code rule below).
+  The session kind's settlement is amended to permit non-zero
+  through this path (it used to hard-code 0, and now also settles
+  130/143 on its own — below),
+  and the session-kind "always supports json" guarantee is amended:
+  a command that may spawn rejects `--json` at PARSE time
+  (delegated terminal output cannot be framed; stated in help).
+- **Exit codes are the engine's** (operator ruling, 2026-08-11): a
+  run a delivered signal terminated settles 128+signal from the
+  ENGINE's own record of that signal, for both command kinds and
+  including the handler that caught the signal, cleaned up and
+  returned successfully. A handler cannot author 130/143 —
+  documented codes stop at 99, and the child-status bypass now
+  refuses an invented child result. The verbatim codes stay
+  verbatim: a real child's status passes through untouched (the
+  child owned the terminal and the signal reached it too), as does
+  a server command's protocol conclusion.
 - **Seam**: spawning enters through `Runtime.spawn` (the bin
   passes a `node:child_process` adapter; the engine never imports
   `node:child_process`); `createTestCli` seeds a scripted fake
@@ -267,7 +282,9 @@ family:
   AFTER, it is a warn event and the session continues. A
   signal-killed converge is SHUTDOWN (cleanup, settle 130), never
   `converge-failed`. Ctrl-C settles 130 (legacy exits 0 —
-  divergence). Windows: refuses, as today.
+  divergence): the handler cleans up and returns `ok(undefined)`,
+  and the ENGINE settles 130 from its own signal record — `dev`
+  states no exit code of its own. Windows: refuses, as today.
 - `log <entry> [address]`: session command reading the LOCAL
   dev-emulator daemon (§4c; not the platform logs surface — S8
   note stands). Windows: refuses, as today.
@@ -388,7 +405,9 @@ install footprint acknowledged as a committed consequence
 
 PR-136 review round (architect + PE on D1, 2026-08-11; orchestrator
 rulings applied): the child-status settlement bypass is fenced to
-`maySpawn` commands (runtime check; the architect blocker);
+`maySpawn` commands (runtime check; the architect blocker) — and,
+since the 2026-08-11 exit-code ruling, to child results the engine
+itself produced;
 `exitWithChildStatus(child, opts?)` gains `{ nextActions? }` rendered
 before the exit — the R-S3-4 surface as written now exists; the spawn
 path's storage read is replaced by the named manager operation

--- a/packages/cli-engine/src/commands.ts
+++ b/packages/cli-engine/src/commands.ts
@@ -301,9 +301,10 @@ export function defineCommand<
  * UNLESS it declares `maySpawn`, in which case it rejects --json as soon
  * as the command is known, before anything runs (S3): output delegated
  * to a child process cannot be framed. A session that returns
- * ok(undefined) exits 0; one that returns ok(exitWithChildStatus(child))
- * exits with the child's status, which is the only way a session
- * settles non-zero without erroring.
+ * ok(undefined) exits 0 — or 130/143 when a signal ended the run, which
+ * the engine settles from its own record of that signal, not from
+ * anything the handler returns; one that returns
+ * ok(exitWithChildStatus(child)) exits with the child's status.
  */
 export interface SessionCommandDefinition<
   TFlags extends Record<string, FlagSpec<unknown>> = Record<

--- a/packages/cli-engine/src/context.ts
+++ b/packages/cli-engine/src/context.ts
@@ -89,6 +89,10 @@ export interface CommandContext<
    * Fires on Ctrl-C/SIGTERM (engine-owned; a second signal force-exits
    * through the runtime's exit proxy). Session commands run until it
    * fires.
+   *
+   * Once it has fired the engine settles the run at 130/143 from its
+   * own record of the signal, whatever the handler goes on to return —
+   * so cleanup code never states an exit code of its own.
    */
   readonly signal: AbortSignal;
 

--- a/packages/cli-engine/src/execution/engine.ts
+++ b/packages/cli-engine/src/execution/engine.ts
@@ -121,6 +121,11 @@ export interface RunState {
    *  prompt's first await, so an unawaited prompt still blocks
    *  ctx.spawn from handing the same terminal to a child. */
   activePrompts: number;
+  /** The signal the engine delivered to this run, if one reached it.
+   *  The engine's own record of how the run ended: a run a signal
+   *  terminated settles 128 + that signal's number whatever its handler
+   *  concluded, and no handler can author those codes. */
+  deliveredSignal: "SIGINT" | "SIGTERM" | undefined;
   /** A signal past the first delivery recorded during a live child,
    *  replayed as the force exit once the run has settled. */
   pendingForceExit: "SIGINT" | "SIGTERM" | undefined;
@@ -263,12 +268,12 @@ export class EngineImpl implements Engine {
       snapshot: undefined,
       delegatedTerminal: undefined,
       activePrompts: 0,
+      deliveredSignal: undefined,
       pendingForceExit: undefined,
       spawnCredential: undefined,
     };
     const startedAtMs = this.now().getTime();
     const controller = new AbortController();
-    let signalDelivered = false;
     /** The engine neither aborts nor exits while a child owns the
      *  terminal: it records, and the affordance replays on child exit,
      *  so the engine always outlives the child. */
@@ -277,11 +282,11 @@ export class EngineImpl implements Engine {
         recordSignalDuringSpawn(state.delegatedTerminal, signal);
         return;
       }
-      if (signalDelivered) {
+      if (state.deliveredSignal !== undefined) {
         runtime.exit(signal === "SIGTERM" ? 143 : 130);
         return;
       }
-      signalDelivered = true;
+      state.deliveredSignal = signal;
       controller.abort(signal);
     };
     const unsubscribe = runtime.onSignal(deliverSignal);

--- a/packages/cli-engine/src/execution/settlement.ts
+++ b/packages/cli-engine/src/execution/settlement.ts
@@ -5,7 +5,7 @@ import type {
 } from "../commands";
 import { PRESENTED, type PresentedResult } from "../presentation";
 import { CliStructuredError, type Diagnostic } from "../protocol";
-import type { ChildStatusSettlement } from "../spawn";
+import { type ChildStatusSettlement, isEngineSpawned } from "../spawn";
 import type { EngineSpec, Invocation } from "./engine";
 import {
   firstLine,
@@ -59,7 +59,8 @@ export function settleCompleted(
   }
   const state = invocation.state;
   invocation.hooks.onPresented?.(presented);
-  state.settledExitCode = presented.exitCode;
+  const exitCode = runExitCode(invocation, presented.exitCode);
+  state.settledExitCode = exitCode;
   if (state.format === "json") {
     const envelope: CompletedEnvelope = {
       ok: true,
@@ -68,7 +69,7 @@ export function settleCompleted(
         presented.presentation.json === undefined
           ? presented.data
           : presented.presentation.json,
-      exitCode: presented.exitCode,
+      exitCode,
       diagnostics: presented.diagnostics.map((diagnostic) =>
         withDocsUrl(state, diagnostic),
       ),
@@ -106,10 +107,27 @@ export function settleErrored(
   });
 }
 
-/** Signal exit codes: 130 SIGINT, 143 SIGTERM. The engine's own
- *  controller only ever aborts with a signal name. */
-function signalExitCode(reason: unknown): number {
-  return reason === "SIGTERM" ? 143 : 130;
+/** The conventional code for a delivered signal: 128 + its number, so
+ *  130 for SIGINT and 143 for SIGTERM. */
+function signalExitCode(signal: "SIGINT" | "SIGTERM" | undefined): number {
+  return signal === "SIGTERM" ? 143 : 130;
+}
+
+/**
+ * The engine's own signal record decides how a run ends. A run a
+ * delivered signal terminated settles 128 + that signal's number even
+ * when its handler caught the signal, cleaned up, and returned
+ * successfully: the exit code states how the RUN ended, and a handler
+ * cannot author it — the documented codes stop at 99.
+ *
+ * Verbatim codes are the exception, because they were never this CLI's
+ * to state: a real child's status (the child owned the terminal and the
+ * signal reached it too) and a server command's protocol conclusion
+ * both pass through untouched.
+ */
+function runExitCode(invocation: Invocation, completed: number): number {
+  const signal = invocation.state.deliveredSignal;
+  return signal === undefined ? completed : signalExitCode(signal);
 }
 
 function isAbortCause(cause: unknown, signal: AbortSignal): boolean {
@@ -134,7 +152,7 @@ export function settleThrown(invocation: Invocation, cause: unknown): void {
 
 function settleAborted(invocation: Invocation): void {
   const state = invocation.state;
-  state.settledExitCode = signalExitCode(invocation.signal.reason);
+  state.settledExitCode = signalExitCode(state.deliveredSignal);
   emitErrored(invocation, {
     ok: false,
     commandId: state.commandId,
@@ -153,7 +171,8 @@ function settleAborted(invocation: Invocation): void {
  * Settle an exit code the engine did not author, verbatim, with no
  * envelope and no presentation: something other than this CLI's code
  * space produced it. The two callers are the child-status settlement
- * and the server-command handoff.
+ * and the server-command handoff. A delivered signal does not overrule
+ * it — a code from outside is reported as it was received.
  */
 export function settleVerbatimExitCode(
   invocation: Invocation,
@@ -164,13 +183,18 @@ export function settleVerbatimExitCode(
 
 /**
  * The child owned the terminal, so its status becomes the run's
- * verbatim. This is the one path on which a session command settles
- * non-zero without erroring, and the one path on which a result
- * command settles a code it never documented: neither is the handler's
- * own conclusion, it is the child's. Only a command that hands the
- * terminal to another program may settle this way — reachable from a
- * non-declaring handler it would also end a json stream without its
- * terminal result frame.
+ * verbatim: the one path on which a result command settles a code it
+ * never documented, because the code is not the handler's own
+ * conclusion, it is the child's.
+ *
+ * Two conditions fence it, both construction errors. The command must
+ * hand the terminal to another program — reachable from a
+ * non-declaring handler this would also end a json stream without its
+ * terminal result frame. And the status must be one the engine watched
+ * a real child produce: a handler that invents a child result is
+ * choosing an exit code through a door meant for reporting one, and a
+ * handler interrupted mid-run has no need to, because the engine
+ * settles a signal-terminated run itself.
  */
 export function settleChildStatus(
   invocation: Invocation,
@@ -182,6 +206,11 @@ export function settleChildStatus(
       `@prisma/cli-engine: command '${invocation.state.commandId}' returned exitWithChildStatus without declaring maySpawn — only a command that hands the terminal to another program may settle with that program's status`,
     );
   }
+  if (!isEngineSpawned(settlement)) {
+    throw new Error(
+      `@prisma/cli-engine: command '${invocation.state.commandId}' returned exitWithChildStatus for a child result the engine did not produce — only the result of a ctx.spawn carries a child's status`,
+    );
+  }
   // Only human format is reachable here: maySpawn forces it.
   for (const action of settlement.nextActions) {
     invocation.runtime.stderr.write(`${renderNextAction(action)}\n`);
@@ -189,12 +218,15 @@ export function settleChildStatus(
   settleVerbatimExitCode(invocation, settlement.exitCode);
 }
 
-/** A session command that returned ok — including after the signal
- *  fired — shut down cleanly: exit 0, no presentation. In json mode the
- *  stream still terminates with exactly one result frame. */
+/** A session command that returned ok shut down cleanly: no
+ *  presentation, and exit 0 — unless a signal ended the run, which
+ *  settles 130/143 from the engine's record even though the shutdown
+ *  itself succeeded. In json mode the stream still terminates with
+ *  exactly one result frame. */
 export function settleSessionCompleted(invocation: Invocation): void {
   const state = invocation.state;
-  state.settledExitCode = 0;
+  const exitCode = runExitCode(invocation, 0);
+  state.settledExitCode = exitCode;
   if (state.format !== "json") {
     return;
   }
@@ -202,7 +234,7 @@ export function settleSessionCompleted(invocation: Invocation): void {
     ok: true,
     commandId: state.commandId,
     result: null,
-    exitCode: 0,
+    exitCode,
     diagnostics: [],
     nextActions: [],
   };

--- a/packages/cli-engine/src/execution/settlement.ts
+++ b/packages/cli-engine/src/execution/settlement.ts
@@ -109,7 +109,7 @@ export function settleErrored(
 
 /** The conventional code for a delivered signal: 128 + its number, so
  *  130 for SIGINT and 143 for SIGTERM. */
-function signalExitCode(signal: "SIGINT" | "SIGTERM" | undefined): number {
+function signalExitCode(signal: "SIGINT" | "SIGTERM"): number {
   return signal === "SIGTERM" ? 143 : 130;
 }
 
@@ -152,7 +152,11 @@ export function settleThrown(invocation: Invocation, cause: unknown): void {
 
 function settleAborted(invocation: Invocation): void {
   const state = invocation.state;
-  state.settledExitCode = signalExitCode(state.deliveredSignal);
+  const signal = state.deliveredSignal;
+  // The run's signal is aborted from one place, and it records the
+  // signal first, so an abort without one would be an engine fault;
+  // it settles cancelled rather than claiming a signal that never came.
+  state.settledExitCode = signal === undefined ? 3 : signalExitCode(signal);
   emitErrored(invocation, {
     ok: false,
     commandId: state.commandId,

--- a/packages/cli-engine/src/execution/spawn.ts
+++ b/packages/cli-engine/src/execution/spawn.ts
@@ -2,12 +2,13 @@ import type { AnyCommand } from "../commands";
 import { credentialsRequiredError } from "../credential-errors";
 import type { EngineEvent } from "../events";
 import { CliStructuredError } from "../protocol";
-import type {
-  ChildResult,
-  SpawnChild,
-  SpawnedChild,
-  SpawnOptions,
-  SpawnRequest,
+import {
+  type ChildResult,
+  engineSpawnedResult,
+  type SpawnChild,
+  type SpawnedChild,
+  type SpawnOptions,
+  type SpawnRequest,
 } from "../spawn";
 import { constructionError } from "./command-tree";
 import { makeDebugLog } from "./debug";
@@ -183,7 +184,7 @@ async function runChild(
   const ended = new AbortController();
   armTerminationLadder(invocation, terminal, child, ended.signal);
   try {
-    return await child.ended;
+    return engineSpawnedResult(await child.ended);
   } catch (cause) {
     throw spawnFailedError(request.command, cause);
   } finally {

--- a/packages/cli-engine/src/spawn.ts
+++ b/packages/cli-engine/src/spawn.ts
@@ -54,12 +54,41 @@ export const CHILD_STATUS: unique symbol = Symbol.for(
   "@prisma/cli-engine.childStatus",
 );
 
+/** Marks a ChildResult the engine watched a real child produce. */
+const ENGINE_SPAWNED: unique symbol = Symbol.for(
+  "@prisma/cli-engine.engineSpawned",
+);
+
+function markEngineSpawned<T extends object>(value: T): T {
+  return Object.freeze(
+    Object.defineProperty(value, ENGINE_SPAWNED, { value: true }),
+  );
+}
+
+export function isEngineSpawned(value: object): boolean {
+  return (value as Record<symbol, unknown>)[ENGINE_SPAWNED] === true;
+}
+
+/**
+ * The child result ctx.spawn hands back: the engine mints it from what
+ * the adapter reported, so a handler cannot pass off an invented one as
+ * a child's status. exitWithChildStatus carries the mark onto its
+ * settlement and the settlement refuses an unmarked one.
+ */
+export function engineSpawnedResult(result: ChildResult): ChildResult {
+  return markEngineSpawned({
+    exitCode: result.exitCode,
+    signal: result.signal,
+  });
+}
+
 /**
  * The sanctioned settlement outcome for "exit with the child's status
  * verbatim": no envelope, the same settlement bypass server commands
  * use. Built exclusively by exitWithChildStatus, and only settled by a
- * command that declares maySpawn. `nextActions` render to stderr before
- * the process exits with the child's code.
+ * command that declares maySpawn, from a child result the engine
+ * itself produced. `nextActions` render to stderr before the process
+ * exits with the child's code.
  */
 export interface ChildStatusSettlement {
   readonly [CHILD_STATUS]: true;
@@ -95,24 +124,30 @@ const SIGNAL_NUMBERS: Readonly<Record<string, number>> = {
  *  child's own exit code, verbatim. Unknown is never success: a signal
  *  outside the portable table, or an adapter that cannot say how the
  *  child ended (exitCode and signal both null), settles 1. */
+function childExitCode(child: ChildResult): number {
+  if (child.signal === null) {
+    return child.exitCode ?? 1;
+  }
+  const signalNumber = SIGNAL_NUMBERS[child.signal];
+  return signalNumber === undefined ? 1 : 128 + signalNumber;
+}
+
+/** Settles the run with the status of the child `ctx.spawn` returned.
+ *  A result the engine did not produce is a construction error at
+ *  settlement: this is how a real child's status reaches the exit code,
+ *  not how a handler picks one. */
 export function exitWithChildStatus(
   child: ChildResult,
   options?: ExitWithChildStatusOptions,
 ): ChildStatusSettlement {
-  const nextActions = Object.freeze([...(options?.nextActions ?? [])]);
-  if (child.signal !== null) {
-    const signalNumber = SIGNAL_NUMBERS[child.signal];
-    return Object.freeze({
-      [CHILD_STATUS]: true as const,
-      exitCode: signalNumber === undefined ? 1 : 128 + signalNumber,
-      nextActions,
-    });
-  }
-  return Object.freeze({
+  const settlement = {
     [CHILD_STATUS]: true as const,
-    exitCode: child.exitCode ?? 1,
-    nextActions,
-  });
+    exitCode: childExitCode(child),
+    nextActions: Object.freeze([...(options?.nextActions ?? [])]),
+  };
+  return isEngineSpawned(child)
+    ? markEngineSpawned(settlement)
+    : Object.freeze(settlement);
 }
 
 export function isChildStatusSettlement(

--- a/packages/cli-engine/tests/lifetimes.test.ts
+++ b/packages/cli-engine/tests/lifetimes.test.ts
@@ -45,25 +45,56 @@ describe("session commands", () => {
     },
   });
 
-  test("runs until the abort signal fires, then exits 0 on clean shutdown", async () => {
+  async function runInterrupted(reason?: string) {
     const controller = new AbortController();
     const cli = createTestCli({ commands: { dev }, now: EPOCH });
-    const result = await cli.run(["dev", "--format", "human"], {
+    return cli.run(["dev", "--format", "human"], {
       abort: controller.signal,
       onEvent: (event) => {
-        if (event.kind === "status") {
+        if (event.kind !== "status") {
+          return;
+        }
+        if (reason === undefined) {
           controller.abort();
+        } else {
+          controller.abort(reason);
         }
       },
     });
+  }
 
-    expect(result.exitCode).toBe(0);
+  test("runs until the signal fires; a clean shutdown still settles 130", async () => {
+    const result = await runInterrupted();
+
+    expect(result.exitCode).toBe(130);
     expect(result.stdout).toBe("");
     expect(result.stderr).toBe("server: listening\nshutting down\n");
     expect(result.events.map((event) => event.kind)).toEqual([
       "status",
       "message",
     ]);
+  });
+
+  test("a session SIGTERM settles 143 the same way", async () => {
+    const result = await runInterrupted("SIGTERM");
+
+    expect(result.exitCode).toBe(143);
+    expect(result.stderr).toBe("server: listening\nshutting down\n");
+  });
+
+  test("a session that finishes on its own settles 0", async () => {
+    const drain = defineSessionCommand({
+      help: { summary: "Reaches the end of its own work" },
+      handler: async (_args, ctx) => {
+        ctx.report({ kind: "message", severity: "info", text: "drained" });
+        return ok(undefined);
+      },
+    });
+    const cli = createTestCli({ commands: { drain }, now: EPOCH });
+
+    const result = await cli.run(["drain", "--format", "human"]);
+
+    expect(result.exitCode).toBe(0);
   });
 
   test("json mode terminates the event stream with one completed result frame", async () => {
@@ -74,14 +105,14 @@ describe("session commands", () => {
       abort: controller.signal,
     });
 
-    expect(result.exitCode).toBe(0);
+    expect(result.exitCode).toBe(130);
     expect(result.json[result.json.length - 1]).toEqual({
       kind: "result",
       envelope: {
         ok: true,
         commandId: "dev",
         result: null,
-        exitCode: 0,
+        exitCode: 130,
         diagnostics: [],
         nextActions: [],
       },
@@ -152,6 +183,51 @@ describe("signal exit codes", () => {
     const result = await runAborted();
 
     expect(result.exitCode).toBe(130);
+  });
+
+  test("a handler that finishes its work after the signal settles 130 too", async () => {
+    const graceful = defineCommand({
+      help: { summary: "Completes successfully after the signal" },
+      handler: async (_args, ctx) => {
+        await signalDone(ctx.signal);
+        return ok(
+          ctx.present({ data: { cleanedUp: true } }, { human: () => [] }),
+        );
+      },
+    });
+    const controller = new AbortController();
+    controller.abort("SIGINT");
+    const cli = createTestCli({ commands: { graceful }, now: EPOCH });
+
+    const result = await cli.run(["graceful", "--json"], {
+      abort: controller.signal,
+    });
+
+    expect(result.exitCode).toBe(130);
+    const last = result.json[result.json.length - 1];
+    expect(
+      last.kind === "result" && last.envelope.ok && last.envelope.exitCode,
+    ).toBe(130);
+  });
+
+  test("a documented exit code does not outrank the delivered signal", async () => {
+    const findings = defineCommand({
+      help: { summary: "Reports findings after the signal" },
+      exitCodes: { 4: "findings" },
+      handler: async (_args, ctx) => {
+        await signalDone(ctx.signal);
+        return ok(
+          ctx.present({ data: null, exitCode: 4 }, { human: () => [] }),
+        );
+      },
+    });
+    const controller = new AbortController();
+    controller.abort("SIGTERM");
+    const cli = createTestCli({ commands: { findings }, now: EPOCH });
+
+    const result = await cli.run(["findings"], { abort: controller.signal });
+
+    expect(result.exitCode).toBe(143);
   });
 });
 

--- a/packages/cli-engine/tests/spawn.test.ts
+++ b/packages/cli-engine/tests/spawn.test.ts
@@ -23,6 +23,16 @@ import { describe, expect, test } from "vitest";
 const NOW = new Date("2030-01-01T00:00:00.000Z");
 const CLOCK = () => NOW;
 
+function signalDone(signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    signal.addEventListener("abort", () => resolve(), { once: true });
+  });
+}
+
 function jwtExpiringIn(seconds: number, workspaceId: string): string {
   return mintTestJwt({
     workspace_id: workspaceId,
@@ -355,10 +365,41 @@ describe("signals", () => {
       },
     });
 
-    await cli.run(["watcher"], { abort: controller.signal });
+    const result = await cli.run(["watcher"], { abort: controller.signal });
 
     expect(abortedInsideChild).toBe(false);
     expect(abortedAfterChild).toBe(true);
+    // The replayed signal is a delivered signal like any other: the
+    // handler completed successfully after it, and the run still
+    // settles as interrupted.
+    expect(result.exitCode).toBe(130);
+  });
+
+  test("a session interrupted during a child cleans up and settles 130", async () => {
+    const controller = new AbortController();
+    const dev = defineSessionCommand({
+      help: { summary: "Converges, then runs until the signal fires" },
+      maySpawn: true,
+      handler: async (_args, ctx) => {
+        await ctx.spawn({ command: "alchemy" });
+        await signalDone(ctx.signal);
+        ctx.report({ kind: "message", severity: "info", text: "stopped" });
+        return ok(undefined);
+      },
+    });
+    const cli = createTestCli({
+      commands: { dev },
+      now: CLOCK,
+      spawnScript: () => {
+        controller.abort();
+        return { exitCode: 0, signal: null };
+      },
+    });
+
+    const result = await cli.run(["dev"], { abort: controller.signal });
+
+    expect(result.exitCode).toBe(130);
+    expect(result.stderr).toContain("stopped");
   });
 
   test("a delivered SIGTERM is forwarded to the child during the window", async () => {
@@ -700,6 +741,39 @@ describe("the settlement bypass is fenced to declaring commands", () => {
 
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("without declaring maySpawn");
+  });
+
+  test("a declaring command inventing a child result is a construction error", async () => {
+    const inventing = defineSessionCommand({
+      help: { summary: "Describes a child that never existed" },
+      maySpawn: true,
+      handler: async (_args, ctx) => {
+        await ctx.spawn({ command: "alchemy" });
+        return ok(exitWithChildStatus({ exitCode: null, signal: "SIGINT" }));
+      },
+    });
+    const cli = createTestCli({
+      commands: { inventing },
+      now: CLOCK,
+      spawnScript: () => ({ exitCode: 0, signal: null }),
+    });
+
+    const result = await cli.run(["inventing"], { isTty: { stdout: true } });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("the engine did not produce");
+  });
+
+  test("the child result ctx.spawn returned settles normally", async () => {
+    const cli = createTestCli({
+      commands: { converge },
+      now: CLOCK,
+      spawnScript: () => ({ exitCode: 7, signal: null }),
+    });
+
+    const result = await cli.run(["converge"]);
+
+    expect(result.exitCode).toBe(7);
   });
 });
 


### PR DESCRIPTION
Press Ctrl-C during `prisma composer dev` and the CLI should exit 130, the conventional code for "terminated by SIGINT". Before this change it exited 0, because a session command's successful return settled 0 no matter what had happened to the process — so the only way to reach 130 was to hand the child-status bypass a **child result describing a child that never existed**:

```ts
// composer's dev command, before
const INTERRUPTED: ChildResult = { exitCode: null, signal: "SIGINT" };
...
return ok(exitWithChildStatus(INTERRUPTED)); // a fiction, for the arithmetic
```

Now the handler cleans up and returns normally, and the engine settles 130 by itself:

```ts
return ok(undefined);
```

## The decision

**Signal exit codes belong to the engine, sourced from its own record.** The engine already knows which signal was delivered — that is the record-and-replay latch that lets Ctrl-C reach a spawned child natively. That record now decides the exit code for both command kinds, including a handler that caught the abort, cleaned up, and returned successfully. Nothing a handler returns can produce a signal exit code.

Two paths stay verbatim, deliberately: a spawned child's own status, and a server command's protocol conclusion. Neither number was this CLI's to author — a forwarded SIGTERM still settles the child's own 42, and the abort ladder still settles 137 rather than 130.

The invented-child trick is now impossible rather than merely discouraged: `ctx.spawn` marks every child result it produces, and the settlement refuses one that the engine did not mint. It is a single extra condition beside the existing declaration fence, in the same place, taking the same construction-error route.

The engine's exit-code doctrine is amended to say all of this, and the handler-facing docs now tell authors that cleanup never states an exit code.

## Alternatives considered

- **An explicit "canceled" outcome for session handlers.** More machinery for the same result, and it lets a handler claim a cancellation that never happened. The engine's own record cannot lie.
- **Leaving the stand-in in composer.** The exit code was right, but the value was a lie a reader would take at face value, and it would break the moment anything validated that a child result came from a real spawn — which is exactly what this change adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
