### PR TITLE
The engine remembers the child it spawned, and decides what a handoff exits with

### DIFF
--- a/.drive/projects/prisma-cli-v8/assets/engine/engine-interface-draft.ts
+++ b/.drive/projects/prisma-cli-v8/assets/engine/engine-interface-draft.ts
@@ -45,15 +45,26 @@
  * manager gains the named engine-facing operation activeAccessToken()
  * for the spawn path's read, so the "engine never calls storage
  * methods" rule is absolute — no sanctioned exception.
- * exitWithChildStatus(child, opts?) takes { nextActions? }, rendered
+ * exitWithChildStatus(opts?) takes { nextActions? }, rendered
  * to stderr before the exit (R-S3-4's reproduce hint).
  * Amended 2026-08-11 (operator ruling) — SIGNAL SETTLEMENT IS THE
  * ENGINE'S: a run a delivered signal terminated settles 128+signal
  * from the engine's own record of that signal, whatever its handler
- * returns (EXIT CODES below). exitWithChildStatus gains its second
- * fence in consequence: the child result must be one the engine
- * produced from a real spawn, so no handler can reach a signal exit
- * code by describing a child that never existed.
+ * returns (EXIT CODES below).
+ * Amended 2026-08-11 (operator review of composer#220) — THE ENGINE
+ * RECORDS THE CHILD, AND OWNS HOW A HANDOFF SETTLES. §4 gains
+ * ctx.lastChild(): the run's most recent completed child, kept by the
+ * engine because ctx.spawn already mints every ChildResult. And
+ * exitWithChildStatus LOSES its child argument — it settles from that
+ * record. Two consequences, both deliberate. Handlers stop threading
+ * the child result out of whatever layer spawned it (composer was
+ * hand-rolling a recorder for exactly this). And the settlement
+ * ORDERING becomes the engine's: a signal-killed child settles as the
+ * abort — 128+signal, no envelope, no nextActions — even when the
+ * caller passed nextActions, so a Ctrl-C'd converge never carries a
+ * reproduce hint. The "invented child result" fence disappears with
+ * the argument that made the misuse possible; the maySpawn fence
+ * stays, joined by a construction error when no child ran at all.
  *
  * THE MODEL, in one analogy (operator, 2026-08-09): commands settle like
  * promises. A command can COMPLETE — and its completion can be
@@ -149,8 +160,10 @@
  * how well the cleanup went, so a session that shuts down cleanly on
  * Ctrl-C settles 130 while still reporting a completed envelope. No
  * handler can author these codes: documented codes stop at 99, and
- * the child-status bypass refuses a child result the engine did not
- * produce. Two codes are exempt, because neither was this CLI's to
+ * the child-status bypass takes its code from the engine's own record
+ * of the child rather than from anything the handler hands back — the
+ * handler names no child and no code at all. Two codes are exempt,
+ * because neither was this CLI's to
  * state in the first place, and both pass through verbatim: a real
  * child's status (the child owned the terminal and the signal reached
  * it too — that is why exitWithChildStatus reports 128+signal itself)
@@ -480,6 +493,14 @@ export interface CommandContext<TConfig = undefined, TCode extends number = neve
    */
   readonly spawn: (options: SpawnOptions) => Promise<ChildResult>
 
+  /** S3: how the run's most recent COMPLETED child ended, or undefined
+   *  when none has run. The engine records every child ctx.spawn
+   *  returns — it mints them all anyway — so a handler whose spawn
+   *  happens somewhere else in its own layering can still ask "did my
+   *  child fail?" where it settles, instead of threading the result
+   *  back by hand. Same record exitWithChildStatus settles from. */
+  readonly lastChild: () => ChildResult | undefined
+
   /** The one way to emit while running (§1). */
   readonly report: (event: EngineEvent) => void
 
@@ -681,27 +702,32 @@ export interface SpawnedChild {
  *  engine never imports it. */
 export type SpawnChild = (request: SpawnRequest) => SpawnedChild
 
-/** Opaque: built exclusively by exitWithChildStatus. */
+/** Opaque: built exclusively by exitWithChildStatus. It carries no
+ *  exit code — the code is not the handler's to state, so the engine
+ *  reads it off its own record of the child at settlement. */
 export interface ChildStatusSettlement {
-  readonly exitCode: number
   readonly nextActions: readonly NextAction[]
 }
 
 /** The sanctioned "exit with the child's status verbatim" outcome:
  *  returned inside ok(...), it settles through the no-envelope bypass
- *  server commands already have — and ONLY from a command that
- *  declares maySpawn, with the ChildResult that command's own
- *  ctx.spawn returned; anywhere else, or with a child result the
- *  engine never produced, it is a construction error (the bypass is
- *  fenced, not merely documented). A signal-killed child
- *  settles 128 + the signal number for the portable signals; an
- *  unknown signal, or an adapter that cannot say how the child ended,
- *  settles 1 — unknown is never success. `nextActions` (a failed
- *  converge's reproduce hint, R-S3-4) render to stderr in the
- *  engine's next-action style before the process exits with the
- *  child's code; the envelope stays absent. */
+ *  server commands already have, with the status of the child THIS
+ *  RUN spawned — ctx.lastChild(). The handler names no child, so
+ *  there is no way to describe one that never existed. Two
+ *  construction errors fence it: settling it from a command that does
+ *  not declare maySpawn, and settling it when no child ran at all.
+ *
+ *  The engine owns the ORDERING, which is composer's converge rule
+ *  promoted into the engine. A signal-killed child is the user
+ *  aborting: it settles 128 + the signal number (portable signals),
+ *  with no envelope and NO nextActions — the hint is dropped even
+ *  when the caller passed one, because there is nothing to reproduce.
+ *  Otherwise the child's own code passes through verbatim and
+ *  `nextActions` (a failed converge's reproduce hint, R-S3-4) render
+ *  to stderr in the engine's next-action style before the process
+ *  exits with that code. An unknown signal, or an adapter that cannot
+ *  say how the child ended, settles 1 — unknown is never success. */
 export declare function exitWithChildStatus(
-  child: ChildResult,
   opts?: { readonly nextActions?: readonly NextAction[] },
 ): ChildStatusSettlement
 
@@ -1126,8 +1152,8 @@ export declare function defineCommand<
  * rejects --json as soon as the command is known. A session that
  * returns ok(undefined) exits 0 — or 130/143 when a delivered signal
  * ended the run, which the engine settles from its own record (EXIT
- * CODES); one that returns ok(exitWithChildStatus(child)) exits with
- * the child's status. Those are the two ways a session settles
+ * CODES); one that returns ok(exitWithChildStatus()) exits with the
+ * status of the child it spawned. Those are the two ways a session settles
  * non-zero without erroring, and neither is a code the handler picks.
  */
 export interface SessionCommandDefinition<

--- a/.drive/projects/prisma-cli-v8/deferred.md
+++ b/.drive/projects/prisma-cli-v8/deferred.md
@@ -37,6 +37,18 @@ Nothing here is tracked outside this file.
   engine's `flag.number` accepts negatives and non-integers; legacy
   `composer log --tail` rejected both. Either the flag gains
   validation or the divergence entry widens.
+- **`v8-spawn-adapter.test.ts` has a race that fails under load.**
+  In `packages/cli/tests/v8-spawn-adapter.test.ts`, the "kill
+  delivers the signal to the live child" case runs an inline child
+  that writes its `ready` marker BEFORE calling
+  `process.on('SIGTERM', ...)`. The test waits on that marker and
+  then kills, so a kill landing in the gap hits the default SIGTERM
+  disposition: the child dies by signal instead of exiting 42, and
+  the assertion fails. Reproduced on a loaded machine (2 of 4 runs)
+  while verifying the child-record change, which does not touch
+  `packages/cli`. Fix: have the child write `ready` only after the
+  handler is installed — the same ordering the engine's own
+  `tests/fixtures/child.mjs` `trap-term` fixture already uses.
 
 ## Upstream, not ours to land
 

--- a/.drive/projects/prisma-cli-v8/specs/s3-composer.md
+++ b/.drive/projects/prisma-cli-v8/specs/s3-composer.md
@@ -67,20 +67,33 @@ const child = await ctx.spawn({ command, args, cwd, env });
 - **Reentrancy**: one live child per run; a second `ctx.spawn`
   while one is live is a construction error. `dev` coalesces
   rebuilds, as today's loop does.
-- **Afterwards**: the handler resumes with the child's status.
-  **A signal-killed child is an ABORT, not a failure** — handlers
-  branch on `signal` before `exitCode`. To exit with the child's
-  code verbatim the handler settles via the sanctioned
-  `exitWithChildStatus(child, opts?)` outcome — `opts` carries
+- **Afterwards**: the handler resumes with the child's status, and
+  so does the ENGINE — it records every child `ctx.spawn` returns.
+  `ctx.lastChild()` reports the run's most recent completed child,
+  or undefined when none ran, which is what lets a handler ask how
+  its child ended at the point it settles when the spawn itself
+  happened somewhere else in its own layering.
+  To exit with the child's code verbatim the handler settles via
+  the sanctioned `exitWithChildStatus(opts?)` outcome. It names no
+  child — the engine settles from its record — and `opts` carries
   `{ nextActions? }`, rendered to stderr in the engine's
   next-action style before the exit (R-S3-4's reproduce hint; the
-  envelope stays absent) — which uses the settlement bypass server
-  commands already have (no envelope; a signal-killed child
-  settles 128+signal; an unknown termination settles 1, never 0).
-  The bypass is FENCED twice, each a construction error: settling
+  envelope stays absent). It uses the settlement bypass server
+  commands already have.
+  The ORDER that settlement is read in is the ENGINE's, not the
+  handler's: **a signal-killed child is an ABORT, not a failure**,
+  and settles 128+signal with no envelope and NO next actions —
+  the hint is dropped even when the handler passed one, because the
+  user stopped the run and there is nothing to reproduce. Otherwise
+  the child's own code passes through verbatim, and an unknown
+  termination settles 1, never 0. A handler reading a `ChildResult`
+  for its own purposes still branches on `signal` before `exitCode`.
+  The bypass is FENCED, each fence a construction error: settling
   it from a command that does not declare `maySpawn`, and settling
-  it with a child result the engine did not itself produce from a
-  real spawn (amended 2026-08-11 — see the exit-code rule below).
+  it when no child ran at all (amended 2026-08-11, operator review
+  of composer#220 — the earlier "a child result the engine did not
+  produce" fence is gone, because with no child argument there is
+  nothing left to invent).
   The session kind's settlement is amended to permit non-zero
   through this path (it used to hard-code 0, and now also settles
   130/143 on its own — below),
@@ -92,8 +105,9 @@ const child = await ctx.spawn({ command, args, cwd, env });
   ENGINE's own record of that signal, for both command kinds and
   including the handler that caught the signal, cleaned up and
   returned successfully. A handler cannot author 130/143 —
-  documented codes stop at 99, and the child-status bypass now
-  refuses an invented child result. The verbatim codes stay
+  documented codes stop at 99, and the child-status bypass takes
+  its code from the engine's record of the child rather than from
+  anything the handler hands back. The verbatim codes stay
   verbatim: a real child's status passes through untouched (the
   child owned the terminal and the signal reached it too), as does
   a server command's protocol conclusion.
