### PR TITLE
The engine works out whether it is in CI, instead of asking every host

### DIFF
--- a/packages/cli-engine/package.json
+++ b/packages/cli-engine/package.json
@@ -50,6 +50,7 @@
     "@prisma/management-api-sdk": "1.55.0",
     "@stricli/core": "1.3.0",
     "c12": "3.3.4",
+    "ci-info": "^4.3.1",
     "colorette": "^2.0.20",
     "package-manager-detector": "1.8.0",
     "string-width": "^8.2.1"

--- a/packages/cli-engine/src/ci.ts
+++ b/packages/cli-engine/src/ci.ts
@@ -1,0 +1,97 @@
+import vendors from "ci-info/vendors.json" with { type: "json" };
+import type { Runtime } from "./runtime";
+
+type Env = Readonly<Record<string, string | undefined>>;
+
+/**
+ * One way a vendor's entry says "this variable proves it is me". The
+ * table uses four shapes: a variable name that must be set, `{ env,
+ * includes }` for a variable that must contain a substring, `{ any }`
+ * for a list where one must be set, and otherwise a set of variables
+ * that must equal the given values.
+ */
+type VendorCheck = string | Readonly<Record<string, unknown>>;
+
+interface Vendor {
+  readonly name: string;
+  readonly env: VendorCheck | readonly VendorCheck[];
+}
+
+/**
+ * ci-info's own list of CI providers, read from the installed package
+ * rather than copied here, so upgrading ci-info is what teaches the
+ * engine a new provider. Its `isCI` export cannot be used instead: that
+ * module evaluates against the real `process.env` the moment it is
+ * imported, and the engine may only read the environment its host
+ * injected.
+ */
+const VENDORS: readonly Vendor[] = vendors;
+
+/**
+ * The variables ci-info checks outside the vendor table, catching CI
+ * systems that set a conventional variable but have no table entry.
+ * These are cross-vendor conventions rather than per-vendor facts,
+ * which is why this list holds still while the table grows.
+ */
+const CONVENTIONAL_CI_VARS = [
+  "BUILD_ID",
+  "BUILD_NUMBER",
+  "CI",
+  "CI_APP_ID",
+  "CI_BUILD_ID",
+  "CI_BUILD_NUMBER",
+  "CI_NAME",
+  "CONTINUOUS_INTEGRATION",
+  "RUN_ID",
+] as const;
+
+function isSet(value: string | undefined): boolean {
+  return value !== undefined && value !== "";
+}
+
+function checkMatches(check: VendorCheck, env: Env): boolean {
+  if (typeof check === "string") {
+    return isSet(env[check]);
+  }
+  const { env: variable, includes, any } = check;
+  if (typeof variable === "string" && typeof includes === "string") {
+    return env[variable]?.includes(includes) === true;
+  }
+  if (Array.isArray(any)) {
+    return any.some((name: unknown) => isSet(env[String(name)]));
+  }
+  return Object.entries(check).every(([name, value]) => env[name] === value);
+}
+
+function vendorMatches(vendor: Vendor, env: Env): boolean {
+  const checks = Array.isArray(vendor.env) ? vendor.env : [vendor.env];
+  return checks.every((check: VendorCheck) => checkMatches(check, env));
+}
+
+/**
+ * Whether this environment is a CI environment, by ci-info's rules
+ * applied to the environment the host injected rather than to
+ * `process.env`. `CI=false` is an explicit denial that stops every
+ * other check, exactly as ci-info treats it.
+ */
+export function detectCI(env: Env): boolean {
+  if (env.CI === "false") {
+    return false;
+  }
+  if (CONVENTIONAL_CI_VARS.some((name) => isSet(env[name]))) {
+    return true;
+  }
+  return VENDORS.some((vendor) => vendorMatches(vendor, env));
+}
+
+/**
+ * The engine's one answer to "is this run in CI", read by telemetry
+ * gating, `ctx.isCI` and the default interactivity decision. A host
+ * that says nothing gets detection, so forgetting to answer cannot turn
+ * a CI run into a reporting one.
+ */
+export function resolveIsCI(
+  host: Pick<Runtime, "env" | "isCIOverride">,
+): boolean {
+  return host.isCIOverride ?? detectCI(host.env);
+}

