### PR TITLE
Engine 0.1.1: the vendor table is built in, not loaded from ci-info at runtime

### DIFF
--- a/.drive/projects/prisma-cli-v8/deferred.md
+++ b/.drive/projects/prisma-cli-v8/deferred.md
@@ -382,3 +382,19 @@ CLI does not do, and each restarts as engine work if wanted:
   prisma/prisma's `check-publish-deps.mjs` both catch this class, and
   prisma-cli has no equivalent. Worth one small check, in its own
   change.
+
+## Found while fixing engine 0.1.1 (2026-08-17) — needs a decision from Will
+
+- **A library depends on CLI tooling: `@prisma/composer-prisma-cloud`
+  imports `@prisma/orm-toolchain/config-loader`.** ADR 0004 says
+  libraries applications install must not depend on product CLI/dev
+  packages, and this import breaks that rule today. It is also how an
+  engine implementation detail reached composer's users: evaluating
+  `prisma-composer.config.ts` loads `composer-prisma-cloud/control`,
+  which loads `orm-toolchain/config-loader`, which imports `ci-info` —
+  putting ORM tooling and its dependencies inside composer's config
+  evaluation in every user's process. The engine defect that exposed
+  this is fixed (prisma-cli#187), but the dependency remains. Options:
+  move `config-loader` into a shared library package the ORM publishes
+  for exactly this kind of consumer, or cut the cloud extension's use
+  of it. Spans both product repos; Will decides which.

--- a/packages/cli-engine/package.json
+++ b/packages/cli-engine/package.json
@@ -50,7 +50,6 @@
     "@prisma/management-api-sdk": "1.55.0",
     "@stricli/core": "1.3.0",
     "c12": "3.3.4",
-    "ci-info": "^4.3.1",
     "colorette": "^2.0.20",
     "package-manager-detector": "1.8.0",
     "string-width": "^8.2.1"
@@ -59,6 +58,7 @@
     "@repo/cli-conformance": "workspace:8.0.0-rc.2",
     "@repo/tsconfig": "workspace:8.0.0-rc.2",
     "@types/node": "^22.19.19",
+    "ci-info": "^4.3.1",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"

--- a/packages/cli-engine/package.json
+++ b/packages/cli-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/cli-engine",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "The execution engine of the unified Prisma CLI.",
   "type": "module",
   "exports": {

--- a/packages/cli-engine/src/ci.ts
+++ b/packages/cli-engine/src/ci.ts
@@ -1,4 +1,4 @@
-import { createRequire } from "node:module";
+import vendors from "ci-info/vendors.json" with { type: "json" };
 import type { Runtime } from "./runtime";
 
 type Env = Readonly<Record<string, string | undefined>>;
@@ -18,25 +18,27 @@ interface Vendor {
 }
 
 /**
- * ci-info's own list of CI providers, read from the installed package
- * rather than copied here, so upgrading ci-info is what teaches the
- * engine a new provider. Its `isCI` export cannot be used instead: that
- * module evaluates against the real `process.env` the moment it is
+ * ci-info's own list of CI providers, INLINED INTO THE BUILT OUTPUT at
+ * build time (tsdown `noExternal`), so upgrading ci-info and rebuilding
+ * is what teaches the engine a new provider — the engine ships built,
+ * so that is every release. Its `isCI` export cannot be used instead:
+ * that module evaluates against the real `process.env` the moment it is
  * imported, and the engine may only read the environment its host
  * injected.
  *
- * Read through the CJS require cache, never as an ES-module JSON
- * import: ci-info's own index.js requires this same file, and under Bun
- * a JSON file that entered the ES module registry first is handed back
- * to `require` as its `{__esModule, default}` wrapper — so any host
- * process that also loads ci-info (composer's config graph does, via
- * orm-toolchain) got an object where ci-info expects an array. Found in
- * prisma/composer#234's engine-0.1.0 adoption; pinned by
+ * Inlining is a correctness requirement, not an optimization. The file
+ * is CJS-owned — ci-info's own index.js requires it — and a published
+ * artifact that loads someone else's internal file at runtime puts one
+ * file in two module systems in the same process. Under Bun, the
+ * ES-module registry entry poisons the later CJS require (the array
+ * arrives as its `{__esModule, default}` wrapper), which broke config
+ * evaluation for every composer-under-bun host the moment the config
+ * graph also loaded ci-info (prisma/composer#234). With the table
+ * embedded, the built engine touches nothing of ci-info's at runtime
+ * and ci-info is not a runtime dependency at all. Pinned by
  * tests/no-esm-json-import-in-dist.test.ts.
  */
-const VENDORS: readonly Vendor[] = createRequire(import.meta.url)(
-  "ci-info/vendors.json",
-);
+const VENDORS: readonly Vendor[] = vendors;
 
 /**
  * The variables ci-info checks outside the vendor table, catching CI

--- a/packages/cli-engine/src/ci.ts
+++ b/packages/cli-engine/src/ci.ts
@@ -18,25 +18,12 @@ interface Vendor {
 }
 
 /**
- * ci-info's own list of CI providers, INLINED INTO THE BUILT OUTPUT at
- * build time (tsdown `noExternal`), so upgrading ci-info and rebuilding
- * is what teaches the engine a new provider — the engine ships built,
- * so that is every release. Its `isCI` export cannot be used instead:
- * that module evaluates against the real `process.env` the moment it is
- * imported, and the engine may only read the environment its host
- * injected.
- *
- * Inlining is a correctness requirement, not an optimization. The file
- * is CJS-owned — ci-info's own index.js requires it — and a published
- * artifact that loads someone else's internal file at runtime puts one
- * file in two module systems in the same process. Under Bun, the
- * ES-module registry entry poisons the later CJS require (the array
- * arrives as its `{__esModule, default}` wrapper), which broke config
- * evaluation for every composer-under-bun host the moment the config
- * graph also loaded ci-info (prisma/composer#234). With the table
- * embedded, the built engine touches nothing of ci-info's at runtime
- * and ci-info is not a runtime dependency at all. Pinned by
- * tests/no-esm-json-import-in-dist.test.ts.
+ * ci-info's provider table. Its `isCI` export is unusable — it reads
+ * the real `process.env` at import; the engine reads only host-injected
+ * env. The table is inlined into the build (tsdown `noExternal`): the
+ * file is CJS-owned by ci-info, and loading it as ESM at runtime breaks
+ * hosts that also require ci-info (Bun's dual registry; composer#234).
+ * Pinned by tests/no-esm-json-import-in-dist.test.ts.
  */
 const VENDORS: readonly Vendor[] = vendors;
 

--- a/packages/cli-engine/src/ci.ts
+++ b/packages/cli-engine/src/ci.ts
@@ -1,4 +1,4 @@
-import vendors from "ci-info/vendors.json" with { type: "json" };
+import { createRequire } from "node:module";
 import type { Runtime } from "./runtime";
 
 type Env = Readonly<Record<string, string | undefined>>;
@@ -24,8 +24,19 @@ interface Vendor {
  * module evaluates against the real `process.env` the moment it is
  * imported, and the engine may only read the environment its host
  * injected.
+ *
+ * Read through the CJS require cache, never as an ES-module JSON
+ * import: ci-info's own index.js requires this same file, and under Bun
+ * a JSON file that entered the ES module registry first is handed back
+ * to `require` as its `{__esModule, default}` wrapper — so any host
+ * process that also loads ci-info (composer's config graph does, via
+ * orm-toolchain) got an object where ci-info expects an array. Found in
+ * prisma/composer#234's engine-0.1.0 adoption; pinned by
+ * tests/no-esm-json-import-in-dist.test.ts.
  */
-const VENDORS: readonly Vendor[] = vendors;
+const VENDORS: readonly Vendor[] = createRequire(import.meta.url)(
+  "ci-info/vendors.json",
+);
 
 /**
  * The variables ci-info checks outside the vendor table, catching CI

--- a/packages/cli-engine/tests/conformance.test.ts
+++ b/packages/cli-engine/tests/conformance.test.ts
@@ -31,6 +31,12 @@ describe("conformance: import purity", () => {
         label: "@prisma/cli-engine",
         output,
         manifest,
+        // ci-info's vendor table is read through createRequire — a CJS
+        // require the lexer rightly does not count as an import — so the
+        // ES module registry never holds vendors.json and ci-info's own
+        // require of it stays sane under Bun (see
+        // no-esm-json-import-in-dist.test.ts).
+        allowedUnimported: ["ci-info"],
         // Anti-vacuity: a run that swept the wrong directory would
         // otherwise report a clean sweep of nothing.
         requiredSpecifiers: ["@stricli/core"],

--- a/packages/cli-engine/tests/conformance.test.ts
+++ b/packages/cli-engine/tests/conformance.test.ts
@@ -31,12 +31,6 @@ describe("conformance: import purity", () => {
         label: "@prisma/cli-engine",
         output,
         manifest,
-        // ci-info's vendor table is read through createRequire — a CJS
-        // require the lexer rightly does not count as an import — so the
-        // ES module registry never holds vendors.json and ci-info's own
-        // require of it stays sane under Bun (see
-        // no-esm-json-import-in-dist.test.ts).
-        allowedUnimported: ["ci-info"],
         // Anti-vacuity: a run that swept the wrong directory would
         // otherwise report a clean sweep of nothing.
         requiredSpecifiers: ["@stricli/core"],

--- a/packages/cli-engine/tests/no-esm-json-import-in-dist.test.ts
+++ b/packages/cli-engine/tests/no-esm-json-import-in-dist.test.ts
@@ -1,0 +1,41 @@
+/**
+ * The vendor table is read through the CJS require cache, never as an
+ * ES-module JSON import. Under Bun 1.3, a JSON file that enters the ES
+ * module registry poisons a later CJS `require` of the same file — it
+ * returns the `{__esModule, default}` wrapper instead of the array — and
+ * ci-info's own index.js requires its vendors.json. The engine cannot
+ * control what else a host process loads, so its built output must use
+ * the same cache ci-info does. Found by composer's engine-0.1.0
+ * adoption (prisma/composer#234): `vendors.map is not a function` when
+ * any config graph reached `import { isCI } from "ci-info"` under bun.
+ */
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const DIST = fileURLToPath(new URL("../dist", import.meta.url));
+const ESM_JSON_IMPORT = /from\s*["'][^"']*vendors\.json["']/;
+const IMPORT_ATTRIBUTE = /with\s*\{\s*type:\s*["']json["']\s*\}/;
+
+describe("the vendor table's loading mechanism", () => {
+  test("the built engine never imports vendors.json as an ES module", () => {
+    expect(existsSync(DIST), `${DIST} is missing — build first`).toBe(true);
+    const files = readdirSync(DIST, {
+      recursive: true,
+      encoding: "utf8",
+    }).filter((name) => name.endsWith(".js"));
+    expect(files.length).toBeGreaterThan(0);
+    for (const name of files) {
+      const source = readFileSync(join(DIST, name), "utf8");
+      expect(
+        ESM_JSON_IMPORT.test(source),
+        `${name} imports vendors.json as an ES module`,
+      ).toBe(false);
+      expect(
+        IMPORT_ATTRIBUTE.test(source),
+        `${name} carries a JSON import attribute`,
+      ).toBe(false);
+    }
+  });
+});

--- a/packages/cli-engine/tests/no-esm-json-import-in-dist.test.ts
+++ b/packages/cli-engine/tests/no-esm-json-import-in-dist.test.ts
@@ -1,13 +1,7 @@
 /**
- * The vendor table is read through the CJS require cache, never as an
- * ES-module JSON import. Under Bun 1.3, a JSON file that enters the ES
- * module registry poisons a later CJS `require` of the same file — it
- * returns the `{__esModule, default}` wrapper instead of the array — and
- * ci-info's own index.js requires its vendors.json. The engine cannot
- * control what else a host process loads, so its built output must use
- * the same cache ci-info does. Found by composer's engine-0.1.0
- * adoption (prisma/composer#234): `vendors.map is not a function` when
- * any config graph reached `import { isCI } from "ci-info"` under bun.
+ * The vendor table is inlined at build time (src/ci.ts): built output
+ * that loads ci-info's CJS-owned vendors.json as ESM breaks any host
+ * that also requires ci-info (Bun's dual registry; composer#234).
  */
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";

--- a/packages/cli-engine/tsdown.config.ts
+++ b/packages/cli-engine/tsdown.config.ts
@@ -7,6 +7,10 @@ export default defineConfig({
     testing: "src/exports/testing.ts",
   },
   format: ["esm"],
+  // The ci-info vendor table is bundled INTO the output (see
+  // src/ci.ts): the built engine may not load another package's
+  // internal file at runtime. Everything else stays external.
+  noExternal: ["ci-info/vendors.json"],
   dts: true,
   clean: true,
   fixedExtension: false,

--- a/packages/cli-engine/tsdown.config.ts
+++ b/packages/cli-engine/tsdown.config.ts
@@ -7,9 +7,7 @@ export default defineConfig({
     testing: "src/exports/testing.ts",
   },
   format: ["esm"],
-  // The ci-info vendor table is bundled INTO the output (see
-  // src/ci.ts): the built engine may not load another package's
-  // internal file at runtime. Everything else stays external.
+  // The vendor table is embedded; see src/ci.ts.
   noExternal: ["ci-info/vendors.json"],
   dts: true,
   clean: true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,7 +47,7 @@
     "conformance": "tsx scripts/conformance.ts"
   },
   "dependencies": {
-    "@prisma/cli-engine": "workspace:0.1.0",
+    "@prisma/cli-engine": "workspace:0.1.1",
     "@prisma/composer": "0.6.0-dev.16",
     "@prisma/compute-sdk": "0.39.0",
     "@prisma/credentials-store": "^7.8.0",

--- a/packages/cli/scripts/conformance.ts
+++ b/packages/cli/scripts/conformance.ts
@@ -87,7 +87,7 @@ async function tarball(): Promise<readonly Finding[]> {
         {
           familyPackage: "@prisma/composer",
           familyPin: "0.0.9",
-          shellPin: "0.1.0",
+          shellPin: "0.1.1",
           reason:
             "operator ruling 2026-08-12: ignore for now — composer cannot pin an engine version that is not published yet",
           removeWhen:
@@ -96,7 +96,7 @@ async function tarball(): Promise<readonly Finding[]> {
         {
           familyPackage: "@prisma/orm-toolchain",
           familyPin: "0.0.9",
-          shellPin: "0.1.0",
+          shellPin: "0.1.1",
           reason:
             "same class, same ruling: the ORM toolchain cannot pin an engine version that is not published yet",
           removeWhen:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,9 +117,6 @@ importers:
       c12:
         specifier: 3.3.4
         version: 3.3.4(magicast@0.5.3)
-      ci-info:
-        specifier: ^4.3.1
-        version: 4.4.0
       colorette:
         specifier: ^2.0.20
         version: 2.0.20
@@ -139,6 +136,9 @@ importers:
       '@types/node':
         specifier: ^22.19.19
         version: 22.19.19
+      ci-info:
+        specifier: ^4.3.1
+        version: 4.4.0
       tsdown:
         specifier: ^0.21.10
         version: 0.21.10(typescript@6.0.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
   packages/cli:
     dependencies:
       '@prisma/cli-engine':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.1.1
         version: link:../cli-engine
       '@prisma/composer':
         specifier: 0.6.0-dev.16


### PR DESCRIPTION
## The failure this fixes

Found by composer's engine-0.1.0 adoption (prisma/composer#234). Under Bun, evaluating any composer config died with `CONFIG.EVALUATION_FAILED ... vendors.map is not a function`.

## The root problem, not the symptom

The engine's published artifact loaded another package's **internal file at runtime**: `import vendors from "ci-info/vendors.json" with { type: "json" }`. That file is CJS-owned — ci-info's own `index.js` requires it — so in any process that loads both (composer's config graph reaches ci-info through orm-toolchain's config-loader), one file lives in two module systems. Bun hands the later CJS require the `{__esModule, default}` wrapper instead of the array. Changing the engine's access mode (an earlier revision used `createRequire`) would only shuffle that hazard; removing the runtime reach removes it.

## The decision

The table is **inlined at build time** (tsdown `noExternal` on the one JSON file). The built engine touches nothing of ci-info's at runtime; `ci-info` moves to devDependencies. The design intent survives intact: the engine ships built, so "upgrade ci-info and rebuild" — which every release already does — is still what teaches it a new provider, and ci-info's `isCI` remains unusable by design (it reads real `process.env` at import; the engine only reads host-injected env).

Pinned by `no-esm-json-import-in-dist.test.ts` (no vendors.json reference survives in the output), and the engine's import-purity conformance run is back to fully strict — no allowances. Verified under real Bun 1.3.13 and Node: engine dist + CJS ci-info coexist; the pre-fix combination reproduced composer's failure verbatim.

## A second problem we found and did NOT fix here

While tracing the failure we found a dependency that should not exist: `@prisma/composer-prisma-cloud` — a library that applications install — imports `@prisma/orm-toolchain/config-loader`, which belongs to the ORM's command-line tooling. ADR 0004 says libraries must not depend on CLI packages, and this import is how an engine internal was able to break composer's users at all. Fixing it means deciding where `config-loader` should actually live, which is Will's decision, so this PR leaves it alone. Recorded in `.drive/projects/prisma-cli-v8/deferred.md` with the full import chain and the options.

## The bump

`pnpm bump-cli-engine-version patch` (#186's first real use) → engine `0.1.1`, shell pin, lockfile in one commit; the shell's pin-exception triples re-keyed, reopened by the version move as designed. On merge the next publish run ships `0.1.1`; composer's #234 then updates its pinned engine version and its remaining red jobs clear.

## Alternatives considered

**`createRequire` of the same file** — shipped in this PR's first revision, rejected on review: it still reaches into ci-info's internals at runtime, and matches only the current owner's access mode. **Hand-copy the table** — loses the upgrade property for no gain over build-time inlining. **Use ci-info's `isCI`** — reads the real environment at import, forbidden by design. **Wait for Bun** — the registry behaviour is arguably Bun's bug, but hosts run today's Bun, and the engine artifact should not be exposed to any runtime's dual-registry semantics in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

