### PR TITLE
The engine-version check diffs against the base branch's current tip

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,5 +79,8 @@ jobs:
 
       - name: The engine version must be new if the engine changed
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: node scripts/check-engine-version.mjs "$BASE_SHA"
+          # The base branch by name: the event's base.sha is recorded when
+          # the pull request is created and goes stale as the base moves,
+          # which blamed other merges' engine changes on unrelated PRs.
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: node scripts/check-engine-version.mjs "origin/$BASE_REF"

--- a/scripts/check-engine-version.mjs
+++ b/scripts/check-engine-version.mjs
@@ -7,7 +7,7 @@
 // `npx prisma@next` crashed on import. The registry is immutable, so a
 // changed engine must claim a new version (`pnpm bump-cli-engine-version`).
 //
-// Usage: node scripts/check-engine-version.mjs <base-sha>
+// Usage: node scripts/check-engine-version.mjs <base-ref>
 
 import { execFile } from "node:child_process";
 import { readFileSync } from "node:fs";
@@ -52,7 +52,7 @@ export function engineBumpVerdict({
 async function main() {
   const baseSha = process.argv[2];
   if (!baseSha) {
-    console.error("Usage: node scripts/check-engine-version.mjs <base-sha>");
+    console.error("Usage: node scripts/check-engine-version.mjs <base-ref>");
     process.exit(1);
   }
 


### PR DESCRIPTION
The check added in #200 diffed against `github.event.pull_request.base.sha`, which is recorded at PR creation and goes stale as the base branch moves. After #200 merged, the check on #201 — a PR that does not touch the engine — diffed across #200's own engine changes and failed. Diffing against `origin/<base ref>` (the checkout has full history) compares only the PR's changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)