### PR TITLE
The dev stamp refreshes the lockfile, so pnpm's pre-script check passes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,7 +114,14 @@ jobs:
       # excluded from the sweep and ships at its own committed version.
       - name: Stamp dev version
         if: ${{ steps.version.outputs.publish == 'true' && steps.version.outputs.tag == 'dev' }}
-        run: node scripts/set-version.ts "${{ steps.version.outputs.version }}"
+        # The lockfile refresh is part of the stamp: pnpm verifies
+        # manifests against the lockfile before running any script, so a
+        # stamped workspace with an unstamped lockfile fails the next
+        # pnpm invocation (it did, publish run 48). Same pairing
+        # bump-version does for committed bumps; still ephemeral.
+        run: |
+          node scripts/set-version.ts "${{ steps.version.outputs.version }}"
+          pnpm install --lockfile-only --no-frozen-lockfile
 
       - name: Build packages
         if: ${{ steps.version.outputs.publish == 'true' }}


### PR DESCRIPTION
Publish run 48 got past #188's fix and died one step later:

```text
specifiers in the lockfile don't match specifiers in package.json:
  - @repo/tsconfig (lockfile: workspace:8.0.0-rc.2, manifest: workspace:8.0.0-rc.2-dev.48)
```

pnpm 11 verifies manifests against the lockfile before running any script, so the stamped workspace with an unstamped lockfile failed the very next `pnpm build`. The stamp step now pairs the manifest write with `pnpm install --lockfile-only --no-frozen-lockfile` — the same pairing `bump-version` does for committed bumps, still fully ephemeral. The real dependency install (frozen) already ran before the stamp and is untouched.

Second and last of the dev channel's first-live-run defects; with this, run 49 should ship engine `0.1.1` and the first dev CLI build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)