@@ -210,7 +224,8 @@ Committed consequences:
 ## Mapping rules
 
 R-S3-1 **Engine additions** (D1, `packages/cli-engine`):
-`ctx.spawn` per above; `Runtime.spawn` + harness fake;
+`ctx.spawn` and `ctx.lastChild` per above; `Runtime.spawn` +
+harness fake;
 `exitWithChildStatus`; parse-time `--json` rejection + the two
 kind amendments; credential injection (SPI amendment recorded);
 the signal record-and-replay + SIGTERM forwarding + abort ladder;
@@ -265,13 +280,14 @@ family:
 - `deploy <entry>` / `destroy <entry>`: result commands. Handler:
   section/args → near-expiry check → config evaluation → pipeline/preflight/artifact with engine
   presentation, authenticated via the in-process leg →
-  `ctx.spawn(alchemy converge)` → branch on `signal` FIRST
-  (signal-killed = abort: settle 128+signal, no failure envelope,
-  no reproduce hint — replacing the status collapse at
-  `run-alchemy.ts:61`) → failure: `exitWithChildStatus` with the
-  reproduce hint as `nextActions` (stage stays container-derived,
-  inventory H8) → success: read the deployment-result file,
-  present the summary. `deploy --production` (accepted-but-always-
+  `ctx.spawn(alchemy converge)` → failure: `exitWithChildStatus`
+  with the reproduce hint as `nextActions` (stage stays
+  container-derived, inventory H8) → success: read the
+  deployment-result file, present the summary. The handler does not
+  order the signal case itself: the ENGINE settles a signal-killed
+  child as the abort (128+signal, no failure envelope, no reproduce
+  hint) whatever the handler asked for, which is what replaces the
+  status collapse at `run-alchemy.ts:61`. `deploy --production` (accepted-but-always-
   errors today) is dropped. The `.alchemy` destroy warning ports
   verbatim, correctness tracked as H6.
 - `dev <entry>`: session command (kind amendments apply). Watch
@@ -405,10 +421,8 @@ install footprint acknowledged as a committed consequence
 
 PR-136 review round (architect + PE on D1, 2026-08-11; orchestrator
 rulings applied): the child-status settlement bypass is fenced to
-`maySpawn` commands (runtime check; the architect blocker) — and,
-since the 2026-08-11 exit-code ruling, to child results the engine
-itself produced;
-`exitWithChildStatus(child, opts?)` gains `{ nextActions? }` rendered
+`maySpawn` commands (runtime check; the architect blocker);
+`exitWithChildStatus(opts?)` gains `{ nextActions? }` rendered
 before the exit — the R-S3-4 surface as written now exists; the spawn
 path's storage read is replaced by the named manager operation
 `activeAccessToken()` and the Auth section's `source` conditional is
@@ -421,3 +435,20 @@ credentials need is structural); a second recorded signal press is
 forwarded to the child as SIGTERM (the direct-signal escalation path);
 the environment-only `CredentialManager` the rebase dropped is
 restored as `EnvironmentCredentialManager` on the main entrypoint.
