### PR TITLE
The release flag derives from the base version, so dev publishes stop crashing the run

### DIFF
--- a/scripts/determine-version-utils.test.ts
+++ b/scripts/determine-version-utils.test.ts
@@ -5,6 +5,7 @@ import {
   computeNextMinor,
   computeNextReleaseVersion,
   devVersion,
+  isReleasePublish,
   parseVersion,
   releaseDistTag,
 } from "./determine-version-utils.ts";
@@ -168,5 +169,21 @@ describe("devVersion", () => {
 
   it("refuses a non-canonical base, same as every other publish path", () => {
     assert.throws(() => devVersion("8.0.0-rc.2-dev.1", "4"));
+  });
+});
+
+describe("isReleasePublish", () => {
+  it("a dev publish is never a release, and its suffixed version never reaches the canonical check", () => {
+    assert.equal(isReleasePublish("8.0.0-rc.2", "dev"), false);
+  });
+
+  it("a publish under the base's canonical tag is a release", () => {
+    assert.equal(isReleasePublish("8.0.0-rc.2", "next"), true);
+    assert.equal(isReleasePublish("8.1.0", "latest"), true);
+  });
+
+  it("a beta or off-tag publish is not a release", () => {
+    assert.equal(isReleasePublish("8.0.0-rc.2", "beta"), false);
+    assert.equal(isReleasePublish("8.0.0-rc.2", "latest"), false);
   });
 });

--- a/scripts/determine-version-utils.ts
+++ b/scripts/determine-version-utils.ts
@@ -111,3 +111,13 @@ export function releaseDistTag(base: string): "latest" | "next" {
   assertCanonicalBase(base);
   return base.includes("-rc.") ? "next" : "latest";
 }
+
+/**
+ * Whether a publish is a release — under the canonical tag for its BASE
+ * version. Dev publishes never are, and their suffixed version must not
+ * reach releaseDistTag, which asserts a canonical base.
+ */
+export function isReleasePublish(base: string, tag: string): boolean {
+  if (tag === "dev") return false;
+  return tag === releaseDistTag(base);
+}

--- a/scripts/determine-version.ts
+++ b/scripts/determine-version.ts
@@ -45,6 +45,7 @@ import type { VersionResult } from "./determine-version-utils.ts";
 import {
   assertCanonicalBase,
   devVersion,
+  isReleasePublish,
   releaseDistTag,
 } from "./determine-version-utils.ts";
 
@@ -100,6 +101,7 @@ function readPreviousRootVersion(): PreviousVersionLookup {
 }
 
 function writeGitHubOutput(
+  base: string,
   result: VersionResult | undefined,
   publish: boolean,
 ): void {
@@ -110,10 +112,11 @@ function writeGitHubOutput(
   appendFileSync(outputFile, `version<<EOF\n${result.version}\nEOF\n`);
   appendFileSync(outputFile, `tag<<EOF\n${result.tag}\nEOF\n`);
   // A run is a release — and gets the GitHub Release + tag — when it
-  // publishes under the canonical tag for its version. Push bumps
+  // publishes under the canonical tag for its BASE version. Push bumps
   // always do; a dispatch counts only when the chosen tag matches
-  // (re-publishing a release), not for beta/preview cuts.
-  const release = result.tag === releaseDistTag(result.version);
+  // (re-publishing a release); dev publishes never do, and their
+  // suffixed version must not reach releaseDistTag's canonical check.
+  const release = isReleasePublish(base, result.tag);
   appendFileSync(outputFile, `release<<EOF\n${String(release)}\nEOF\n`);
 }
 
@@ -183,9 +186,9 @@ switch (eventName) {
 }
 
 if (result === undefined) {
-  writeGitHubOutput(undefined, false);
+  writeGitHubOutput(baseVersion, undefined, false);
 } else {
   console.log(`Resolved version:      ${result.version}`);
   console.log(`Resolved dist-tag:     ${result.tag}`);
-  writeGitHubOutput(result, true);
+  writeGitHubOutput(baseVersion, result, true);
 }


### PR DESCRIPTION
The dev channel's first live run (publish run 46, after #187 merged) died in `Determine version`:

```text
Error: Base version "8.0.0-rc.2-dev.46" is not canonical.
```

My bug, one layer down from the tested code: the run's release flag was computed as `result.tag === releaseDistTag(result.version)`, and for a dev publish `result.version` carries the `-dev.N` suffix — which `releaseDistTag` rejects by design. The suffix computation had unit tests; the output-writing path that consumed it did not.

The flag now comes from `isReleasePublish(base, tag)`: a dev publish is never a release, and only the canonical base ever reaches `releaseDistTag`. Three unit tests cover the dev, release, and off-tag cases. 57 script tests pass.

Consequence once merged: the blocked publish (engine `0.1.1` + the first dev CLI build) ships on the next push — this PR's own merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)