### PR TITLE
Close slice S2: records, retro, and what the stale-PR sweep left behind

### DIFF
--- a/.drive/projects/prisma-cli-v8/deferred.md
+++ b/.drive/projects/prisma-cli-v8/deferred.md
@@ -95,6 +95,32 @@ composer can use it.
   each of the four commands — rewritten to use it. Recorded in
   `assets/s2/parity-divergences-s3.md`.
 
+## A live bug carried out of the port (found closing PR #92, 2026-08-12)
+
+- **The production branch is still resolved by name, not role.**
+  `packages/cli/src/commands/service/target.ts` derives branch kind from
+  the literal name (`toBranchKind`, used where domain attachment decides
+  production-ness), so a project whose production branch is named
+  `master` cannot attach a custom domain. Closed PR #92 fixed exactly
+  this in the old controller and died with it; the fix should land in
+  `target.ts`, taking the role from the API's branch record.
+
+## Orphaned by the stale-PR sweep (2026-08-12) — capabilities with no engine successor
+
+Nine pre-port PRs were closed as unmergeable after the shell deletion
+(#139). Most were superseded outright; these wanted things the engine
+CLI does not do, and each restarts as engine work if wanted:
+
+- **`branch remove` / branch CRUD** (#110, #73): the `branch` group is
+  list-only. Returns with exact-id consent if wanted.
+- **`env pull` into a dotenv file** (#79): `project env list` never
+  returns values by design, so an engine `env pull` needs a ruling on
+  secret handling before it is built.
+- **A `github` group for workspace-level GitHub connections** (#113):
+  the engine ships repo-level `git connect|disconnect` only.
+- **Transient-read retry on `build logs` streaming** (#104): joins the
+  existing streaming follow-ups below.
+
 ## Ratified-as-shipped at the S2 sign-off (2026-08-12) — the gaps stay real
 
 - **Streaming service logs is unavailable in any form.** `app logs` died

--- a/.drive/projects/prisma-cli-v8/plan.md
+++ b/.drive/projects/prisma-cli-v8/plan.md
@@ -28,6 +28,8 @@ draft returns to the operator as design questions; the draft in
 
 ### S2 — Platform family port + auth extraction
 
+**CLOSED 2026-08-12** — shipped as prisma-cli #130 (S2a), #133 (S2b), #132 (S2c), #139 (S2d: init port, shell deletion, bin cutover, the v8 working name retired). Acceptance verified against `specs/s2d-init-and-retirement.md`; the cumulative divergence record `assets/s2/parity-divergences.md` was ratified by the operator on 2026-08-12; the deletion's survivor list is `assets/s2/shell-deletion-survivors.md`; ratified-as-shipped gaps and the stale-PR sweep's orphaned capabilities are in `deferred.md`.
+
 Repo: prisma-cli. Port the ~60 management-API commands onto the engine
 in grouped batches (auth + project; database + bucket; app + build +
 git + agent + env; init wizard last — it stresses prompts hardest).

--- a/.drive/projects/prisma-cli-v8/specs/s2d-init-and-retirement.md
+++ b/.drive/projects/prisma-cli-v8/specs/s2d-init-and-retirement.md
@@ -76,14 +76,14 @@ reinstatement (Q1 unless ruled meanwhile).
 
 ## Acceptance
 
-- [ ] `init` wizard green on the full prompt matrix (interactive,
+- [x] `init` wizard green on the full prompt matrix (interactive,
       `--yes`, non-interactive, cancel) with byte-asserted templates.
-- [ ] Bin cutover complete, config loaded through `c12` as the
+- [x] Bin cutover complete, config loaded through `c12` as the
       reference repositories do; `prisma-cli` runs the
       engine shell from a packed tarball on plain Node.
-- [ ] Commander shell + fixture machinery deleted per R-S2d-4's
+- [x] Commander shell + fixture machinery deleted per R-S2d-4's
       checklist; survivor list enumerated.
-- [ ] Grammar completeness test green.
-- [ ] Consolidated divergence document reviewed by the operator.
-- [ ] Root verification green; PR ≥1k LOC; review loop run; S2 slice
+- [x] Grammar completeness test green (landed via S7's `check:grammar`; `version` is a ruled removal, and the ORM's initializer moved to `orm init` so top-level `init` is the platform wizard — operator, 2026-08-12).
+- [x] Consolidated divergence document reviewed and RATIFIED by the operator (2026-08-12).
+- [x] Root verification green; PR ≥1k LOC; review loop run; S2 slice
       closed in the project plan.


### PR DESCRIPTION
Process records only — no code.

S2 is done: every platform command on the engine, the Commander shell deleted, the bin cut over, the working name retired, the divergence record ratified (2026-08-12). This PR closes the books:

- **plan.md** marks S2 closed in the house style, naming its four PRs (#130, #133, #132, #139).
- **specs/s2d-init-and-retirement.md** acceptance boxes ticked against what actually shipped, including the two operator rulings that changed the contract mid-flight (`version` removed; the ORM's initializer at `orm init`).
- **reviews/retro-s2-close.md** — six root-caused lessons from the run, each with the mechanism that catches the failure: the duplicated config work (re-survey per piece, not per session), the two silent test-clobbers (before/after test-count diffs), the latent `init` grammar collision, the ctx.host boundary, the coverage manifest's quoted-keys blind spot, and the Windows harness/machine disagreement.
- **deferred.md** gains today's stale-PR sweep: nine pre-port PRs were closed as unmergeable after the shell deletion; the four capabilities they wanted that have no engine successor are recorded (branch remove, env pull, the github group, build-logs stream retry), and one **live bug** — closed #92 fixed production-branch-by-name resolution in code that was then deleted, and the ported `commands/service/target.ts` still has the by-name check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)