+
+composer#220 review round (operator on the D3 family, 2026-08-11):
+two things composer's `converge.ts` was hand-rolling belong to the
+engine, and move there. Composer kept a mutable closure recording
+whatever `ctx.spawn` returned, so its handler could read the child
+where it settles — the engine mints every `ChildResult` anyway, so it
+now keeps the run's most recent one and exposes it as
+`ctx.lastChild()`. And composer's `settleConverge` hand-rolled the
+order the outcome is read in — signal-killed child first, then a
+failure that reached a failing child, then an ordinary structured
+error — so the signal-first half becomes the engine's:
+`exitWithChildStatus` loses its child argument, settles from the
+record, and settles a signal-killed child as the abort whatever
+`nextActions` the caller passed. The "invented child result" fence
+retires with the argument that made the misuse reachable; a run that
+settles this way with no child on record is the construction error
+that takes its place.

--- a/packages/cli-engine/src/commands.ts
+++ b/packages/cli-engine/src/commands.ts
@@ -304,7 +304,8 @@ export function defineCommand<
  * ok(undefined) exits 0 — or 130/143 when a signal ended the run, which
  * the engine settles from its own record of that signal, not from
  * anything the handler returns; one that returns
- * ok(exitWithChildStatus(child)) exits with the child's status.
+ * ok(exitWithChildStatus()) exits with the status of the child it
+ * spawned.
  */
 export interface SessionCommandDefinition<
   TFlags extends Record<string, FlagSpec<unknown>> = Record<

--- a/packages/cli-engine/src/context.ts
+++ b/packages/cli-engine/src/context.ts
@@ -68,6 +68,16 @@ export interface CommandContext<
    */
   readonly spawn: (options: SpawnOptions) => Promise<ChildResult>;
 
+  /**
+   * How the run's most recent completed child ended, or undefined when
+   * none has run. The engine records every child ctx.spawn returns, so
+   * a handler whose spawn happens deep in its own layering can still
+   * ask "did my child fail?" where it settles, without threading the
+   * result back by hand. This is the same record exitWithChildStatus
+   * settles from.
+   */
+  readonly lastChild: () => ChildResult | undefined;
+
   /** The one way to emit while running. */
   readonly report: (event: EngineEvent) => void;
 

--- a/packages/cli-engine/src/execution/command-context.ts
+++ b/packages/cli-engine/src/execution/command-context.ts
@@ -112,6 +112,7 @@ export function makeContext(
       return api;
     },
     spawn: makeSpawn(invocation, def),
+    lastChild: () => state.lastChild,
     report: (event) => reportEvent(invocation, event),
     prompt: makePromptSurface(invocation),
     openUrl: (request) => announceUrl(invocation, request),

--- a/packages/cli-engine/src/execution/engine.ts
+++ b/packages/cli-engine/src/execution/engine.ts
@@ -18,7 +18,11 @@ import type { Format, PresentedResult } from "../presentation";
 import { CliStructuredError, type Result } from "../protocol";
 import type { EngineCommandSnapshot, RunSummary } from "../run-summary";
 import type { InputStream, Runtime } from "../runtime";
