### PR TITLE
chore(release): bump to 8.0.0-rc.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-cli",
-  "version": "8.0.0-rc.3",
+  "version": "8.0.0-rc.4",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/packages/cli-conformance/package.json
+++ b/packages/cli-conformance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/cli-conformance",
   "private": true,
-  "version": "8.0.0-rc.3",
+  "version": "8.0.0-rc.4",
   "description": "Reusable conformance checks for the engine's consumers: import purity over built output, config-section validators that never throw, and verification of the tarballs a registry would receive. Depends on no package it checks.",
   "type": "module",
   "exports": {
@@ -24,7 +24,7 @@
     "test": "pnpm run typecheck && vitest run"
   },
   "devDependencies": {
-    "@repo/tsconfig": "workspace:8.0.0-rc.3",
+    "@repo/tsconfig": "workspace:8.0.0-rc.4",
     "@types/node": "^22.19.19",
     "es-module-lexer": "^2.1.0",
     "tsx": "^4.22.4",

--- a/packages/cli-engine/package.json
+++ b/packages/cli-engine/package.json
@@ -55,8 +55,8 @@
     "string-width": "^8.2.1"
   },
   "devDependencies": {
-    "@repo/cli-conformance": "workspace:8.0.0-rc.3",
-    "@repo/tsconfig": "workspace:8.0.0-rc.3",
+    "@repo/cli-conformance": "workspace:8.0.0-rc.4",
+    "@repo/tsconfig": "workspace:8.0.0-rc.4",
     "@types/node": "^22.19.19",
     "ci-info": "^4.3.1",
     "tsdown": "^0.21.10",

--- a/packages/cli-telemetry/package.json
+++ b/packages/cli-telemetry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/cli-telemetry",
   "private": true,
-  "version": "8.0.0-rc.3",
+  "version": "8.0.0-rc.4",
   "description": "CLI telemetry child sender: the detached subprocess the engine hands a composed payload to, its system probes, and the POST",
   "type": "module",
   "sideEffects": [
@@ -35,7 +35,7 @@
     "@vercel/detect-agent": "^1.2.3"
   },
   "devDependencies": {
-    "@repo/tsconfig": "workspace:8.0.0-rc.3",
+    "@repo/tsconfig": "workspace:8.0.0-rc.4",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/cli",
-  "version": "8.0.0-rc.3",
+  "version": "8.0.0-rc.4",
   "description": "Command-line interface for the Prisma Developer Platform.",
   "type": "module",
   "bin": {
@@ -62,9 +62,9 @@
   },
   "devDependencies": {
     "@prisma/composer": "0.7.0",
-    "@repo/cli-conformance": "workspace:8.0.0-rc.3",
-    "@repo/cli-telemetry": "workspace:8.0.0-rc.3",
-    "@repo/tsconfig": "workspace:8.0.0-rc.3",
+    "@repo/cli-conformance": "workspace:8.0.0-rc.4",
+    "@repo/cli-telemetry": "workspace:8.0.0-rc.4",
+    "@repo/tsconfig": "workspace:8.0.0-rc.4",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "tsx": "^4.22.4",

--- a/packages/compute/package.json
+++ b/packages/compute/package.json
@@ -42,7 +42,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@repo/tsconfig": "workspace:8.0.0-rc.3",
+    "@repo/tsconfig": "workspace:8.0.0-rc.4",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3",

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma",
-  "version": "8.0.0-rc.3",
+  "version": "8.0.0-rc.4",
   "description": "The Prisma CLI: one binary for the ORM, Composer, and the Prisma Developer Platform.",
   "type": "module",
   "bin": {
@@ -56,9 +56,9 @@
     "open": "^11.0.0"
   },
   "devDependencies": {
-    "@prisma/cli": "workspace:8.0.0-rc.3",
-    "@repo/cli-telemetry": "workspace:8.0.0-rc.3",
-    "@repo/tsconfig": "workspace:8.0.0-rc.3",
+    "@prisma/cli": "workspace:8.0.0-rc.4",
+    "@repo/cli-telemetry": "workspace:8.0.0-rc.4",
+    "@repo/tsconfig": "workspace:8.0.0-rc.4",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3"

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/tsconfig",
   "private": true,
-  "version": "8.0.0-rc.3",
+  "version": "8.0.0-rc.4",
   "description": "Base tsconfig providing package for the monorepo",
   "license": "Apache-2.0",
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,13 +61,13 @@ importers:
         specifier: 0.7.0
         version: 0.7.0(@types/node@22.19.19)(magicast@0.5.3)(rollup@4.62.2)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8(@types/node@22.19.19)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(workerd@1.20260704.1)(ws@8.21.0)
       '@repo/cli-conformance':
-        specifier: workspace:8.0.0-rc.3
+        specifier: workspace:8.0.0-rc.4
         version: link:../cli-conformance
       '@repo/cli-telemetry':
-        specifier: workspace:8.0.0-rc.3
+        specifier: workspace:8.0.0-rc.4
         version: link:../cli-telemetry
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.3
+        specifier: workspace:8.0.0-rc.4
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -88,7 +88,7 @@ importers:
   packages/cli-conformance:
     devDependencies:
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.3
+        specifier: workspace:8.0.0-rc.4
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -131,10 +131,10 @@ importers:
         version: 8.2.1
     devDependencies:
       '@repo/cli-conformance':
-        specifier: workspace:8.0.0-rc.3
+        specifier: workspace:8.0.0-rc.4
         version: link:../cli-conformance
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.3
+        specifier: workspace:8.0.0-rc.4
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -159,7 +159,7 @@ importers:
         version: 1.2.4
     devDependencies:
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.3
+        specifier: workspace:8.0.0-rc.4
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -177,7 +177,7 @@ importers:
   packages/compute:
     devDependencies:
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.3
+        specifier: workspace:8.0.0-rc.4
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -229,13 +229,13 @@ importers:
         version: 11.0.0
     devDependencies:
       '@prisma/cli':
-        specifier: workspace:8.0.0-rc.3
+        specifier: workspace:8.0.0-rc.4
         version: link:../cli
       '@repo/cli-telemetry':
-        specifier: workspace:8.0.0-rc.3
+        specifier: workspace:8.0.0-rc.4
         version: link:../cli-telemetry
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.3
+        specifier: workspace:8.0.0-rc.4
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19


### PR DESCRIPTION
`8.0.0-rc.3` → `8.0.0-rc.4`. Version fields, `workspace:` pins, and the matching lockfile — no source changes.

Merging this publishes `@prisma/cli-engine`, `@prisma/cli`, and `prisma` under dist-tag **`next`** over npm OIDC trusted publishing, and creates GitHub Release `v8.0.0-rc.4` marked pre-release. `latest` is untouched: it keeps serving Prisma 7 on the bare `prisma` name until the deliberate cutover.

## What makes this release different

It is the first one built entirely on **released** product versions:

| Dependency | Version | Engine relationship |
| --- | --- | --- |
| `@prisma/composer-cli` | `0.7.0` | peers `@prisma/cli-engine@0.1.1` |
| `@prisma/orm-toolchain` | `8.0.0-rc.2` | peers `@prisma/cli-engine@0.1.1` |
| `@prisma/cli-engine` | `0.1.1` | — |

`rc.3` shipped `@prisma/composer@0.6.0-dev.16` and `@prisma/orm-toolchain@8.0.0-rc.1-dev.40` — dev builds, in a release, resolving two copies of the engine. Both products published proper releases today, and the conformance checks now refuse a release whose dependencies are dev builds, so that cannot recur silently.

**One engine per install, verified rather than excused.** ADR 0004's invariant holds for the first time: the exception list in `packages/cli/scripts/conformance.ts` is empty, and the installed-tree check finds a single `@prisma/cli-engine`.

## Verified on this exact tree

- `PUBLISH_CHANNEL=release pnpm check:conformance` → `5 subject(s) checked, nothing to report`. No dev dependencies, one engine, no suppressed findings.
- `pnpm check:grammar` → 10 passed. The assembled command tree lost nothing.
- The bump diff contains version strings only; `@prisma/cli-engine` stays at `0.1.1` and `@prisma/compute` at its own version, both excluded from the lockstep by ruling.

The engine is already published at `0.1.1`, so its publish step is a no-op — an already-published version is treated as done.