--- a/packages/cli-engine/src/context.ts
+++ b/packages/cli-engine/src/context.ts
@@ -116,9 +116,10 @@ export interface CommandContext<
   readonly env: Readonly<Record<string, string | undefined>>;
 
   /**
-   * The host's answer to "is this CI", from Runtime.isCI — what
-   * telemetry gates on. Not the engine's interactivity decision, which
-   * is its own thing (stdin a TTY, no CI in the environment,
+   * Whether this run is in CI: detected from the environment the host
+   * injected, or forced by Runtime.isCIOverride. This is what telemetry
+   * gates on. It is one input to the engine's interactivity decision
+   * rather than the whole of it (which also weighs a TTY stdin and
    * --interactive/--no-interactive), so prompts and spinners follow
    * ctx.prompt and the engine's interaction handling, not this.
    */

--- a/packages/cli-engine/src/execution/command-context.ts
+++ b/packages/cli-engine/src/execution/command-context.ts
@@ -1,3 +1,4 @@
+import { resolveIsCI } from "../ci";
 import type { AnyCommand } from "../commands";
 import type { CommandContext } from "../context";
 import type {
@@ -141,7 +142,7 @@ export function makeContext(
     signal: invocation.signal,
     cwd: invocation.runtime.cwd,
     env: invocation.runtime.env,
-    isCI: invocation.runtime.isCI,
+    isCI: resolveIsCI(invocation.runtime),
     requireDependency: async (specifier) => {
       if (dependencyResolvable(specifier, invocation.runtime.cwd)) {
         return okVoid();

--- a/packages/cli-engine/src/execution/shared-flags.ts
+++ b/packages/cli-engine/src/execution/shared-flags.ts
@@ -1,3 +1,4 @@
+import { resolveIsCI } from "../ci";
 import type { Severity } from "../events";
 import type { Format } from "../presentation";
 import { CliStructuredError } from "../protocol";
@@ -177,9 +178,13 @@ function resolveColorEnabled(shared: SharedFlags, runtime: Runtime): boolean {
  *  --no-interactive override in either direction. Format never decides
  *  interactivity (operator ruling, 2026-08-09): an interactive json run
  *  may prompt — the prompt UI writes to stderr, so stdout stays a clean
- *  frame stream. */
+ *  frame stream.
+ *
+ *  This asks the engine's CI detection rather than testing `CI` for
+ *  being set at all: a Jenkins, TeamCity or Azure Pipelines job sets no
+ *  `CI` variable, and used to be offered a prompt no one could answer. */
 export function defaultInteractive(runtime: Runtime): boolean {
-  return runtime.isTty.stdin && runtime.env.CI === undefined;
+  return runtime.isTty.stdin && !resolveIsCI(runtime);
 }
 
 function resolveAutoFormat(shared: SharedFlags, runtime: Runtime): Format {

--- a/packages/cli-engine/src/runtime.ts
+++ b/packages/cli-engine/src/runtime.ts
@@ -36,12 +36,17 @@ export interface Runtime {
     readonly stderr: boolean;
   };
   /**
-   * True when this process runs in CI, where telemetry never reports.
-   * The bin wires `ci-info`; the engine detects CI no more than it
-   * detects a TTY. Required, not optional: a host that forgot it would
-   * silently report from CI.
+   * Forces the answer to "is this CI", where telemetry never reports.
+   * Absent — the normal case — means the engine detects CI from `env`
+   * using ci-info's vendor table, which is why no host has to answer:
+   * unlike a TTY, CI-ness is derivable from the environment the host
+   * already injects, and every host computing the same boolean was the
+   * same detection table forked N ways. Set it only where detection
+   * cannot be right — an exotic platform, or a test that needs both
+   * sides of the branch. Absence means detected, never false, so a host
+   * that says nothing still stays silent in CI.
    */
-  readonly isCI: boolean;
+  readonly isCIOverride?: boolean;
   /**
    * Ends the process. The bin passes process.exit; the engine is the
    * only caller (second-signal force exit, 130/143).

--- a/packages/cli-engine/src/telemetry/gating.ts
+++ b/packages/cli-engine/src/telemetry/gating.ts
@@ -25,8 +25,8 @@ export interface GatingInputs {
   readonly env: Readonly<Record<string, string | undefined>>;
   /** Result of `readUserConfig()` — file-missing tolerated as `{}`. */
   readonly config: UserConfig;
-  /** CI detection, supplied by the host through `Runtime.isCI`. The
-   *  engine never detects CI itself. CI hard-disables. */
+  /** The engine's CI answer, from `resolveIsCI`: detected from the
+   *  injected environment unless the host forced it. CI hard-disables. */
   readonly inCI: boolean;
 }
 

--- a/packages/cli-engine/src/telemetry/report.ts
+++ b/packages/cli-engine/src/telemetry/report.ts
@@ -1,3 +1,4 @@
+import { resolveIsCI } from "../ci";
 import type { EngineCommandSnapshot } from "../run-summary";
 import type { Runtime } from "../runtime";
 import { resolveTelemetryEndpoint } from "./endpoint";
@@ -23,7 +24,7 @@ export interface TelemetryDeclaration {
 /** The Runtime members reporting reads. */
 export type TelemetryHost = Pick<
   Runtime,
-  "env" | "cwd" | "stderr" | "isCI" | "spawnTelemetry"
+  "env" | "cwd" | "stderr" | "isCIOverride" | "spawnTelemetry"
 >;
 
 export interface TelemetryReportInputs {
@@ -113,7 +114,9 @@ export function reportCommandStart(inputs: TelemetryReportInputs): void {
       return;
     }
     const config = readUserConfig(host.env);
-    if (!resolveGating({ env: host.env, config, inCI: host.isCI }).enabled) {
+    if (
+      !resolveGating({ env: host.env, config, inCI: resolveIsCI(host) }).enabled
+    ) {
       return;
     }
     const stored = config.installationId;

--- a/packages/cli-engine/src/testing.ts
+++ b/packages/cli-engine/src/testing.ts
@@ -132,7 +132,8 @@ export interface TestCli {
       readonly columns?: { stderr?: number };
       readonly env?: Readonly<Record<string, string | undefined>>;
       /** Overrides the CLI-level seed, so one harness can assert both
-       *  sides of the CI branch. */
+       *  sides of the CI branch. Absent leaves the engine to detect CI
+       *  from `env`, which is how a test asserts detection itself. */
       readonly isCI?: boolean;
     },
   ): Promise<{
@@ -266,7 +267,8 @@ export function createTestCli(spec: {
    *  thrower to exercise failure isolation, or `null` to model a host
    *  that wires no seam at all. */
   readonly telemetrySpawner?: ((payload: TelemetryPayload) => void) | null;
-  /** Seeds Runtime.isCI for every run; `run({ isCI })` overrides it. */
+  /** Forces the CI answer for every run; `run({ isCI })` overrides it.
+   *  Absent leaves the engine to detect CI from the run's `env`. */
   readonly isCI?: boolean;
 }): TestCli {
   const credentialManager = new InMemoryCredentialManager({
@@ -350,7 +352,7 @@ export function createTestCli(spec: {
           stdout: opts?.isTty?.stdout ?? false,
           stderr: opts?.isTty?.stderr ?? false,
         },
-        isCI: opts?.isCI ?? spec.isCI ?? false,
+        isCIOverride: opts?.isCI ?? spec.isCI,
         exit: (code: number): never => {
           throw new Error(
             `@prisma/cli-engine: runtime.exit(${code}) reached the test harness`,

--- a/packages/cli-engine/tests/ci.test.ts
+++ b/packages/cli-engine/tests/ci.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Deciding whether a run is in CI is the engine's job, not a host's: a
+ * host injects the environment and the engine reads ci-info's vendor
+ * table against it. Pinned here: detection reads only the environment
+ * it is handed, a host that answers nothing still gets CI whenever the
+ * environment says so, the override wins in both directions, and the
+ * matcher understands every shape the installed vendor table uses.
+ */
+import vendors from "ci-info/vendors.json" with { type: "json" };
+import { afterEach, describe, expect, it } from "vitest";
+import { detectCI, resolveIsCI } from "../src/ci";
+
+type Env = Readonly<Record<string, string | undefined>>;
+
+const DEVELOPER_SHELL: Env = {
+  HOME: "/home/dev",
+  TERM: "xterm-256color",
+  EDITOR: "vim",
+};
+
+/** Real vendors, spelled as each one spells itself. TeamCity and Azure
+ *  Pipelines set no CI variable at all, so only the vendor table finds
+ *  them — they are why detection is a table lookup and not a check for
+ *  one well-known variable. */
+const GITHUB_ACTIONS: Env = {
+  CI: "true",
+  GITHUB_ACTIONS: "true",
+  GITHUB_RUN_ID: "1234567890",
+};
+const TEAMCITY: Env = { TEAMCITY_VERSION: "2024.03.1" };
+const AZURE_PIPELINES: Env = { TF_BUILD: "True" };
+const JENKINS: Env = {
+  JENKINS_URL: "https://ci.example.invalid/",
+  BUILD_ID: "42",
+};
+
+describe("detection reads the injected environment and nothing else", () => {
+  const saved = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  it("ignores a CI-looking process.env when the injected one is clean", () => {
+    process.env.GITHUB_ACTIONS = "true";
+    process.env.TEAMCITY_VERSION = "2024.03.1";
+
+    expect(detectCI(DEVELOPER_SHELL)).toBe(false);
+  });
+
+  it("finds CI in the injected environment when process.env is clean", () => {
+    process.env = { HOME: "/home/dev" };
+
+    expect(detectCI(GITHUB_ACTIONS)).toBe(true);
+  });
+});
+
+describe("detectCI", () => {
+  it("says a developer's shell is not CI", () => {
+    expect(detectCI(DEVELOPER_SHELL)).toBe(false);
+  });
+
+  it("says an empty environment is not CI", () => {
+    expect(detectCI({})).toBe(false);
+  });
+
+  it.each([
+    ["GitHub Actions", GITHUB_ACTIONS],
+    ["TeamCity", TEAMCITY],
+    ["Azure Pipelines", AZURE_PIPELINES],
+    ["Jenkins", JENKINS],
+    ["CircleCI", { CI: "true", CIRCLECI: "true" }],
+  ])("says %s is CI", (_name, env) => {
+    expect(detectCI(env)).toBe(true);
+  });
+
+  it("wants every variable a vendor names, not just one", () => {
+    expect(detectCI({ JENKINS_URL: "https://ci.example.invalid/" })).toBe(
+      false,
+    );
+    expect(detectCI(JENKINS)).toBe(true);
+  });
+
+  it("treats CI=false as a denial that outranks a vendor's own variables", () => {
+    expect(detectCI({ ...GITHUB_ACTIONS, CI: "false" })).toBe(false);
+  });
+
+  it("treats an empty CI variable as unset", () => {
+    expect(detectCI({ CI: "" })).toBe(false);
+  });
+});
+
+describe("resolveIsCI", () => {
+  it("detects when the host answers nothing", () => {
+    expect(resolveIsCI({ env: TEAMCITY })).toBe(true);
+    expect(resolveIsCI({ env: DEVELOPER_SHELL })).toBe(false);
+  });
+
+  it("lets the override win over detection in both directions", () => {
+    expect(resolveIsCI({ env: TEAMCITY, isCIOverride: false })).toBe(false);
+    expect(resolveIsCI({ env: DEVELOPER_SHELL, isCIOverride: true })).toBe(
+      true,
+    );
+  });
+});
+
+/**
+ * The vendor table is read from the installed ci-info rather than
+ * copied into this repo, so an upgrade can introduce an entry shape the
+ * matcher has never seen. Building each vendor's environment from its
+ * own entry and asserting it is detected turns that into a failing
+ * test: an unrecognised shape either throws here or produces an
+ * environment detection misses.
+ */
+describe("every vendor in the installed table is detected", () => {
+  type Check = string | Readonly<Record<string, unknown>>;
+
+  function envTriggering(check: Check): Record<string, string> {
+    if (typeof check === "string") {
+      return { [check]: "1" };
+    }
+    const { env, includes, any } = check;
+    if (typeof env === "string" && typeof includes === "string") {
+      return { [env]: `/opt${includes}/bin` };
+    }
+    if (Array.isArray(any)) {
+      return { [String(any[0])]: "1" };
+    }
+    if (Object.values(check).every((value) => typeof value === "string")) {
+      return check as Record<string, string>;
+    }
+    throw new Error(
+      `ci-info's vendor table gained an entry shape this test does not know: ${JSON.stringify(check)}`,
+    );
+  }
+
+  const cases = (vendors as ReadonlyArray<{ name: string; env: unknown }>).map(
+    (vendor) => {
+      const checks = Array.isArray(vendor.env) ? vendor.env : [vendor.env];
+      const env = Object.assign(
+        {},
+        ...checks.map((check: Check) => envTriggering(check)),
+      ) as Env;
+      return [vendor.name, env] as const;
+    },
+  );
+
+  it("covers a table worth reading", () => {
+    expect(cases.length).toBeGreaterThan(40);
+  });
+
+  it.each(cases)("detects %s", (_name, env) => {
+    expect(detectCI(env)).toBe(true);
+  });
+});

--- a/packages/cli-engine/tests/clack-isolation.test.ts
+++ b/packages/cli-engine/tests/clack-isolation.test.ts
@@ -93,7 +93,6 @@ describe("scripted and non-TTY paths are clack-free", () => {
   test("canary: a raw-mode-capable TTY run does reach the clack import", async () => {
     let stderr = "";
     const runtime: Runtime = {
-      isCI: false,
       stdout: { write: () => {} },
       stderr: {
         write: (text) => {

--- a/packages/cli-engine/tests/clack-prompts.test.ts
+++ b/packages/cli-engine/tests/clack-prompts.test.ts
@@ -86,7 +86,6 @@ async function runInteractive(
   let stdout = "";
   let stderr = "";
   const runtime: Runtime = {
-    isCI: false,
     stdout: {
       write: (text) => {
         stdout += text;

--- a/packages/cli-engine/tests/config.test.ts
+++ b/packages/cli-engine/tests/config.test.ts
@@ -842,7 +842,6 @@ describe("needs.config", { timeout: 60_000 }, () => {
   function jsonRuntime(cwd: string, reads?: { value: number }) {
     let stdoutText = "";
     const runtime: Runtime = {
-      isCI: false,
       stdout: {
         write: (text) => {
           stdoutText += text;

--- a/packages/cli-engine/tests/engine.type-test.ts
+++ b/packages/cli-engine/tests/engine.type-test.ts
@@ -411,7 +411,6 @@ export const loadedConfig: LoadedConfig = {
 };
 
 export const runtimeShape: Runtime = {
-  isCI: false,
   stdout: { write() {} },
   stderr: { write() {} },
   stdin: undefined as unknown as InputStream,
@@ -432,6 +431,13 @@ export const runtimeShape: Runtime = {
 export const runtimeWithPackageManagerOverride: Runtime = {
   ...runtimeShape,
   packageManager: "pnpm",
+};
+
+/** runtimeShape answers nothing about CI and still conforms: a host is
+ *  never required to. Forcing the answer stays available. */
+export const runtimeWithCIOverride: Runtime = {
+  ...runtimeShape,
+  isCIOverride: true,
 };
 
 export const runtimeWithUnrecognizedPackageManager: Runtime = {

--- a/packages/cli-engine/tests/environment-credential-manager.test.ts
+++ b/packages/cli-engine/tests/environment-credential-manager.test.ts
@@ -153,7 +153,6 @@ describe("wired as a Runtime's manager", () => {
     record: (childEnv: Readonly<Record<string, string | undefined>>) => void,
   ): Runtime {
     return {
-      isCI: false,
       stdout: { write: () => {} },
       stderr: { write: () => {} },
       stdin: {

--- a/packages/cli-engine/tests/execution.test.ts
+++ b/packages/cli-engine/tests/execution.test.ts
@@ -535,7 +535,6 @@ describe("needs preconditions", () => {
     });
     let stderrText = "";
     const runtime: Runtime = {
-      isCI: false,
       stdout: { write: () => {} },
       stderr: {
         write: (text) => {
@@ -723,7 +722,6 @@ describe("report() after the handler resolved", () => {
     });
     let stderrText = "";
     const runtime: Runtime = {
-      isCI: false,
       stdout: { write: () => {} },
       stderr: {
         write: (text) => {
@@ -784,7 +782,6 @@ describe("credentials that cannot be read", () => {
       { why: "token file corrupt: unexpected end of JSON input" },
     );
     const runtime: Runtime = {
-      isCI: false,
       stdout: {
         write: (text) => {
           stdoutText += text;

--- a/packages/cli-engine/tests/lifetimes.test.ts
+++ b/packages/cli-engine/tests/lifetimes.test.ts
@@ -239,7 +239,6 @@ describe("the engine owns the double-signal policy", () => {
     let subscriber: ((signal: "SIGINT" | "SIGTERM") => void) | undefined;
     const exited: number[] = [];
     const runtime: Runtime = {
-      isCI: false,
       stdout: { write: () => {} },
       stderr: { write: () => {} },
       stdin: {

--- a/packages/cli-engine/tests/management-api.test.ts
+++ b/packages/cli-engine/tests/management-api.test.ts
@@ -87,7 +87,6 @@ function makeRuntime(overrides?: {
   let stderrText = "";
   let stdoutText = "";
   return {
-    isCI: false,
     stdout: {
       write: (text) => {
         stdoutText += text;

--- a/packages/cli-engine/tests/prompts.test.ts
+++ b/packages/cli-engine/tests/prompts.test.ts
@@ -123,6 +123,36 @@ describe("prompt defaults", () => {
     expect(result.presented?.data).toEqual({ answer: true });
     expect(result.stderr).toBe("✔ answer=true\n");
   });
+
+  /** Interactivity asks the engine's CI detection, so a vendor that
+   *  sets no CI variable is no longer offered a prompt nobody is there
+   *  to answer. TeamCity and Azure Pipelines are both such vendors. */
+  test.each([
+    ["TeamCity", { TEAMCITY_VERSION: "2024.03.1" }],
+    ["Azure Pipelines", { TF_BUILD: "True" }],
+  ])("%s suppresses interactivity though it sets no CI variable", async (_name, env) => {
+    const result = await cliWith(confirmDefaultTrue).run(["probe"], {
+      ...INTERACTIVE,
+      env,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.presented?.data).toEqual({ answer: true });
+    expect(result.stderr).toBe("✔ answer=true\n");
+  });
+
+  /** CI=false is a denial, not a marker: it used to read as "CI is in
+   *  the environment" and cost a developer their prompt. */
+  test("CI=false leaves a TTY interactive", async () => {
+    const result = await cliWith(confirmDefaultTrue).run(["probe"], {
+      ...INTERACTIVE,
+      env: { CI: "false" },
+      answers: ["n"],
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.presented?.data).toEqual({ answer: false });
+  });
 });
 
 describe("prompts with no default halt", () => {
@@ -482,7 +512,6 @@ describe("stdin cleanup", () => {
       commands: { probe: promptCommand(confirmNoDefault) },
     });
     const runtime: Runtime = {
-      isCI: false,
       stdout: { write: () => {} },
       stderr: { write: () => {} },
       stdin: unendingStdin,

--- a/packages/cli-engine/tests/spawn.test.ts
+++ b/packages/cli-engine/tests/spawn.test.ts
@@ -1224,7 +1224,6 @@ function controllableRuntime() {
   const exited: number[] = [];
   const stderrText: string[] = [];
   const runtime: Runtime = {
-    isCI: false,
     stdout: { write: () => {} },
     stderr: {
       write: (text) => {

--- a/packages/cli-engine/tests/telemetry-report.test.ts
+++ b/packages/cli-engine/tests/telemetry-report.test.ts
@@ -71,7 +71,7 @@ function makeHost(overrides?: {
         stderrText += text;
       },
     },
-    isCI: overrides?.isCI ?? false,
+    isCIOverride: overrides?.isCI,
     spawnTelemetry:
       spawner === null
         ? undefined

--- a/packages/cli-engine/tests/telemetry-run.test.ts
+++ b/packages/cli-engine/tests/telemetry-run.test.ts
@@ -435,6 +435,39 @@ describe("gating, through a run", () => {
     expect(notInCI.telemetry).toHaveLength(1);
   });
 
+  /** The safety property, through a whole run: nobody answered the CI
+   *  question, and the environment is a CI vendor that sets no CI
+   *  variable. Reporting has to stop anyway. */
+  it("stays silent in a CI nobody declared", async () => {
+    const teamCity = await run(makeCli(), DEPLOY_ARGV, {
+      env: { ...isolatedEnv(), TEAMCITY_VERSION: "2024.03.1" },
+    });
+    const azurePipelines = await run(makeCli(), DEPLOY_ARGV, {
+      env: { ...isolatedEnv(), TF_BUILD: "True" },
+    });
+
+    expect(teamCity.telemetry).toEqual([]);
+    expect(teamCity.stderr).not.toContain("anonymous CLI usage data");
+    expect(azurePipelines.telemetry).toEqual([]);
+  });
+
+  it("reports from a developer's shell, where nobody answered either", async () => {
+    const result = await run(makeCli(), DEPLOY_ARGV, {
+      env: { ...isolatedEnv(), TERM: "xterm-256color", EDITOR: "vim" },
+    });
+
+    expect(result.telemetry).toHaveLength(1);
+  });
+
+  it("lets a host force not-CI over an environment that looks like CI", async () => {
+    const result = await run(makeCli(), DEPLOY_ARGV, {
+      env: { ...isolatedEnv(), GITHUB_ACTIONS: "true", CI: "true" },
+      isCI: false,
+    });
+
+    expect(result.telemetry).toHaveLength(1);
+  });
+
   it("honours the endpoint override", async () => {
     const result = await run(makeCli(), DEPLOY_ARGV, {
       env: {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,6 @@
     "@prisma/management-api-sdk": "1.55.0",
     "@vercel/detect-agent": "^1.2.3",
     "better-result": "^2.9.2",
-    "ci-info": "^4.3.1",
     "colorette": "^2.0.20",
     "commander": "^14.0.3",
     "dotenv": "^17.4.2",

--- a/packages/cli/src/v8/runtime.ts
+++ b/packages/cli/src/v8/runtime.ts
@@ -6,7 +6,6 @@ import {
   type Runtime,
 } from "@prisma/cli-engine";
 import { runTelemetry } from "@repo/cli-telemetry";
-import { isCI } from "ci-info";
 import open from "open";
 import {
   CLIENT_ID,
@@ -101,7 +100,6 @@ export async function assembleRuntime(proc: HostProcess): Promise<Runtime> {
       stdout: proc.stdout.isTTY === true,
       stderr: proc.stderr.isTTY === true,
     },
-    isCI,
     exit: (code) => proc.exit(code),
     onSignal: makeOnSignal(proc),
     loadConfig: (configPath) => loadConfig(proc.cwd(), configPath),

--- a/packages/cli/tests/v8-telemetry-reporting.test.ts
+++ b/packages/cli/tests/v8-telemetry-reporting.test.ts
@@ -1,11 +1,14 @@
 /**
  * The shell's half of telemetry after the engine took the rest: the
- * runtime seam that forks the detached sender, the CI answer the engine
- * gates on, and the guard that keeps the suite from ever reaching a real
- * fork or the developer's real config file.
+ * runtime seam that forks the detached sender, and the guard that keeps
+ * the suite from ever reaching a real fork or the developer's real
+ * config file.
  *
  * The decision, the disclosure, the mint and the payload are the
- * engine's and are tested there (`packages/cli-engine/tests/telemetry-*`).
+ * engine's and are tested there (`packages/cli-engine/tests/telemetry-*`),
+ * as is the CI answer the decision gates on
+ * (`packages/cli-engine/tests/ci.test.ts`) — this shell no longer
+ * answers that question at all.
  */
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -17,7 +20,6 @@ import { main } from "../src/v8/main";
 import { assembleRuntime, type HostProcess } from "../src/v8/runtime";
 
 vi.mock("@repo/cli-telemetry", () => ({ runTelemetry: vi.fn() }));
-vi.mock("ci-info", () => ({ isCI: false }));
 
 const SENDER_ENTRY = /sender\.js$/;
 
@@ -113,16 +115,16 @@ describe("the runtime's telemetry seam", () => {
     expect(runtime.spawnTelemetry).toBeTypeOf("function");
   });
 
-  it("takes the CI answer from ci-info, so a CI run never reports", async () => {
-    vi.resetModules();
-    vi.doMock("ci-info", () => ({ isCI: true }));
-    const { assembleRuntime: assembleInCI } = await import("../src/v8/runtime");
+  /** The shell answers nothing about CI, even standing in one. It hands
+   *  the environment over and the engine detects from it, which is why
+   *  this package imports no CI-detection library. */
+  it("leaves the CI question to the engine and hands over the environment", async () => {
+    const proc = makeProcess({ env: { TEAMCITY_VERSION: "2024.03.1" } });
 
-    const runtime = await assembleInCI(makeProcess());
+    const runtime = await assembleRuntime(proc);
 
-    expect(runtime.isCI).toBe(true);
-    vi.doUnmock("ci-info");
-    vi.resetModules();
+    expect(runtime.isCIOverride).toBeUndefined();
+    expect(runtime.env).toBe(proc.env);
   });
 });
 

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -16,7 +16,7 @@ export default defineConfig([
   // @repo/cli-telemetry workspace package lands inside this package's
   // own dist instead of being a published dependency; the sender entry
   // ships the forkable script at dist/v8/sender.js. Published deps
-  // (engine, ci-info, @vercel/detect-agent, …) stay external.
+  // (engine, @vercel/detect-agent, …) stay external.
   {
     entry: {
       "v8/cli": "src/v8/bin.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       better-result:
         specifier: ^2.9.2
         version: 2.9.2
-      ci-info:
-        specifier: ^4.3.1
-        version: 4.4.0
       colorette:
         specifier: ^2.0.20
         version: 2.0.20
@@ -108,6 +105,9 @@ importers:
       c12:
         specifier: 3.3.4
         version: 3.3.4(magicast@0.5.3)
+      ci-info:
+        specifier: ^4.3.1
+        version: 4.4.0
       colorette:
         specifier: ^2.0.20
         version: 2.0.20


### PR DESCRIPTION
A host used to have to tell the engine whether it was running in CI:

```ts
import { isCI } from "ci-info";   // every host, separately

const runtime: Runtime = { /* … */ isCI };
```

It no longer does. The engine works it out from the environment the host already hands it:

```ts
const runtime: Runtime = { /* … */ };   // says nothing about CI
```

## The decision

**CI detection belongs to the engine.** `Runtime.isCI` was required of every host, which meant every host imported the same package to compute the same boolean — and a host that wrote its own version instead forked a table of CI vendors that goes stale as new ones appear. That is what prompted this: composer, mounting its commands into this CLI, became the second host and had to answer the same question.

The engine's own rationale for pushing it out was that "the engine detects CI no more than it detects a TTY." The analogy does not hold. TTY-ness is not derivable from the environment; CI-ness is, and the engine already receives `Runtime.env` — the injected, process-global-free environment its own rules require it to read from.

The field survives as `isCIOverride`, optional. Removing it outright was tempting, but a test that needs to force *not*-CI would then have to doctor `env.CI`, and that variable is read by other things — the interactivity decision, the telemetry opt-outs. The rename matters as much as the optionality: left as `isCI?: boolean` it still reads like something a host ought to answer. `undefined` means detect, so the safety property that made it required in the first place still holds — a host that says nothing gets detection, never `false`.

## How the detection avoids becoming the thing it replaces

`ci-info` has no `exports` map and ships `vendors.json` among its files, so the upstream vendor table is importable directly. The engine reads that table and matches it against the injected env; nothing about any individual CI provider is copied into this repo. What is ours is a twenty-line matcher, and ci-info's nine conventional variable names (`CI`, `BUILD_ID`, `RUN_ID`, …), which live in its `index.js` as code rather than data — cross-vendor conventions, not per-vendor facts.

The matcher was checked against reality rather than reasoned about: a throwaway script compared it to real `ci-info` in child processes across all 53 vendors in the table plus seven edge cases, with no disagreements.

## Interactivity now shares it

The engine had a second, cruder CI test deciding whether to prompt: `runtime.env.CI === undefined`. It now uses the same detection, which is better in both directions:

- Jenkins, TeamCity and Azure Pipelines set no `CI` variable at all. They were being offered prompts with nobody there to answer them.
- `CI=false` is an explicit denial, and it used to cost a developer their prompts, because the old test only asked whether the variable was set.

## Testing

Sixty-eight cases, built around what could go wrong rather than what the code does: a CI-looking `process.env` is ignored when the injected env is clean, and the reverse; five vendors in their own env shapes, including the ones that set no `CI` variable and can only be found through the table; Jenkins needing both of its variables present; `CI=false` outranking a vendor's own variables; and every vendor in the installed table detected from its own entry, so an upstream shape the matcher does not understand fails loudly rather than silently.

Through whole runs: a TeamCity or Azure environment that no host declared reports no telemetry, a developer's shell does, and the override beats detection either way.

Nine existing engine tests got shorter — they deleted the `isCI: false` line they used to need, which is the change stated in one diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