-import { type ChildStatusSettlement, isChildStatusSettlement } from "../spawn";
+import {
+  type ChildResult,
+  type ChildStatusSettlement,
+  isChildStatusSettlement,
+} from "../spawn";
 import { makeContext } from "./command-context";
 import { buildCommandSnapshot } from "./command-snapshot";
 import {
@@ -137,6 +141,10 @@ export interface RunState {
    *  signals are recorded rather than acted on, and commentary is
    *  buffered. */
   delegatedTerminal: DelegatedTerminal | undefined;
+  /** How the run's most recent completed child ended, as ctx.spawn
+   *  reported it. The engine's own record: what ctx.lastChild()
+   *  returns, and the only status exitWithChildStatus can settle. */
+  lastChild: ChildResult | undefined;
   /** How many prompts are reading the terminal. Claimed before a
    *  prompt's first await, so an unawaited prompt still blocks
    *  ctx.spawn from handing the same terminal to a child. */
@@ -290,6 +298,7 @@ export class EngineImpl implements Engine {
       unresolvedFlagNames: [],
       snapshot: undefined,
       delegatedTerminal: undefined,
+      lastChild: undefined,
       activePrompts: 0,
       deliveredSignal: undefined,
       pendingForceExit: undefined,

--- a/packages/cli-engine/src/execution/settlement.ts
+++ b/packages/cli-engine/src/execution/settlement.ts
@@ -11,7 +11,7 @@ import {
   type Diagnostic,
   type NextAction,
 } from "../protocol";
-import { type ChildStatusSettlement, isEngineSpawned } from "../spawn";
+import { type ChildStatusSettlement, childExitCode } from "../spawn";
 import type { EngineSpec, Invocation } from "./engine";
 import {
   firstLine,
@@ -197,14 +197,16 @@ export function settleVerbatimExitCode(
  * never documented, because the code is not the handler's own
  * conclusion, it is the child's.
  *
- * Two conditions fence it, both construction errors. The command must
+ * The status comes from the engine's own record of the child, never
+ * from the handler, so there is nothing here for a handler to state.
+ * Two conditions fence it, both construction errors: the command must
  * hand the terminal to another program — reachable from a
  * non-declaring handler this would also end a json stream without its
- * terminal result frame. And the status must be one the engine watched
- * a real child produce: a handler that invents a child result is
- * choosing an exit code through a door meant for reporting one, and a
- * handler interrupted mid-run has no need to, because the engine
- * settles a signal-terminated run itself.
+ * terminal result frame — and a child must actually have run.
+ *
+ * A signal-killed child overrules whatever the handler asked for. The
+ * user stopped the run: it settles 128 + the signal number, with no
+ * envelope and no next actions, because there is nothing to reproduce.
  */
 export function settleChildStatus(
   invocation: Invocation,
@@ -216,16 +218,19 @@ export function settleChildStatus(
       `@prisma/cli-engine: command '${invocation.state.commandId}' returned exitWithChildStatus without declaring maySpawn — only a command that hands the terminal to another program may settle with that program's status`,
     );
   }
-  if (!isEngineSpawned(settlement)) {
+  const child = invocation.state.lastChild;
+  if (child === undefined) {
     throw new Error(
-      `@prisma/cli-engine: command '${invocation.state.commandId}' returned exitWithChildStatus for a child result the engine did not produce — only the result of a ctx.spawn carries a child's status`,
+      `@prisma/cli-engine: command '${invocation.state.commandId}' returned exitWithChildStatus without a child having run — that settlement reports the status of a child ctx.spawn started, and this run started none`,
     );
   }
   // Only human format is reachable here: maySpawn forces it.
-  for (const action of settlement.nextActions) {
-    invocation.runtime.stderr.write(`${renderNextAction(action)}\n`);
+  if (child.signal === null) {
+    for (const action of settlement.nextActions) {
+      invocation.runtime.stderr.write(`${renderNextAction(action)}\n`);
+    }
   }
-  settleVerbatimExitCode(invocation, settlement.exitCode);
+  settleVerbatimExitCode(invocation, childExitCode(child));
 }
 
 /** A session command that returned ok shut down cleanly: no

--- a/packages/cli-engine/src/execution/spawn.ts
+++ b/packages/cli-engine/src/execution/spawn.ts
@@ -6,13 +6,12 @@ import {
 } from "../credential-manager";
 import type { EngineEvent } from "../events";
 import { CliStructuredError } from "../protocol";
-import {
-  type ChildResult,
-  engineSpawnedResult,
-  type SpawnChild,
-  type SpawnedChild,
-  type SpawnOptions,
-  type SpawnRequest,
+import type {
+  ChildResult,
+  SpawnChild,
+  SpawnedChild,
+  SpawnOptions,
+  SpawnRequest,
 } from "../spawn";
 import { constructionError } from "./command-tree";
 import { makeDebugLog } from "./debug";
@@ -185,12 +184,29 @@ async function runChild(
   const ended = new AbortController();
   armTerminationLadder(invocation, terminal, child, ended.signal);
   try {
-    return engineSpawnedResult(await child.ended);
+    return recordCompletedChild(invocation, await child.ended);
   } catch (cause) {
     throw spawnFailedError(request.command, cause);
   } finally {
     ended.abort();
   }
+}
+
+/** The engine mints the result the handler sees and keeps it on the
+ *  run: the settlement then reads the child's status from the engine's
+ *  own record rather than from anything the handler hands back, and a
+ *  handler whose spawn sits deep in its own layering can still ask how
+ *  the child ended through ctx.lastChild(). */
+function recordCompletedChild(
+  invocation: Invocation,
+  ended: ChildResult,
+): ChildResult {
+  const result = Object.freeze({
+    exitCode: ended.exitCode,
+    signal: ended.signal,
+  });
+  invocation.state.lastChild = result;
+  return result;
 }
 
 /** A programmatic abort of ctx.signal (a delivered signal is recorded

--- a/packages/cli-engine/src/spawn.ts
+++ b/packages/cli-engine/src/spawn.ts
@@ -16,8 +16,9 @@ export interface SpawnRequest {
 }
 
 /** How a child ended. A signal-killed child carries `signal` and a null
- *  `exitCode`; handlers branch on `signal` first — a signal-killed child
- *  is an abort, not a failure. */
+ *  `exitCode`, and is an abort rather than a failure: exitWithChildStatus
+ *  settles it as one, and a handler that reads the result itself branches
+ *  on `signal` before `exitCode`. */
 export interface ChildResult {
   readonly exitCode: number | null;
   readonly signal: string | null;
@@ -54,51 +55,25 @@ export const CHILD_STATUS: unique symbol = Symbol.for(
   "@prisma/cli-engine.childStatus",
 );
 
-/** Marks a ChildResult the engine watched a real child produce. */
-const ENGINE_SPAWNED: unique symbol = Symbol.for(
-  "@prisma/cli-engine.engineSpawned",
-);
-
-function markEngineSpawned<T extends object>(value: T): T {
-  return Object.freeze(
-    Object.defineProperty(value, ENGINE_SPAWNED, { value: true }),
-  );
-}
-
-export function isEngineSpawned(value: object): boolean {
-  return (value as Record<symbol, unknown>)[ENGINE_SPAWNED] === true;
-}
-
-/**
- * The child result ctx.spawn hands back: the engine mints it from what
- * the adapter reported, so a handler cannot pass off an invented one as
- * a child's status. exitWithChildStatus carries the mark onto its
- * settlement and the settlement refuses an unmarked one.
- */
-export function engineSpawnedResult(result: ChildResult): ChildResult {
-  return markEngineSpawned({
-    exitCode: result.exitCode,
-    signal: result.signal,
-  });
-}
-
 /**
  * The sanctioned settlement outcome for "exit with the child's status
  * verbatim": no envelope, the same settlement bypass server commands
  * use. Built exclusively by exitWithChildStatus, and only settled by a
- * command that declares maySpawn, from a child result the engine
- * itself produced. `nextActions` render to stderr before the process
- * exits with the child's code.
+ * command that declares maySpawn. It carries no exit code, because the
+ * code is not the handler's to state: the engine reads it off its own
+ * record of the child. `nextActions` render to stderr before the
+ * process exits with the child's code.
  */
 export interface ChildStatusSettlement {
   readonly [CHILD_STATUS]: true;
-  readonly exitCode: number;
   readonly nextActions: readonly NextAction[];
 }
 
 export interface ExitWithChildStatusOptions {
   /** Engine-styled guidance printed to stderr before the exit — a
-   *  failed converge's reproduce hint. The envelope stays absent. */
+   *  failed converge's reproduce hint. The envelope stays absent, and
+   *  a signal-killed child drops these entirely: the user stopped the
+   *  run, so there is nothing to reproduce. */
   readonly nextActions?: readonly NextAction[];
 }
 
@@ -124,7 +99,7 @@ const SIGNAL_NUMBERS: Readonly<Record<string, number>> = {
  *  child's own exit code, verbatim. Unknown is never success: a signal
  *  outside the portable table, or an adapter that cannot say how the
  *  child ended (exitCode and signal both null), settles 1. */
-function childExitCode(child: ChildResult): number {
+export function childExitCode(child: ChildResult): number {
   if (child.signal === null) {
     return child.exitCode ?? 1;
   }
@@ -132,22 +107,24 @@ function childExitCode(child: ChildResult): number {
   return signalNumber === undefined ? 1 : 128 + signalNumber;
 }
 
-/** Settles the run with the status of the child `ctx.spawn` returned.
- *  A result the engine did not produce is a construction error at
- *  settlement: this is how a real child's status reaches the exit code,
- *  not how a handler picks one. */
+/**
+ * Settles the run with the status of the child the run spawned — the
+ * one `ctx.lastChild()` reports. The handler names no child and no
+ * code: this is how a real child's status reaches the exit code, not
+ * how a handler picks one, so a run that spawned nothing is a
+ * construction error at settlement.
+ *
+ * A signal-killed child overrules everything the caller asked for: it
+ * settles 128 + the signal number with no `nextActions`, because the
+ * user stopped the run and there is nothing to reproduce.
+ */
 export function exitWithChildStatus(
-  child: ChildResult,
   options?: ExitWithChildStatusOptions,
 ): ChildStatusSettlement {
-  const settlement = {
+  return Object.freeze({
     [CHILD_STATUS]: true as const,
-    exitCode: childExitCode(child),
     nextActions: Object.freeze([...(options?.nextActions ?? [])]),
-  };
-  return isEngineSpawned(child)
-    ? markEngineSpawned(settlement)
-    : Object.freeze(settlement);
+  });
 }
 
 export function isChildStatusSettlement(

--- a/packages/cli-engine/tests/environment-credential-manager.test.ts
+++ b/packages/cli-engine/tests/environment-credential-manager.test.ts
@@ -135,8 +135,10 @@ describe("wired as a Runtime's manager", () => {
     help: { summary: "Hands credentials to a child" },
     maySpawn: true,
     needs: { credentials: "child" },
-    handler: async (_args, ctx) =>
-      ok(exitWithChildStatus(await ctx.spawn({ command: "alchemy" }))),
+    handler: async (_args, ctx) => {
+      await ctx.spawn({ command: "alchemy" });
+      return ok(exitWithChildStatus());
+    },
   });
   const cli = createCli({
     name: "t",

--- a/packages/cli-engine/tests/fixtures/spawn-host.mjs
+++ b/packages/cli-engine/tests/fixtures/spawn-host.mjs
@@ -68,7 +68,7 @@ const command = defineCommand({
         aborted: ctx.signal.aborted,
       }),
     );
-    return ok(exitWithChildStatus(child));
+    return ok(exitWithChildStatus());
   },
 });
 

--- a/packages/cli-engine/tests/spawn-real-child.test.ts
+++ b/packages/cli-engine/tests/spawn-real-child.test.ts
@@ -51,11 +51,11 @@ function childCommand(...childArgs: string[]) {
     help: { summary: "Runs the fixture child" },
     maySpawn: true,
     handler: async (_args, ctx) => {
-      const child = await ctx.spawn({
+      await ctx.spawn({
         command: NODE,
         args: [CHILD, ...childArgs],
       });
-      return ok(exitWithChildStatus(child));
+      return ok(exitWithChildStatus());
     },
   });
 }
@@ -126,10 +126,10 @@ describe.skipIf(process.platform === "win32")(
         help: { summary: "Spawns a program that does not exist" },
         maySpawn: true,
         handler: async (_args, ctx) => {
-          const child = await ctx.spawn({
+          await ctx.spawn({
             command: "/definitely/not/a/real/binary-s3",
           });
-          return ok(exitWithChildStatus(child));
+          return ok(exitWithChildStatus());
         },
       });
       const cli = createTestCli({
@@ -197,9 +197,9 @@ describe.skipIf(process.platform === "win32")(
           await waitForFile(ready);
           controller.abort();
           abortedDuringChild = ctx.signal.aborted;
-          const child = await live;
+          await live;
           abortedAfterChild = ctx.signal.aborted;
-          return ok(exitWithChildStatus(child));
+          return ok(exitWithChildStatus());
         },
       });
       const cli = createTestCli({
@@ -225,11 +225,11 @@ describe.skipIf(process.platform === "win32")(
         handler: async (_args, ctx) => {
           ctx.report({ kind: "status", subject: "run", status: "ready" });
           await new Promise((resolve) => setTimeout(resolve, 0));
-          const child = await ctx.spawn({
+          await ctx.spawn({
             command: NODE,
             args: [CHILD, "ignore-term", ready],
           });
-          return ok(exitWithChildStatus(child));
+          return ok(exitWithChildStatus());
         },
       });
       const cli = createTestCli({

--- a/packages/cli-engine/tests/spawn.test.ts
+++ b/packages/cli-engine/tests/spawn.test.ts
@@ -44,8 +44,8 @@ const converge = defineCommand({
   help: { summary: "Hands the terminal to a child" },
   maySpawn: true,
   handler: async (_args, ctx) => {
-    const child = await ctx.spawn({ command: "alchemy", args: ["deploy"] });
-    return ok(exitWithChildStatus(child));
+    await ctx.spawn({ command: "alchemy", args: ["deploy"] });
+    return ok(exitWithChildStatus());
   },
 });
 
@@ -135,8 +135,10 @@ describe("the child's status", () => {
     const dev = defineSessionCommand({
       help: { summary: "A session that converges through a child" },
       maySpawn: true,
-      handler: async (_args, ctx) =>
-        ok(exitWithChildStatus(await ctx.spawn({ command: "alchemy" }))),
+      handler: async (_args, ctx) => {
+        await ctx.spawn({ command: "alchemy" });
+        return ok(exitWithChildStatus());
+      },
     });
     const cli = createTestCli({
       commands: { dev },
@@ -161,6 +163,109 @@ describe("the child's status", () => {
     expect(result.exitCode).toBe(2);
     expect(result.stderr).toContain("CLI.SPAWN_FAILED");
     expect(result.stderr).toContain("ENOENT");
+  });
+});
+
+/** Composer's shape: the spawn happens down in an operations layer
+ *  that hands the handler nothing back, so the only place the child's
+ *  status can come from is the engine's own record. */
+async function convergeInAnotherLayer(ctx: {
+  readonly spawn: (options: { readonly command: string }) => Promise<unknown>;
+}): Promise<void> {
+  await ctx.spawn({ command: "alchemy" });
+}
+
+describe("the run records its most recent child", () => {
+  test("ctx.lastChild() is undefined until a child has run", async () => {
+    const asking = defineCommand({
+      help: { summary: "Asks for a child before running one" },
+      maySpawn: true,
+      handler: async (_args, ctx) =>
+        ok(
+          ctx.present({ data: ctx.lastChild() ?? "none" }, { human: () => [] }),
+        ),
+    });
+    const cli = createTestCli({ commands: { asking }, now: CLOCK });
+
+    const result = await cli.run(["asking"]);
+
+    expect(result.presented?.data).toBe("none");
+    expect(result.spawns).toEqual([]);
+  });
+
+  test("ctx.lastChild() reports how the child ended", async () => {
+    const asking = defineCommand({
+      help: { summary: "Reads its child off the run" },
+      maySpawn: true,
+      handler: async (_args, ctx) => {
+        await ctx.spawn({ command: "alchemy" });
+        return ok(ctx.present({ data: ctx.lastChild() }, { human: () => [] }));
+      },
+    });
+    const cli = createTestCli({
+      commands: { asking },
+      now: CLOCK,
+      spawnScript: () => ({ exitCode: 9, signal: null }),
+    });
+
+    const result = await cli.run(["asking"]);
+
+    expect(result.presented?.data).toEqual({ exitCode: 9, signal: null });
+  });
+
+  test("after two children it is the LAST one, not the first", async () => {
+    const twice = defineCommand({
+      help: { summary: "Runs two children in sequence" },
+      maySpawn: true,
+      handler: async (_args, ctx) => {
+        await ctx.spawn({ command: "first" });
+        const afterFirst = ctx.lastChild();
+        await ctx.spawn({ command: "second" });
+        return ok(
+          ctx.present(
+            { data: { afterFirst, afterSecond: ctx.lastChild() } },
+            { human: () => [] },
+          ),
+        );
+      },
+    });
+    const cli = createTestCli({
+      commands: { twice },
+      now: CLOCK,
+      spawnScript: (request) => ({
+        exitCode: request.command === "first" ? 4 : 5,
+        signal: null,
+      }),
+    });
+
+    const result = await cli.run(["twice"]);
+
+    expect(result.presented?.data).toEqual({
+      afterFirst: { exitCode: 4, signal: null },
+      afterSecond: { exitCode: 5, signal: null },
+    });
+    expect(result.spawns.map((spawn) => spawn.command)).toEqual([
+      "first",
+      "second",
+    ]);
+  });
+
+  test("exitWithChildStatus settles from the record, not from the handler", async () => {
+    const layered = defineCommand({
+      help: { summary: "Spawns through a layer that returns nothing" },
+      maySpawn: true,
+      handler: async (_args, ctx) => {
+        await convergeInAnotherLayer(ctx);
+        return ok(exitWithChildStatus());
+      },
+    });
+    const cli = createTestCli({
+      commands: { layered },
+      now: CLOCK,
+      spawnScript: () => ({ exitCode: 6, signal: null }),
+    });
+
+    expect((await cli.run(["layered"])).exitCode).toBe(6);
   });
 });
 
@@ -255,7 +360,8 @@ describe("the spawn request", () => {
       maySpawn: true,
       handler: async (_args, ctx) => {
         handlerRan = true;
-        return ok(exitWithChildStatus(await ctx.spawn({ command: "alchemy" })));
+        await ctx.spawn({ command: "alchemy" });
+        return ok(exitWithChildStatus());
       },
     });
     const cli = createCli({
@@ -454,8 +560,8 @@ describe("signals", () => {
       handler: async (_args, ctx) => {
         ctx.report({ kind: "status", subject: "run", status: "ready" });
         await new Promise((resolve) => setTimeout(resolve, 0));
-        const child = await ctx.spawn({ command: "alchemy" });
-        return ok(exitWithChildStatus(child));
+        await ctx.spawn({ command: "alchemy" });
+        return ok(exitWithChildStatus());
       },
     });
     const cli = createTestCli({
@@ -487,8 +593,8 @@ const credentialedConverge = defineCommand({
   maySpawn: true,
   needs: { credentials: "child" },
   handler: async (_args, ctx) => {
-    const child = await ctx.spawn({ command: "alchemy", args: ["deploy"] });
-    return ok(exitWithChildStatus(child));
+    await ctx.spawn({ command: "alchemy", args: ["deploy"] });
+    return ok(exitWithChildStatus());
   },
 });
 
@@ -512,8 +618,8 @@ describe("credential injection", () => {
       needs: { credentials: "child" },
       handler: async (_args, ctx) => {
         ctx.report({ kind: "status", subject: "run", status: "pre-spawn" });
-        const child = await ctx.spawn({ command: "alchemy" });
-        return ok(exitWithChildStatus(child));
+        await ctx.spawn({ command: "alchemy" });
+        return ok(exitWithChildStatus());
       },
     });
     const cli = createTestCli({
@@ -698,8 +804,7 @@ describe("the settlement bypass is fenced to declaring commands", () => {
   test("a result command without maySpawn returning exitWithChildStatus is a construction error", async () => {
     const undeclared = defineCommand({
       help: { summary: "Settles a child status it never earned" },
-      handler: async () =>
-        ok(exitWithChildStatus({ exitCode: 7, signal: null })),
+      handler: async () => ok(exitWithChildStatus()),
     });
     const cli = createTestCli({ commands: { undeclared }, now: CLOCK });
 
@@ -714,8 +819,7 @@ describe("the settlement bypass is fenced to declaring commands", () => {
   test("in json mode the stream still ends with its result frame", async () => {
     const undeclared = defineCommand({
       help: { summary: "Settles a child status it never earned" },
-      handler: async () =>
-        ok(exitWithChildStatus({ exitCode: 7, signal: null })),
+      handler: async () => ok(exitWithChildStatus()),
     });
     const cli = createTestCli({ commands: { undeclared }, now: CLOCK });
 
@@ -730,8 +834,7 @@ describe("the settlement bypass is fenced to declaring commands", () => {
   test("a session command without maySpawn is fenced the same way", async () => {
     const undeclared = defineSessionCommand({
       help: { summary: "A session settling a child status it never earned" },
-      handler: async () =>
-        ok(exitWithChildStatus({ exitCode: 7, signal: null })),
+      handler: async () => ok(exitWithChildStatus()),
     });
     const cli = createTestCli({ commands: { undeclared }, now: CLOCK });
 
@@ -743,28 +846,22 @@ describe("the settlement bypass is fenced to declaring commands", () => {
     expect(result.stderr).toContain("without declaring maySpawn");
   });
 
-  test("a declaring command inventing a child result is a construction error", async () => {
-    const inventing = defineSessionCommand({
-      help: { summary: "Describes a child that never existed" },
+  test("a declaring command that never spawned is a construction error", async () => {
+    const empty = defineSessionCommand({
+      help: { summary: "Settles a child status without running a child" },
       maySpawn: true,
-      handler: async (_args, ctx) => {
-        await ctx.spawn({ command: "alchemy" });
-        return ok(exitWithChildStatus({ exitCode: null, signal: "SIGINT" }));
-      },
+      handler: async () => ok(exitWithChildStatus()),
     });
-    const cli = createTestCli({
-      commands: { inventing },
-      now: CLOCK,
-      spawnScript: () => ({ exitCode: 0, signal: null }),
-    });
+    const cli = createTestCli({ commands: { empty }, now: CLOCK });
 
-    const result = await cli.run(["inventing"], { isTty: { stdout: true } });
+    const result = await cli.run(["empty"], { isTty: { stdout: true } });
 
     expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain("the engine did not produce");
+    expect(result.stderr).toContain("without a child having run");
+    expect(result.spawns).toEqual([]);
   });
 
-  test("the child result ctx.spawn returned settles normally", async () => {
+  test("the child ctx.spawn ran settles normally", async () => {
     const cli = createTestCli({
       commands: { converge },
       now: CLOCK,
@@ -778,38 +875,55 @@ describe("the settlement bypass is fenced to declaring commands", () => {
 });
 
 describe("next actions on a child-status settlement", () => {
+  const hinting = defineCommand({
+    help: { summary: "A converge that always asks for a reproduce hint" },
+    maySpawn: true,
+    handler: async (_args, ctx) => {
+      await ctx.spawn({ command: "alchemy" });
+      return ok(
+        exitWithChildStatus({
+          nextActions: [
+            {
+              kind: "run-command",
+              label: "Reproduce the failed converge",
+              command: "alchemy deploy ./entry.ts",
+            },
+          ],
+        }),
+      );
+    },
+  });
+
   test("they render to stderr before the run exits with the child's code", async () => {
-    const failing = defineCommand({
-      help: { summary: "A converge that fails with a reproduce hint" },
-      maySpawn: true,
-      handler: async (_args, ctx) => {
-        const child = await ctx.spawn({ command: "alchemy" });
-        return ok(
-          exitWithChildStatus(child, {
-            nextActions: [
-              {
-                kind: "run-command",
-                label: "Reproduce the failed converge",
-                command: "alchemy deploy ./entry.ts",
-              },
-            ],
-          }),
-        );
-      },
-    });
     const cli = createTestCli({
-      commands: { failing },
+      commands: { hinting },
       now: CLOCK,
       spawnScript: () => ({ exitCode: 3, signal: null }),
     });
 
-    const result = await cli.run(["failing"]);
+    const result = await cli.run(["hinting"]);
 
     expect(result.exitCode).toBe(3);
     expect(result.stdout).toBe("");
     expect(result.stderr).toContain(
       "→ Reproduce the failed converge: alchemy deploy ./entry.ts",
     );
+  });
+
+  test("a signal-killed child drops them and settles the abort", async () => {
+    const cli = createTestCli({
+      commands: { hinting },
+      now: CLOCK,
+      spawnScript: () => ({ exitCode: null, signal: "SIGINT" }),
+    });
+
+    const result = await cli.run(["hinting"]);
+
+    // The user stopped the converge, so there is nothing to reproduce:
+    // the abort wins over what the handler asked for.
+    expect(result.exitCode).toBe(130);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
   });
 });
 
@@ -934,8 +1048,8 @@ describe("signal replay routes every force exit after settlement", () => {
       handler: async (_args, ctx) => {
         deliver("SIGINT");
         await new Promise((resolve) => setTimeout(resolve, 0));
-        const child = await ctx.spawn({ command: "alchemy" });
-        return ok(exitWithChildStatus(child));
+        await ctx.spawn({ command: "alchemy" });
+        return ok(exitWithChildStatus());
       },
     });
     const cli = createCli({
@@ -1090,8 +1204,8 @@ describe("the terminal has one owner at a time", () => {
       maySpawn: true,
       handler: async (_args, ctx) => {
         await ctx.prompt.confirm("Proceed?", { default: true });
-        const child = await ctx.spawn({ command: "alchemy" });
-        return ok(exitWithChildStatus(child));
+        await ctx.spawn({ command: "alchemy" });
+        return ok(exitWithChildStatus());
       },
     });
     const cli = createTestCli({ commands: { sequential }, now: CLOCK });


### PR DESCRIPTION
A command whose work is done by a child process has to answer one question when the child is gone: what does this run exit with? Composer was answering it by hand — keeping the child result in a closure because the spawn happens deep in its operations layer while the decision happens in the handler, then re-deriving the ordering:

```ts
// composer, before — a recorder and a policy that are not composer's
let seen: ChildResult | undefined;                 // capture whatever ctx.spawn returned
...
const child = spawn.child();
if (child !== undefined && child.signal !== null) {
  return ok(exitWithChildStatus(child));           // a killed child is an abort
}
```

Both belong here. The engine mints every child result, so it keeps the last one, and it owns what a handoff settles as:

```ts
if (!result.ok) {
  const child = ctx.lastChild();
  if (child !== undefined && child.exitCode !== 0) {
    return ok(exitWithChildStatus({ nextActions: reproduceHint(result.failure) }));
  }
  return notOk(toEngineError(result.failure));
}
```

## The decision

**`ctx.lastChild()`** returns the run's most recent completed child, or `undefined` if none ran — so a handler can ask "did my child fail?" without threading the result out of wherever the spawn happened. A spawn that never launched leaves no record.

**`exitWithChildStatus()` loses its child argument** and settles from that record. A signal-killed child settles as the abort — 128 + the signal, no envelope — and any `nextActions` the caller passed are dropped, because a reproduce hint for a deploy the user interrupted is noise.

The argument's removal deletes a fence rather than adding one. The previous round had to check that a settlement carried a child result the engine itself produced, because a handler could otherwise pass an invented one to choose an exit code through a door meant for reporting one. With nothing to pass, that misuse is unreachable, so the marking machinery — `ENGINE_SPAWNED`, `markEngineSpawned`, `isEngineSpawned`, and the check — is gone. The `maySpawn` declaration fence stays, joined by a construction error for settling with no child on record.

## Behavior worth knowing

Composer's old first branch fired even when the operation *succeeded* while its child was signal-killed. That case now falls through to presenting the success. The run still exits 130 — the engine settles a signal-terminated run from its own delivered-signal record — but it presents a result envelope rather than an abort. A command that wants the abort presentation there should say so explicitly.

## Alternatives considered

- **Leaving the recorder in composer.** It is the engine's bookkeeping: the engine creates the value, and every other consumer of `ctx.spawn` would write the same closure.
- **Keeping the child argument and the fence.** The fence existed only because the argument did. Removing the argument removes the class of misuse instead of policing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
