### PR TITLE
The CLI publishes as `prisma`, and this release is 8.0.0-rc.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,10 @@ name: Publish to npm
 #   - workflow_dispatch                                 → publish `<base>`
 #     under the chosen dist-tag (default `latest`); also the dry-run path.
 #
-# Scope: publishes `@prisma/cli-engine` then `@prisma/cli` (the cli
-# depends on the engine, so the engine goes first). The engine versions
+# Scope: publishes `@prisma/cli-engine`, then `@prisma/cli`, then
+# `prisma` — the unscoped name is the same shell under the `prisma` bin,
+# and it goes last because it carries the whole tree (dependents after
+# dependencies). The engine versions
 # INDEPENDENTLY of the lockstep (ADR 0004, operator 2026-08-13): it
 # publishes at whatever version its own manifest carries, and because
 # an already-published version is treated as done (see publish_one), an
@@ -186,6 +188,7 @@ jobs:
         run: |
           pnpm --filter @prisma/cli-engine publish --tag "${{ steps.version.outputs.tag }}" --access public --no-git-checks --dry-run
           pnpm --filter @prisma/cli publish --tag "${{ steps.version.outputs.tag }}" --access public --no-git-checks --dry-run
+          pnpm --filter prisma publish --tag "${{ steps.version.outputs.tag }}" --access public --no-git-checks --dry-run
 
       # A rerun (or a re-publish dispatch) meets versions that are
       # already on the registry. npm refuses to publish over them —
@@ -214,6 +217,7 @@ jobs:
           }
           publish_one @prisma/cli-engine
           publish_one @prisma/cli
+          publish_one prisma
 
       # Emit a GitHub Release for releases only — runs whose dist-tag is
       # the canonical one for their version (`next` on the RC line,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-cli",
-  "version": "8.0.0-rc.2",
+  "version": "8.0.0-rc.3",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/packages/cli-conformance/package.json
+++ b/packages/cli-conformance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/cli-conformance",
   "private": true,
