### PR TITLE
chore(release): bump to 8.0.0-rc.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-cli",
-  "version": "8.0.0-rc.1",
+  "version": "8.0.0-rc.2",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/packages/cli-conformance/package.json
+++ b/packages/cli-conformance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/cli-conformance",
   "private": true,
-  "version": "8.0.0-rc.1",
+  "version": "8.0.0-rc.2",
   "description": "Reusable conformance checks for the engine's consumers: import purity over built output, config-section validators that never throw, and verification of the tarballs a registry would receive. Depends on no package it checks.",
   "type": "module",
   "exports": {
@@ -23,7 +23,7 @@
     "test": "pnpm run typecheck && vitest run"
   },
   "devDependencies": {
-    "@repo/tsconfig": "workspace:8.0.0-rc.1",
+    "@repo/tsconfig": "workspace:8.0.0-rc.2",
     "@types/node": "^22.19.19",
     "es-module-lexer": "^2.1.0",
     "tsx": "^4.22.4",

--- a/packages/cli-engine/package.json
+++ b/packages/cli-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/cli-engine",
-  "version": "8.0.0-rc.1",
+  "version": "8.0.0-rc.2",
   "description": "The execution engine of the unified Prisma CLI.",
   "type": "module",
   "exports": {
@@ -56,8 +56,8 @@
     "string-width": "^8.2.1"
   },
   "devDependencies": {
-    "@repo/cli-conformance": "workspace:8.0.0-rc.1",
-    "@repo/tsconfig": "workspace:8.0.0-rc.1",
+    "@repo/cli-conformance": "workspace:8.0.0-rc.2",
+    "@repo/tsconfig": "workspace:8.0.0-rc.2",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3",

--- a/packages/cli-telemetry/package.json
+++ b/packages/cli-telemetry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/cli-telemetry",
   "private": true,
-  "version": "8.0.0-rc.1",
+  "version": "8.0.0-rc.2",
   "description": "CLI telemetry child sender: the detached subprocess the engine hands a composed payload to, its system probes, and the POST",
   "type": "module",
   "sideEffects": [
@@ -35,7 +35,7 @@
     "@vercel/detect-agent": "^1.2.3"
   },
   "devDependencies": {
-    "@repo/tsconfig": "workspace:8.0.0-rc.1",
+    "@repo/tsconfig": "workspace:8.0.0-rc.2",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/cli",
-  "version": "8.0.0-rc.1",
+  "version": "8.0.0-rc.2",
   "description": "Command-line interface for the Prisma Developer Platform.",
   "type": "module",
   "bin": {
@@ -47,7 +47,7 @@
     "conformance": "tsx scripts/conformance.ts"
   },
   "dependencies": {
-    "@prisma/cli-engine": "workspace:8.0.0-rc.1",
+    "@prisma/cli-engine": "workspace:8.0.0-rc.2",
     "@prisma/composer": "0.6.0-dev.16",
     "@prisma/compute-sdk": "0.39.0",
     "@prisma/credentials-store": "^7.8.0",
@@ -60,9 +60,9 @@
     "open": "^11.0.0"
   },
   "devDependencies": {
-    "@repo/cli-conformance": "workspace:8.0.0-rc.1",
-    "@repo/cli-telemetry": "workspace:8.0.0-rc.1",
-    "@repo/tsconfig": "workspace:8.0.0-rc.1",
+    "@repo/cli-conformance": "workspace:8.0.0-rc.2",
+    "@repo/cli-telemetry": "workspace:8.0.0-rc.2",
+    "@repo/tsconfig": "workspace:8.0.0-rc.2",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "tsx": "^4.22.4",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/tsconfig",
   "private": true,
-  "version": "8.0.0-rc.1",
+  "version": "8.0.0-rc.2",
   "description": "Base tsconfig providing package for the monorepo",
   "license": "Apache-2.0",
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
   packages/cli:
     dependencies:
       '@prisma/cli-engine':
-        specifier: workspace:8.0.0-rc.1
+        specifier: workspace:8.0.0-rc.2
         version: link:../cli-engine
       '@prisma/composer':
         specifier: 0.6.0-dev.16
@@ -58,13 +58,13 @@ importers:
         version: 11.0.0
     devDependencies:
       '@repo/cli-conformance':
-        specifier: workspace:8.0.0-rc.1
+        specifier: workspace:8.0.0-rc.2
         version: link:../cli-conformance
       '@repo/cli-telemetry':
-        specifier: workspace:8.0.0-rc.1
+        specifier: workspace:8.0.0-rc.2
         version: link:../cli-telemetry
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.1
+        specifier: workspace:8.0.0-rc.2
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -85,7 +85,7 @@ importers:
   packages/cli-conformance:
     devDependencies:
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.1
+        specifier: workspace:8.0.0-rc.2
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -131,10 +131,10 @@ importers:
         version: 8.2.1
     devDependencies:
       '@repo/cli-conformance':
-        specifier: workspace:8.0.0-rc.1
+        specifier: workspace:8.0.0-rc.2
         version: link:../cli-conformance
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.1
+        specifier: workspace:8.0.0-rc.2
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -156,7 +156,7 @@ importers:
         version: 1.2.4
     devDependencies:
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.1
+        specifier: workspace:8.0.0-rc.2
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19


### PR DESCRIPTION
`8.0.0-rc.1` → `8.0.0-rc.2` across the lockstep workspace (`@prisma/cli-engine`, `@prisma/cli`, and the internal packages), per [docs/oss/versioning.md](docs/oss/versioning.md).

**Merging this PR ships the release**: the push to `main` carries the bumped root version, and the `Publish to npm` workflow publishes `@prisma/cli-engine@8.0.0-rc.2` first, then `@prisma/cli@8.0.0-rc.2`, both under dist-tag `next`, with a pre-release GitHub Release. `latest` stays on the pre-8 CLI.

## What rc.2 ships (8 commits since v8.0.0-rc.1)

Engine (`@prisma/cli-engine`):
- `defineConfig` renamed to `definePrismaConfig` (#173) — breaking for config authors on the rc line
- Every presentation a command declares is required (#171)
- One visual system: engine-rendered help, renderer-owned output conventions (#172)

CLI (`@prisma/cli`):
- init ported onto the engine; the Commander shell is deleted — the CLI runs entirely on the engine (#139)
- Conformance checker built and wired into publish CI (#161)
- Services get a full resource surface: deployment subgroup, create/list, lifecycle verbs (#162)
- Release pipeline hardening: tarballs attach before the Release publishes (#166)

Downstream: prisma/prisma converges its `@prisma/cli-engine` pins onto rc.2 next (including the `definePrismaConfig` rename sweep), then cuts its own `8.0.0-rc.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
