### PR TITLE
Rename the engine's defineConfig to definePrismaConfig

### DIFF
--- a/packages/cli-engine/src/config-loader.ts
+++ b/packages/cli-engine/src/config-loader.ts
@@ -62,13 +62,17 @@ export function reservedConfigSectionName(name: string): boolean {
  * top-level key names a config section, and the recognised section
  * names are exactly the ones the CLI's command families declare. Never
  * throws — bad section values are the section validator's problem, not
- * defineConfig's.
+ * definePrismaConfig's.
  */
-export function defineConfig<T extends Record<string, unknown>>(
+export function definePrismaConfig<T extends Record<string, unknown>>(
   config: T,
 ): T & { readonly $prismaConfig: number } {
   return Object.freeze({ ...config, $prismaConfig: PRISMA_CONFIG_VERSION });
 }
+
+/** @deprecated Renamed to {@link definePrismaConfig}: every family's
+ *  config helper carries a unique name, so none needs an import alias. */
+export const defineConfig = definePrismaConfig;
 
 function hasVersionMarker(value: unknown): value is Record<string, unknown> {
   return (
@@ -87,12 +91,12 @@ function missingMarkerDiagnostic(path: string): Diagnostic {
     code: "CLI.CONFIG_MISSING_MARKER",
     severity: "error",
     summary: `${path} was not written for this version of the Prisma CLI, so it cannot be used.`,
-    why: "Configs for this CLI are created with defineConfig, which records a version marker on the exported object. This file's default export has no marker — it is most likely a Prisma 7 config, which uses the same filename — and the CLI stops rather than misread it.",
+    why: "Configs for this CLI are created with definePrismaConfig, which records a version marker on the exported object. This file's default export has no marker — it is most likely a Prisma 7 config, which uses the same filename — and the CLI stops rather than misread it.",
     nextActions: [
       {
         kind: "user-choice",
         label:
-          "Migrate the file: wrap the exported object in defineConfig from @prisma/cli-engine and export the result as the default export.",
+          "Migrate the file: wrap the exported object in definePrismaConfig from @prisma/cli-engine and export the result as the default export.",
       },
     ],
     where: { path },
@@ -113,7 +117,7 @@ function unsupportedVersionDiagnostic(path: string, found: number): Diagnostic {
       {
         kind: "user-choice",
         label:
-          "Regenerate the config with a defineConfig matching this CLI, or update the CLI to a version that supports the declared config version.",
+          "Regenerate the config with a definePrismaConfig matching this CLI, or update the CLI to a version that supports the declared config version.",
       },
     ],
     where: { path },

--- a/packages/cli-engine/src/exports/index.ts
+++ b/packages/cli-engine/src/exports/index.ts
@@ -41,7 +41,11 @@ export {
   type SessionCommandDefinition,
   type SpawnDeclarations,
 } from "../commands";
-export { defineConfig, loadConfig } from "../config-loader";
+export {
+  defineConfig,
+  definePrismaConfig,
+  loadConfig,
+} from "../config-loader";
 export {
   type ConfigSection,
   defineConfigSection,

--- a/packages/cli-engine/tests/config.test.ts
+++ b/packages/cli-engine/tests/config.test.ts
@@ -1,6 +1,6 @@
 /**
  * The config loader behind Runtime.loadConfig — cwd-only discovery,
- * defineConfig marker semantics with the pinned Prisma 7 fail-early
+ * definePrismaConfig marker semantics with the pinned Prisma 7 fail-early
  * diagnostic, the engine's closed set of section names, and
  * needs.config validation wired end to end through the harness.
  */
@@ -15,6 +15,7 @@ import {
   defineCommandFamily,
   defineConfig,
   defineConfigSection,
+  definePrismaConfig,
   flag,
   type LoadedConfig,
   loadConfig,
@@ -34,12 +35,18 @@ const FIXTURES = join(TESTS_DIR, "fixtures", "config");
 const EPOCH = () => new Date(0);
 const T0 = "1970-01-01T00:00:00.000Z";
 
-describe("defineConfig", () => {
+describe("definePrismaConfig", () => {
   test("stamps the version marker on the config object", () => {
-    expect(defineConfig({ toy: { greeting: "hi" } })).toEqual({
+    expect(definePrismaConfig({ toy: { greeting: "hi" } })).toEqual({
       toy: { greeting: "hi" },
       $prismaConfig: PRISMA_CONFIG_VERSION,
     });
+  });
+
+  test("the deprecated defineConfig alias stamps the same marker", () => {
+    expect(defineConfig({ toy: { greeting: "hi" } })).toEqual(
+      definePrismaConfig({ toy: { greeting: "hi" } }),
+    );
   });
 });
 
@@ -82,12 +89,12 @@ describe("loadConfig", { timeout: 60_000 }, () => {
             code: "CLI.CONFIG_MISSING_MARKER",
             severity: "error",
             summary: `${join(FIXTURES, "unmarked", "prisma.config.ts")} was not written for this version of the Prisma CLI, so it cannot be used.`,
-            why: "Configs for this CLI are created with defineConfig, which records a version marker on the exported object. This file's default export has no marker — it is most likely a Prisma 7 config, which uses the same filename — and the CLI stops rather than misread it.",
+            why: "Configs for this CLI are created with definePrismaConfig, which records a version marker on the exported object. This file's default export has no marker — it is most likely a Prisma 7 config, which uses the same filename — and the CLI stops rather than misread it.",
             nextActions: [
               {
                 kind: "user-choice",
                 label:
-                  "Migrate the file: wrap the exported object in defineConfig from @prisma/cli-engine and export the result as the default export.",
+                  "Migrate the file: wrap the exported object in definePrismaConfig from @prisma/cli-engine and export the result as the default export.",
               },
             ],
             where: { path: join(FIXTURES, "unmarked", "prisma.config.ts") },
@@ -112,7 +119,7 @@ describe("loadConfig", { timeout: 60_000 }, () => {
               {
                 kind: "user-choice",
                 label:
-                  "Regenerate the config with a defineConfig matching this CLI, or update the CLI to a version that supports the declared config version.",
+                  "Regenerate the config with a definePrismaConfig matching this CLI, or update the CLI to a version that supports the declared config version.",
               },
             ],
             where: {
@@ -242,7 +249,7 @@ describe("top-level keys that are not sections", { timeout: 60_000 }, () => {
    * The one key the report cannot cover. c12 takes `$meta` as layer
    * metadata and deletes it from the config object whatever else it is
    * told, so it never reaches the engine's unknown-key check.
-   * defineConfig freezes what it returns, so that delete throws and the
+   * definePrismaConfig freezes what it returns, so that delete throws and the
    * whole file is refused — a worse message than the unknown-key one,
    * and the reason no section may be named `$meta`.
    */
@@ -522,11 +529,11 @@ process.stdout.write("__PROBE__" + JSON.stringify({
 
 /** The file --config names in the probe: TypeScript plain Node cannot
  *  run, in a directory discovery would never look in. */
-const NAMED_CONFIG = `import { defineConfig } from "@prisma/cli-engine";
+const NAMED_CONFIG = `import { definePrismaConfig } from "@prisma/cli-engine";
 
 const greeting: string = "from the file --config named";
 
-export default defineConfig({ toy: { greeting } });
+export default definePrismaConfig({ toy: { greeting } });
 `;
 
 interface ProbeResult {
@@ -594,11 +601,11 @@ describe("loadConfig on a Node that cannot execute TypeScript", {
 }, () => {
   test("reads a config when Node's TypeScript support is switched off", () => {
     const probe = runProbeOnPlainNode(
-      `import { defineConfig } from "@prisma/cli-engine";
+      `import { definePrismaConfig } from "@prisma/cli-engine";
 
 const greeting: string = "hello from plain node";
 
-export default defineConfig({ toy: { greeting } });
+export default definePrismaConfig({ toy: { greeting } });
 `,
       ["--no-experimental-strip-types"],
     );
@@ -621,13 +628,13 @@ export default defineConfig({ toy: { greeting } });
 
   test("reads a config using TypeScript that Node cannot strip", () => {
     const probe = runProbeOnPlainNode(
-      `import { defineConfig } from "@prisma/cli-engine";
+      `import { definePrismaConfig } from "@prisma/cli-engine";
 
 enum Level {
   Verbose = "verbose",
 }
 
-export default defineConfig({ toy: { greeting: Level.Verbose } });
+export default definePrismaConfig({ toy: { greeting: Level.Verbose } });
 `,
       [],
     );

--- a/packages/cli-engine/tests/engine.test.ts
+++ b/packages/cli-engine/tests/engine.test.ts
@@ -31,6 +31,7 @@ describe("main export", () => {
       "defineCommandFamily",
       "defineConfig",
       "defineConfigSection",
+      "definePrismaConfig",
       "defineServerCommand",
       "defineSessionCommand",
       "emptyServiceTokenError",

--- a/packages/cli-engine/tests/fixtures/config/env-block/prisma.config.ts
+++ b/packages/cli-engine/tests/fixtures/config/env-block/prisma.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "@prisma/cli-engine";
+import { definePrismaConfig } from "@prisma/cli-engine";
 
-export default defineConfig({
+export default definePrismaConfig({
   toy: { greeting: "plain" },
   $env: { production: { toy: { greeting: "overlaid by $env" } } },
 });

--- a/packages/cli-engine/tests/fixtures/config/env-overlay/prisma.config.ts
+++ b/packages/cli-engine/tests/fixtures/config/env-overlay/prisma.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "@prisma/cli-engine";
+import { definePrismaConfig } from "@prisma/cli-engine";
 
-export default defineConfig({
+export default definePrismaConfig({
   toy: { greeting: "plain" },
   $production: { toy: { greeting: "overlaid by $production" } },
 });

--- a/packages/cli-engine/tests/fixtures/config/extends-key/prisma.config.ts
+++ b/packages/cli-engine/tests/fixtures/config/extends-key/prisma.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig } from "@prisma/cli-engine";
+import { definePrismaConfig } from "@prisma/cli-engine";
 
 // A string is the form c12 would act on if the loader left its merge
 // directive enabled: it would read another file in and delete the key.
-export default defineConfig({
+export default definePrismaConfig({
   extends: "./base.config.ts",
   values: { list: [1, 2] },
 });

--- a/packages/cli-engine/tests/fixtures/config/extends-remote/prisma.config.ts
+++ b/packages/cli-engine/tests/fixtures/config/extends-remote/prisma.config.ts
@@ -1,9 +1,9 @@
-import { defineConfig } from "@prisma/cli-engine";
+import { definePrismaConfig } from "@prisma/cli-engine";
 
 // A dead local port: if the loader ever let c12 act on this key, the
 // download would be attempted and would fail here rather than reach a
 // real host.
-export default defineConfig({
+export default definePrismaConfig({
   extends: "http://127.0.0.1:1/evil.tar.gz",
   values: { list: [1, 2] },
 });

--- a/packages/cli-engine/tests/fixtures/config/marked/prisma.config.ts
+++ b/packages/cli-engine/tests/fixtures/config/marked/prisma.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "@prisma/cli-engine";
+import { definePrismaConfig } from "@prisma/cli-engine";
 
-export default defineConfig({
+export default definePrismaConfig({
   toy: { greeting: "hello" },
   other: { level: 2 },
 });

--- a/packages/cli-engine/tests/fixtures/config/meta-key/prisma.config.ts
+++ b/packages/cli-engine/tests/fixtures/config/meta-key/prisma.config.ts
@@ -1,9 +1,9 @@
-import { defineConfig } from "@prisma/cli-engine";
+import { definePrismaConfig } from "@prisma/cli-engine";
 
 // $meta is the one top-level key that can never be reported as an
 // unknown section: c12 deletes it from the config object before the
 // loader is handed it.
-export default defineConfig({
+export default definePrismaConfig({
   $meta: { note: "c12 takes this for layer metadata" },
   toy: { greeting: "hello" },
 });

--- a/packages/cli-engine/tests/fixtures/config/named/elsewhere.config.ts
+++ b/packages/cli-engine/tests/fixtures/config/named/elsewhere.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "@prisma/cli-engine";
+import { definePrismaConfig } from "@prisma/cli-engine";
 
-export default defineConfig({
+export default definePrismaConfig({
   toy: { greeting: "from the named file" },
 });

--- a/packages/cli-engine/tests/fixtures/config/passthrough/prisma.config.ts
+++ b/packages/cli-engine/tests/fixtures/config/passthrough/prisma.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "@prisma/cli-engine";
+import { definePrismaConfig } from "@prisma/cli-engine";
 
-export default defineConfig({
+export default definePrismaConfig({
   values: { list: [1, 2], when: new Date(0) },
 });

--- a/packages/cli-engine/tests/fixtures/config/proto-key/prisma.config.ts
+++ b/packages/cli-engine/tests/fixtures/config/proto-key/prisma.config.ts
@@ -1,9 +1,9 @@
-import { defineConfig } from "@prisma/cli-engine";
+import { definePrismaConfig } from "@prisma/cli-engine";
 
 // A computed key is the only way to write __proto__ as an ordinary
 // property. Copied to the loader's own object by assignment it would
 // run Object.prototype's setter instead, and vanish.
-export default defineConfig({
+export default definePrismaConfig({
   ["__proto__"]: { injected: true },
   toy: { greeting: "hello" },
 });

--- a/packages/cli/tests/fixtures/config/composer-section.config.ts
+++ b/packages/cli/tests/fixtures/config/composer-section.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "@prisma/cli-engine";
+import { definePrismaConfig } from "@prisma/cli-engine";
 
-export default defineConfig({
+export default definePrismaConfig({
   composer: { configPath: "./named-by-the-section.config.ts" },
 });

--- a/packages/cli/tests/fixtures/config/elsewhere.config.ts
+++ b/packages/cli/tests/fixtures/config/elsewhere.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "@prisma/cli-engine";
+import { definePrismaConfig } from "@prisma/cli-engine";
 
-export default defineConfig({
+export default definePrismaConfig({
   toy: { greeting: "from the named file" },
 });


### PR DESCRIPTION
## What

Every command family ships a config helper named `defineConfig` — the engine's (prisma.config.ts wrapper), the ORM's (`@prisma/orm-postgres/config`), composer's (`@prisma/composer/config`). A prisma.config.ts that composes two of them has to alias imports (`import { defineConfig as ormConfig } ...`). This gives the engine's helper a unique name: **`definePrismaConfig`**.

- `defineConfig` stays exported as a deprecated alias, so existing configs and the pinned family packages (orm-toolchain, composer, which bundle their own engine copies) keep working unchanged.
- The CLI's own error prose (`CLI.CONFIG_MISSING_MARKER`, `CLI.CONFIG_VERSION_UNSUPPORTED`) now names `definePrismaConfig`.
- Internal fixtures and tests migrated; a regression test pins the alias.

## Cross-repo follow-ups (not this PR)

The same de-aliasing needs the other two helpers renamed in their own repos: `defineOrmConfig` in prisma/prisma's `@prisma/orm-*` config packages, and `defineComposerConfig` in `@prisma/composer/config`. (`defineComputeConfig` is already unique.)

## Testing

`pnpm test` (1,791 green), `pnpm lint`, `pnpm typecheck` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