-  "version": "8.0.0-rc.2",
+  "version": "8.0.0-rc.3",
   "description": "Reusable conformance checks for the engine's consumers: import purity over built output, config-section validators that never throw, and verification of the tarballs a registry would receive. Depends on no package it checks.",
   "type": "module",
   "exports": {
@@ -23,7 +23,7 @@
     "test": "pnpm run typecheck && vitest run"
   },
   "devDependencies": {
-    "@repo/tsconfig": "workspace:8.0.0-rc.2",
+    "@repo/tsconfig": "workspace:8.0.0-rc.3",
     "@types/node": "^22.19.19",
     "es-module-lexer": "^2.1.0",
     "tsx": "^4.22.4",

--- a/packages/cli-engine/package.json
+++ b/packages/cli-engine/package.json
@@ -55,8 +55,8 @@
     "string-width": "^8.2.1"
   },
   "devDependencies": {
-    "@repo/cli-conformance": "workspace:8.0.0-rc.2",
-    "@repo/tsconfig": "workspace:8.0.0-rc.2",
+    "@repo/cli-conformance": "workspace:8.0.0-rc.3",
+    "@repo/tsconfig": "workspace:8.0.0-rc.3",
     "@types/node": "^22.19.19",
     "ci-info": "^4.3.1",
     "tsdown": "^0.21.10",

--- a/packages/cli-telemetry/package.json
+++ b/packages/cli-telemetry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/cli-telemetry",
   "private": true,
-  "version": "8.0.0-rc.2",
+  "version": "8.0.0-rc.3",
   "description": "CLI telemetry child sender: the detached subprocess the engine hands a composed payload to, its system probes, and the POST",
   "type": "module",
   "sideEffects": [
@@ -35,7 +35,7 @@
     "@vercel/detect-agent": "^1.2.3"
   },
   "devDependencies": {
-    "@repo/tsconfig": "workspace:8.0.0-rc.2",
+    "@repo/tsconfig": "workspace:8.0.0-rc.3",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3",

--- a/packages/cli/scripts/conformance.ts
+++ b/packages/cli/scripts/conformance.ts
@@ -33,6 +33,7 @@ import {
 
 const CLI_DIR = fileURLToPath(new URL("..", import.meta.url));
 const ENGINE_DIR = join(CLI_DIR, "..", "cli-engine");
+const PRISMA_DIR = join(CLI_DIR, "..", "prisma");
 // At the REPO ROOT, not inside this package: a sandbox node_modules of
 // ~440 packages inside packages/cli slows vitest's file crawl enough to
 // time out unrelated tests.
@@ -51,13 +52,19 @@ async function importPurity(): Promise<readonly Finding[]> {
     manifest: await manifest(CLI_DIR),
     requiredSpecifiers: ["@prisma/cli-engine", "@prisma/composer/family"],
   });
+  const unscoped = checkImportPurity({
+    label: "prisma",
+    output: await sweepBuiltOutput(join(PRISMA_DIR, "dist")),
+    manifest: await manifest(PRISMA_DIR),
+    requiredSpecifiers: ["@prisma/cli-engine", "@prisma/composer/family"],
+  });
   const engine = checkImportPurity({
     label: "@prisma/cli-engine",
     output: await sweepBuiltOutput(join(ENGINE_DIR, "dist")),
     manifest: await manifest(ENGINE_DIR),
     requiredSpecifiers: ["@stricli/core"],
   });
-  return [...shell, ...engine];
+  return [...shell, ...unscoped, ...engine];
 }
 
 function validatorNoThrow(): readonly Finding[] {
@@ -78,6 +85,7 @@ async function tarball(): Promise<readonly Finding[]> {
     {
       packages: [
         { name: "@prisma/cli", dir: CLI_DIR },
+        { name: "prisma", dir: PRISMA_DIR },
         { name: "@prisma/cli-engine", dir: ENGINE_DIR },
       ],
       shellPackage: "@prisma/cli",

--- a/packages/compute/package.json
+++ b/packages/compute/package.json
@@ -42,7 +42,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@repo/tsconfig": "workspace:*",
+    "@repo/tsconfig": "workspace:8.0.0-rc.3",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3",

--- a/packages/prisma/LICENSE
+++ b/packages/prisma/LICENSE
@@ -1,0 +1,158 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work.
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work by
+the copyright owner or by an individual or Legal Entity authorized to submit on
+behalf of the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent to the
+Licensor or its representatives, including but not limited to communication on
+electronic mailing lists, source code control systems, and issue tracking
+systems that are managed by, or on behalf of, the Licensor for the purpose of
+discussing and improving the Work, but excluding communication that is
+conspicuously marked or otherwise designated in writing by the copyright owner
+as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare Derivative Works of, publicly display, publicly perform,
+sublicense, and distribute the Work and such Derivative Works in Source or Object
+form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License,
+each Contributor hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section) patent
+license to make, have made, use, offer to sell, sell, import, and otherwise
+transfer the Work, where such license applies only to those patent claims
+licensable by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s) with the Work to
+which such Contribution(s) was submitted. If You institute patent litigation
+against any entity (including a cross-claim or counterclaim in a lawsuit)
+alleging that the Work or a Contribution incorporated within the Work
+constitutes direct or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate as of the date
+such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or
+Derivative Works thereof in any medium, with or without modifications, and in
+Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from the
+Source form of the Work, excluding those notices that do not pertain to any part
+of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution, then
+any Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the Derivative
+Works; within the Source form or documentation, if provided along with the
+Derivative Works; or, within a display generated by the Derivative Works, if and
+wherever such third-party notices normally appear. The contents of the NOTICE
+file are for informational purposes only and do not modify the License. You may
+add Your own attribution notices within Derivative Works that You distribute,
+alongside or as an addendum to the NOTICE text from the Work, provided that such
+additional attribution notices cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any
+Contribution intentionally submitted for inclusion in the Work by You to the
+Licensor shall be under the terms and conditions of this License, without any
+additional terms or conditions. Notwithstanding the above, nothing herein shall
+supersede or modify the terms of any separate license agreement you may have
+executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names,
+trademarks, service marks, or product names of the Licensor, except as required
+for reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in
+writing, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied, including, without limitation, any warranties or
+conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any risks
+associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in
+tort (including negligence), contract, or otherwise, unless required by
+applicable law (such as deliberate and grossly negligent acts) or agreed to in
+writing, shall any Contributor be liable to You for damages, including any
+direct, indirect, special, incidental, or consequential damages of any character
+arising as a result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill, work stoppage,
+computer failure or malfunction, or any and all other commercial damages or
+losses), even if such Contributor has been advised of the possibility of such
+damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or
+Derivative Works thereof, You may choose to offer, and charge a fee for,
+acceptance of support, warranty, indemnity, or other liability obligations and/or
+rights consistent with this License. However, in accepting such obligations, You
+may act only on Your own behalf and on Your sole responsibility, not on behalf of
+any other Contributor, and only if You agree to indemnify, defend, and hold each
+Contributor harmless for any liability incurred by, or claims asserted against,
+such Contributor by reason of your accepting any such warranty or additional
+liability.
+
+END OF TERMS AND CONDITIONS

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -1,0 +1,136 @@
+<p align="center">
+  <img src="https://i.imgur.com/h6UIYTu.png" alt="Prisma" width="360" />
+</p>
+
+# Prisma CLI
+
+[![npm version](https://img.shields.io/npm/v/prisma?label=npm)](https://www.npmjs.com/package/prisma)
+[![license](https://img.shields.io/npm/l/prisma)](https://github.com/prisma/prisma-cli/blob/main/LICENSE)
+[![Node.js](https://img.shields.io/node/v/prisma)](https://www.npmjs.com/package/prisma)
+
+[Quickstart](#quickstart) • [Commands](#commands) • [Beta notes](#beta-notes) • [Documentation](#documentation) • [Support](#support)
+
+---
+
+`prisma` is the public beta of the new CLI for the
+Prisma Developer Platform.
+
+It is the terminal surface managing your platform projects, branches, apps,
+deployments, and environment variables.
+
+The command model is under active development to include tooling for your
+schema, database, migration, and broader platform workflows.
+
+Looking for Prisma ORM commands such as `prisma generate`, `prisma migrate`, or
+`prisma studio`? Use the [`prisma`](https://www.npmjs.com/package/prisma)
+package.
+
+---
+
+## Quickstart
+
+Install the beta package locally:
+
+```bash
+npm install --save-dev prisma@next
+```
+
+Run the binary exposed by this package:
+
+```bash
+npx prisma --help
+npx prisma auth login
+npx prisma app deploy
+```
+
+With `pnpm`:
+
+```bash
+pnpm add -D prisma
+pnpm prisma auth login
+pnpm prisma app deploy
+```
+
+Useful next commands:
+
+```bash
+npx prisma app logs
+npx prisma app open
+npx prisma project env add DATABASE_URL=postgresql://example --role preview
+npx prisma project env add --file .env --role preview
+npx prisma project env list
+npx prisma project env list --role preview
+```
+
+The beta package exposes `prisma-cli` so it can coexist with the existing
+`prisma` executable.
+
+---
+
+## Commands
+
+| Group | What it does |
+| --- | --- |
+| `version` | Show the installed CLI build and host environment. |
+| `auth` | Log in, log out, and inspect the active Prisma account. |
+| `project` | List projects, show the resolved project, and manage project environment variables. |
+| `git` | Connect or disconnect a project from a GitHub repository. |
+| `branch` | List Prisma branches for the resolved project. |
+| `database` | Create, inspect, and remove Prisma Postgres databases and their connection strings. |
+| `bucket` | Create, list, and delete Tigris object-store buckets and their access keys. |
+| `app` | Build, run, deploy, inspect, open, stream logs, promote, roll back, and remove apps. |
+
+Common examples:
+
+```bash
+npx prisma version
+npx prisma auth whoami
+npx prisma project show
+npx prisma branch list
+npx prisma app deploy --branch feat-login --framework nextjs
+npx prisma app promote <deployment-id>
+```
+
+### Built for humans, CI, and agents
+
+- Human-readable output by default.
+- `--json` for structured output.
+- `--no-interactive` and `--yes` for automation.
+- `PRISMA_SERVICE_TOKEN` for headless authenticated commands.
+- Stable command groups, flags, and error codes for scripts and agents.
+- Environment variable values are not printed back to the terminal.
+
+---
+
+## Beta notes
+
+- Requires Node.js 22.18 or newer.
+- This is a beta package and may change quickly.
+- Official beta releases publish as `prisma`.
+- The package binary is `prisma-cli`, not `prisma`, during beta.
+- Local project context is cached in `.prisma/local.json`, which is gitignored and not a declarative repo config file.
+
+---
+
+## Documentation
+
+- [CLI docs index](https://github.com/prisma/prisma-cli/blob/main/docs/README.md)
+- [Resource model](https://github.com/prisma/prisma-cli/blob/main/docs/product/resource-model.md)
+- [Command principles](https://github.com/prisma/prisma-cli/blob/main/docs/product/command-principles.md)
+- [Command spec](https://github.com/prisma/prisma-cli/blob/main/docs/product/command-spec.md)
+- [Output conventions](https://github.com/prisma/prisma-cli/blob/main/docs/product/output-conventions.md)
+- [Error conventions](https://github.com/prisma/prisma-cli/blob/main/docs/product/error-conventions.md)
+
+## Support
+
+Issues and feedback are welcome while the CLI is in public beta. Please use
+[GitHub issues](https://github.com/prisma/prisma-cli/issues) for bug reports and
+feature requests.
+
+Security reports should follow Prisma's
+[security policy](https://github.com/prisma/prisma-cli/blob/main/SECURITY.md)
+and should not be filed as public issues.
+
+## License
+
+Apache-2.0

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -1,14 +1,13 @@
 {
-  "name": "@prisma/cli",
+  "name": "prisma",
   "version": "8.0.0-rc.3",
-  "description": "Command-line interface for the Prisma Developer Platform.",
+  "description": "The Prisma CLI: one binary for the ORM, Composer, and the Prisma Developer Platform.",
   "type": "module",
   "bin": {
-    "prisma-cli": "./dist/cli.js"
+    "prisma": "./dist/prisma.js"
   },
   "exports": {
-    "./package.json": "./package.json",
-    "./src/bin": "./src/bin.ts"
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",
@@ -24,14 +23,14 @@
   "keywords": [
     "prisma",
     "cli",
+    "orm",
     "database",
-    "app",
     "deployment"
   ],
   "repository": {
     "type": "git",
     "url": "https://github.com/prisma/prisma-cli.git",
-    "directory": "packages/cli"
+    "directory": "packages/prisma"
   },
   "homepage": "https://github.com/prisma/prisma-cli#readme",
   "bugs": {
@@ -41,11 +40,7 @@
   "scripts": {
     "build": "tsdown",
     "prepack": "pnpm run build",
-    "check:grammar": "vitest run tests/mount-coverage.test.ts",
-    "typecheck": "tsc --noEmit",
-    "test": "pnpm run build && vitest run",
-    "test:e2e": "vitest run --config vitest.e2e.config.ts",
-    "conformance": "tsx scripts/conformance.ts"
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@prisma/cli-engine": "workspace:0.1.1",
@@ -61,13 +56,11 @@
     "open": "^11.0.0"
   },
   "devDependencies": {
-    "@repo/cli-conformance": "workspace:8.0.0-rc.3",
+    "@prisma/cli": "workspace:8.0.0-rc.3",
     "@repo/cli-telemetry": "workspace:8.0.0-rc.3",
     "@repo/tsconfig": "workspace:8.0.0-rc.3",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
-    "tsx": "^4.22.4",
-    "typescript": "^6.0.3",
-    "vitest": "^4.1.8"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/prisma/src/bin.ts
+++ b/packages/prisma/src/bin.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+// The `prisma` bin. The implementation is @prisma/cli's, bundled in at
+// build time (see tsdown.config.ts): the two published names ship the
+// same shell, so a command cannot behave differently depending on which
+// one a user installed.
+import "@prisma/cli/src/bin";

--- a/packages/prisma/src/sender.ts
+++ b/packages/prisma/src/sender.ts
@@ -1,0 +1,4 @@
+// The detached telemetry sender, forked by the running CLI. It ships
+// beside the bin because the runtime resolves it relative to its own
+// entry (see @prisma/cli's runtime.ts).
+import "@repo/cli-telemetry/sender";

--- a/packages/prisma/tsconfig.json
+++ b/packages/prisma/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@repo/tsconfig/base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/prisma/tsdown.config.ts
+++ b/packages/prisma/tsdown.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig([
+  // The same shell, published under the unscoped name with the `prisma`
+  // bin. @prisma/cli's source is bundled in (as is the private telemetry
+  // package) so this package has one implementation and no dependency on
+  // an unpublishable workspace sibling; the published runtime deps stay
+  // external and are declared here to match.
+  {
+    entry: {
+      prisma: "src/bin.ts",
+      sender: "src/sender.ts",
+    },
+    format: ["esm"],
+    clean: true,
+    shims: true,
+    fixedExtension: false,
+    noExternal: ["@prisma/cli", "@repo/cli-telemetry"],
+    outDir: "dist",
+  },
+]);

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/tsconfig",
   "private": true,
-  "version": "8.0.0-rc.2",
+  "version": "8.0.0-rc.3",
   "description": "Base tsconfig providing package for the monorepo",
   "license": "Apache-2.0",
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,13 +58,13 @@ importers:
         version: 11.0.0
     devDependencies:
       '@repo/cli-conformance':
-        specifier: workspace:8.0.0-rc.2
+        specifier: workspace:8.0.0-rc.3
         version: link:../cli-conformance
       '@repo/cli-telemetry':
-        specifier: workspace:8.0.0-rc.2
+        specifier: workspace:8.0.0-rc.3
         version: link:../cli-telemetry
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.2
+        specifier: workspace:8.0.0-rc.3
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -85,7 +85,7 @@ importers:
   packages/cli-conformance:
     devDependencies:
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.2
+        specifier: workspace:8.0.0-rc.3
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -128,10 +128,10 @@ importers:
         version: 8.2.1
     devDependencies:
       '@repo/cli-conformance':
-        specifier: workspace:8.0.0-rc.2
+        specifier: workspace:8.0.0-rc.3
         version: link:../cli-conformance
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.2
+        specifier: workspace:8.0.0-rc.3
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -156,7 +156,7 @@ importers:
         version: 1.2.4
     devDependencies:
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.2
+        specifier: workspace:8.0.0-rc.3
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -174,7 +174,7 @@ importers:
   packages/compute:
     devDependencies:
       '@repo/tsconfig':
-        specifier: workspace:*
+        specifier: workspace:8.0.0-rc.3
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -188,6 +188,61 @@ importers:
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@22.19.19)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  packages/prisma:
+    dependencies:
+      '@prisma/cli-engine':
+        specifier: workspace:0.1.1
+        version: link:../cli-engine
+      '@prisma/composer':
+        specifier: 0.6.0-dev.16
+        version: 0.6.0-dev.16(@types/node@22.19.19)(magicast@0.5.3)(rollup@4.62.2)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8(@types/node@22.19.19)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(workerd@1.20260704.1)(ws@8.21.0)
+      '@prisma/compute-sdk':
+        specifier: 0.39.0
+        version: 0.39.0(@prisma/management-api-sdk@1.55.0)(rollup@4.62.2)
+      '@prisma/credentials-store':
+        specifier: ^7.8.0
+        version: 7.8.0
+      '@prisma/management-api-sdk':
+        specifier: 1.55.0
+        version: 1.55.0
+      '@prisma/orm-toolchain':
+        specifier: 8.0.0-rc.1-dev.40
+        version: 8.0.0-rc.1-dev.40(magicast@0.5.3)(typanion@3.14.0)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vercel/detect-agent':
+        specifier: ^1.2.3
+        version: 1.2.4
+      better-result:
+        specifier: ^2.9.2
+        version: 2.9.2
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
+      execa:
+        specifier: ^9.6.1
+        version: 9.6.1
+      open:
+        specifier: ^11.0.0
+        version: 11.0.0
+    devDependencies:
+      '@prisma/cli':
+        specifier: workspace:8.0.0-rc.3
+        version: link:../cli
+      '@repo/cli-telemetry':
+        specifier: workspace:8.0.0-rc.3
+        version: link:../cli-telemetry
+      '@repo/tsconfig':
+        specifier: workspace:8.0.0-rc.3
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^22.19.19
+        version: 22.19.19
+      tsdown:
+        specifier: ^0.21.10
+        version: 0.21.10(typescript@6.0.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/tsconfig: {}
 
@@ -992,12 +1047,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
-
   '@napi-rs/wasm-runtime@1.2.2':
     resolution: {integrity: sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
@@ -1594,9 +1643,6 @@ packages:
     resolution: {integrity: sha512-W2Ub165Qv0iMFljbYKxxbZN+2dVSngnzEjQNEFXtnz5oJVx9XSypmNmUvMtuYMeZ3kdVC1zI7yd/rtuX+SDnbg==}
     cpu: [arm64]
     os: [win32]
-
-  '@tybys/wasm-util@0.10.2':
-    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -3847,11 +3893,11 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.2
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
@@ -3970,7 +4016,7 @@ snapshots:
       c12: 3.3.4(magicast@0.5.3)
       colorette: 2.0.20
       package-manager-detector: 1.8.0
-      string-width: 8.2.1
+      string-width: 8.2.2
     transitivePeerDependencies:
       - magicast
 
@@ -4197,7 +4243,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.1.5':
@@ -4392,11 +4438,6 @@ snapshots:
     optional: true
 
   '@turbo/windows-arm64@2.10.9':
-    optional: true
-
-  '@tybys/wasm-util@0.10.2':
-    dependencies:
-      tslib: 2.8.1
     optional: true
 
   '@tybys/wasm-util@0.10.3':
@@ -4720,7 +4761,7 @@ snapshots:
   cli-truncate@5.2.0:
     dependencies:
       slice-ansi: 8.0.0
-      string-width: 8.2.1
+      string-width: 8.2.2
 
   clipanion@4.0.0-rc.4(typanion@3.14.0):
     dependencies:
@@ -5044,7 +5085,7 @@ snapshots:
       signal-exit: 3.0.7
       slice-ansi: 8.0.0
       stack-utils: 2.0.6
-      string-width: 8.2.1
+      string-width: 8.2.2
       terminal-size: 4.0.1
       type-fest: 5.8.0
       widest-line: 6.0.0
@@ -5847,7 +5888,7 @@ snapshots:
 
   widest-line@6.0.0:
     dependencies:
-      string-width: 8.2.1
+      string-width: 8.2.2
 
   workerd@1.20260704.1:
     optionalDependencies:
@@ -5860,7 +5901,7 @@ snapshots:
   wrap-ansi@10.0.0:
     dependencies:
       ansi-styles: 6.2.3
-      string-width: 8.2.1
+      string-width: 8.2.2
       strip-ansi: 7.2.0
 
   wrap-ansi@9.0.2:


### PR DESCRIPTION
## Before and after

```bash
# before
$ npm install -g prisma@next
npm error notarget No matching version found for prisma@next
# `prisma` on npm carries only the v7 train; nothing from this repo publishes under it.

# after (on merge)
$ npm install -g prisma@next && prisma --version
prisma 8.0.0-rc.3
```

## The decision

The `prisma` name is ours now — you configured OIDC trusted publishing on the package — so this adds the package that uses it. Rollout-plan step 4, which S7 deferred until the name was available.

`packages/prisma` is **the same shell under the `prisma` bin, not a second implementation.** tsdown bundles `@prisma/cli`'s source in, exactly as it already bundles the private telemetry package, so a command cannot behave differently depending on which name a user installed. Its published dependency set matches the shell's, and `@prisma/cli` gains one export — its bin entry — so the bundling has something to name.

Both names publish from one run: engine first, `@prisma/cli`, then `prisma` last (dependents after dependencies). Both are in the dry-run path too.

## What the checks now cover

The conformance run treats the new tarball on the same terms as the others — packed output imports only what it declares, the tarball installs into a clean sandbox, and the bin named `prisma` starts there on plain Node. Verified against the tarball that would actually ship:

```text
name: prisma 8.0.0-rc.3
bin: {"prisma":"./dist/prisma.js"}
engine dep: 0.1.1
no workspace: leaks: true
```

## Scope of the release

Root version is `8.0.0-rc.3`, so merging this publishes under **`next`**. `prisma@latest` stays on v7 and is untouched — moving `latest` remains a separate deliberate act (`docs/oss/versioning.md`).

Three pin exceptions still ride along, unchanged: composer and the ORM toolchain pin engine `0.0.9` in their currently-published versions. Their adaptations to `0.1.1` are merged/approved but not yet released, so this release still resolves those older engines. The exceptions are keyed on the observed versions and die when the two products publish — that is the next release, not this one.

## Alternatives considered

**A thin wrapper depending on `@prisma/cli`.** Its `exports` map exposes nothing importable, so a wrapper would have nothing to call; adding a runtime export surface to publish a bin is worse than bundling.

**Renaming `@prisma/cli` to `prisma`.** Breaks every existing install of the scoped name, which the rollout plan keeps alive until the cutover deprecates it deliberately.

**Waiting for the two product releases first.** Would delay proving the pipeline for no gain: `next` is a channel nobody lands on by accident, and the clean-pin release follows within hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
