### PR TITLE
chore(release): bump to 8.0.0-rc.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-cli",
-  "version": "8.0.0-rc.4",
+  "version": "8.0.0-rc.5",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/packages/cli-conformance/package.json
+++ b/packages/cli-conformance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/cli-conformance",
   "private": true,
-  "version": "8.0.0-rc.4",
+  "version": "8.0.0-rc.5",
   "description": "Reusable conformance checks for the engine's consumers: import purity over built output, config-section validators that never throw, and verification of the tarballs a registry would receive. Depends on no package it checks.",
   "type": "module",
   "exports": {
@@ -24,7 +24,7 @@
     "test": "pnpm run typecheck && vitest run"
   },
   "devDependencies": {
-    "@repo/tsconfig": "workspace:8.0.0-rc.4",
+    "@repo/tsconfig": "workspace:8.0.0-rc.5",
     "@types/node": "^22.19.19",
     "es-module-lexer": "^2.1.0",
     "tsx": "^4.22.4",

--- a/packages/cli-engine/package.json
+++ b/packages/cli-engine/package.json
@@ -55,8 +55,8 @@
     "string-width": "^8.2.1"
   },
   "devDependencies": {
-    "@repo/cli-conformance": "workspace:8.0.0-rc.4",
-    "@repo/tsconfig": "workspace:8.0.0-rc.4",
+    "@repo/cli-conformance": "workspace:8.0.0-rc.5",
+    "@repo/tsconfig": "workspace:8.0.0-rc.5",
     "@types/node": "^22.19.19",
     "ci-info": "^4.3.1",
     "tsdown": "^0.21.10",

--- a/packages/cli-telemetry/package.json
+++ b/packages/cli-telemetry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/cli-telemetry",
   "private": true,
-  "version": "8.0.0-rc.4",
+  "version": "8.0.0-rc.5",
   "description": "CLI telemetry child sender: the detached subprocess the engine hands a composed payload to, its system probes, and the POST",
   "type": "module",
   "sideEffects": [
@@ -35,7 +35,7 @@
     "@vercel/detect-agent": "^1.2.3"
   },
   "devDependencies": {
-    "@repo/tsconfig": "workspace:8.0.0-rc.4",
+    "@repo/tsconfig": "workspace:8.0.0-rc.5",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/cli",
-  "version": "8.0.0-rc.4",
+  "version": "8.0.0-rc.5",
   "description": "Command-line interface for the Prisma Developer Platform.",
   "type": "module",
   "bin": {
@@ -49,11 +49,11 @@
   },
   "dependencies": {
     "@prisma/cli-engine": "workspace:0.2.0",
-    "@prisma/composer-cli": "0.7.0",
+    "@prisma/composer-cli": "0.8.0",
     "@prisma/compute-sdk": "0.39.0",
     "@prisma/credentials-store": "^7.8.0",
     "@prisma/management-api-sdk": "1.55.0",
-    "@prisma/orm-toolchain": "8.0.0-rc.2",
+    "@prisma/orm-toolchain": "8.0.0-rc.3",
     "@vercel/detect-agent": "^1.2.3",
     "better-result": "^2.9.2",
     "dotenv": "^17.4.2",
@@ -61,10 +61,10 @@
     "open": "^11.0.0"
   },
   "devDependencies": {
-    "@prisma/composer": "0.7.0",
-    "@repo/cli-conformance": "workspace:8.0.0-rc.4",
-    "@repo/cli-telemetry": "workspace:8.0.0-rc.4",
-    "@repo/tsconfig": "workspace:8.0.0-rc.4",
+    "@prisma/composer": "0.8.0",
+    "@repo/cli-conformance": "workspace:8.0.0-rc.5",
+    "@repo/cli-telemetry": "workspace:8.0.0-rc.5",
+    "@repo/tsconfig": "workspace:8.0.0-rc.5",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "tsx": "^4.22.4",

--- a/packages/cli/scripts/conformance.ts
+++ b/packages/cli/scripts/conformance.ts
@@ -100,34 +100,13 @@ async function tarball(): Promise<readonly Finding[]> {
       shellPackage: "@prisma/cli",
       enginePackage: "@prisma/cli-engine",
       familyPackages: ["@prisma/composer-cli", "@prisma/orm-toolchain"],
-      // The empty list is the goal state: both families peering the
-      // exact engine version this repo ships, one engine per install
-      // (ADR 0004). The two entries below are an engine version
-      // transition in flight — a family cannot peer an engine version
-      // that is not on the registry, so the engine publishes first and
-      // the mismatch is real until both families release against it.
-      // The entries expire with the versions they name, and the rc.5
-      // bump PR removes them; while they stand, a release could ship
-      // the two-engine install they describe, which is why they must
-      // not outlive the transition.
-      exceptions: [
-        {
-          familyPackage: "@prisma/composer-cli",
-          familyPin: "0.1.1",
-          shellPin: "0.2.0",
-          reason: "engine 0.2.0 must publish before composer-cli can peer it",
-          removeWhen:
-            "composer-cli releases peering 0.2.0 and the 8.0.0-rc.5 bump PR pins that release",
-        },
-        {
-          familyPackage: "@prisma/orm-toolchain",
-          familyPin: "0.1.1",
-          shellPin: "0.2.0",
-          reason: "engine 0.2.0 must publish before orm-toolchain can peer it",
-          removeWhen:
-            "orm-toolchain releases peering 0.2.0 and the 8.0.0-rc.5 bump PR pins that release",
-        },
-      ],
+      // No exceptions. Both families declare @prisma/cli-engine as an
+      // exact peer at the version this repo ships, so one engine
+      // resolves in an install — what ADR 0004 asks for. An entry here
+      // exists only while an engine version transition is in flight
+      // (the engine must publish before a family can peer it), and the
+      // release PR that pins the families' new versions removes it.
+      exceptions: [],
       channel: CHANNEL,
       sandboxDir: join(WORK_DIR, "sandbox"),
     },

--- a/packages/compute/package.json
+++ b/packages/compute/package.json
@@ -42,7 +42,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@repo/tsconfig": "workspace:8.0.0-rc.4",
+    "@repo/tsconfig": "workspace:8.0.0-rc.5",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3",

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma",
-  "version": "8.0.0-rc.4",
+  "version": "8.0.0-rc.5",
   "description": "The Prisma CLI: one binary for the ORM, Composer, and the Prisma Developer Platform.",
   "type": "module",
   "bin": {
@@ -44,11 +44,11 @@
   },
   "dependencies": {
     "@prisma/cli-engine": "workspace:0.2.0",
-    "@prisma/composer-cli": "0.7.0",
+    "@prisma/composer-cli": "0.8.0",
     "@prisma/compute-sdk": "0.39.0",
     "@prisma/credentials-store": "^7.8.0",
     "@prisma/management-api-sdk": "1.55.0",
-    "@prisma/orm-toolchain": "8.0.0-rc.2",
+    "@prisma/orm-toolchain": "8.0.0-rc.3",
     "@vercel/detect-agent": "^1.2.3",
     "better-result": "^2.9.2",
     "dotenv": "^17.4.2",
@@ -56,9 +56,9 @@
     "open": "^11.0.0"
   },
   "devDependencies": {
-    "@prisma/cli": "workspace:8.0.0-rc.4",
-    "@repo/cli-telemetry": "workspace:8.0.0-rc.4",
-    "@repo/tsconfig": "workspace:8.0.0-rc.4",
+    "@prisma/cli": "workspace:8.0.0-rc.5",
+    "@repo/cli-telemetry": "workspace:8.0.0-rc.5",
+    "@repo/tsconfig": "workspace:8.0.0-rc.5",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3"

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/tsconfig",
   "private": true,
-  "version": "8.0.0-rc.4",
+  "version": "8.0.0-rc.5",
   "description": "Base tsconfig providing package for the monorepo",
   "license": "Apache-2.0",
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: workspace:0.2.0
         version: link:../cli-engine
       '@prisma/composer-cli':
-        specifier: 0.7.0
-        version: 0.7.0(@prisma/cli-engine@packages+cli-engine)(@types/node@22.19.19)(magicast@0.5.3)(rollup@4.62.2)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8(@types/node@22.19.19)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(workerd@1.20260704.1)(ws@8.21.0)
+        specifier: 0.8.0
+        version: 0.8.0(@prisma/cli-engine@packages+cli-engine)(@types/node@22.19.19)(magicast@0.5.3)(rollup@4.62.2)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8(@types/node@22.19.19)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(workerd@1.20260704.1)(ws@8.21.0)
       '@prisma/compute-sdk':
         specifier: 0.39.0
         version: 0.39.0(@prisma/management-api-sdk@1.55.0)(rollup@4.62.2)
@@ -39,8 +39,8 @@ importers:
         specifier: 1.55.0
         version: 1.55.0
       '@prisma/orm-toolchain':
-        specifier: 8.0.0-rc.2
-        version: 8.0.0-rc.2(@prisma/cli-engine@packages+cli-engine)(magicast@0.5.3)(typanion@3.14.0)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        specifier: 8.0.0-rc.3
+        version: 8.0.0-rc.3(@prisma/cli-engine@packages+cli-engine)(magicast@0.5.3)(typanion@3.14.0)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vercel/detect-agent':
         specifier: ^1.2.3
         version: 1.2.4
@@ -58,16 +58,16 @@ importers:
         version: 11.0.0
     devDependencies:
       '@prisma/composer':
-        specifier: 0.7.0
-        version: 0.7.0(@types/node@22.19.19)(magicast@0.5.3)(rollup@4.62.2)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8(@types/node@22.19.19)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(workerd@1.20260704.1)(ws@8.21.0)
+        specifier: 0.8.0
+        version: 0.8.0(@types/node@22.19.19)(magicast@0.5.3)(rollup@4.62.2)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8(@types/node@22.19.19)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(workerd@1.20260704.1)(ws@8.21.0)
       '@repo/cli-conformance':
-        specifier: workspace:8.0.0-rc.4
+        specifier: workspace:8.0.0-rc.5
         version: link:../cli-conformance
       '@repo/cli-telemetry':
-        specifier: workspace:8.0.0-rc.4
+        specifier: workspace:8.0.0-rc.5
         version: link:../cli-telemetry
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.4
+        specifier: workspace:8.0.0-rc.5
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -88,7 +88,7 @@ importers:
   packages/cli-conformance:
     devDependencies:
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.4
+        specifier: workspace:8.0.0-rc.5
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -131,10 +131,10 @@ importers:
         version: 8.2.1
     devDependencies:
       '@repo/cli-conformance':
-        specifier: workspace:8.0.0-rc.4
+        specifier: workspace:8.0.0-rc.5
         version: link:../cli-conformance
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.4
+        specifier: workspace:8.0.0-rc.5
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -159,7 +159,7 @@ importers:
         version: 1.2.4
     devDependencies:
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.4
+        specifier: workspace:8.0.0-rc.5
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -177,7 +177,7 @@ importers:
   packages/compute:
     devDependencies:
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.4
+        specifier: workspace:8.0.0-rc.5
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -198,8 +198,8 @@ importers:
         specifier: workspace:0.2.0
         version: link:../cli-engine
       '@prisma/composer-cli':
-        specifier: 0.7.0
-        version: 0.7.0(@prisma/cli-engine@packages+cli-engine)(@types/node@22.19.19)(magicast@0.5.3)(rollup@4.62.2)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8(@types/node@22.19.19)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(workerd@1.20260704.1)(ws@8.21.0)
+        specifier: 0.8.0
+        version: 0.8.0(@prisma/cli-engine@packages+cli-engine)(@types/node@22.19.19)(magicast@0.5.3)(rollup@4.62.2)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8(@types/node@22.19.19)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(workerd@1.20260704.1)(ws@8.21.0)
       '@prisma/compute-sdk':
         specifier: 0.39.0
         version: 0.39.0(@prisma/management-api-sdk@1.55.0)(rollup@4.62.2)
@@ -210,8 +210,8 @@ importers:
         specifier: 1.55.0
         version: 1.55.0
       '@prisma/orm-toolchain':
-        specifier: 8.0.0-rc.2
-        version: 8.0.0-rc.2(@prisma/cli-engine@packages+cli-engine)(magicast@0.5.3)(typanion@3.14.0)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        specifier: 8.0.0-rc.3
+        version: 8.0.0-rc.3(@prisma/cli-engine@packages+cli-engine)(magicast@0.5.3)(typanion@3.14.0)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vercel/detect-agent':
         specifier: ^1.2.3
         version: 1.2.4
@@ -229,13 +229,13 @@ importers:
         version: 11.0.0
     devDependencies:
       '@prisma/cli':
-        specifier: workspace:8.0.0-rc.4
+        specifier: workspace:8.0.0-rc.5
         version: link:../cli
       '@repo/cli-telemetry':
-        specifier: workspace:8.0.0-rc.4
+        specifier: workspace:8.0.0-rc.5
         version: link:../cli-telemetry
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.4
+        specifier: workspace:8.0.0-rc.5
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -1154,15 +1154,15 @@ packages:
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
-  '@prisma/composer-cli@0.7.0':
-    resolution: {integrity: sha512-06GcFYP4UCZ2a2ObARUrYZebJpu42GU5CC4UePOs5ArBvJ9AToCANIF2IFT/tjtIc1N0HU4hp4uBDM1YxyBN+g==}
+  '@prisma/composer-cli@0.8.0':
+    resolution: {integrity: sha512-GZ8mI3BizuatavD0KCaScqZ/pfJKbWtX72dS4tNXIlLEUSB8HM7RMr8BHmMZk/hodNSf6IN0S8N528cYxbJQjg==}
     engines: {node: '>=22.18.0'}
     hasBin: true
     peerDependencies:
-      '@prisma/cli-engine': 0.1.1
+      '@prisma/cli-engine': 0.2.0
 
-  '@prisma/composer@0.7.0':
-    resolution: {integrity: sha512-e9iVz4lIbMyUiTnVw3HCE1PIIrL5U+j7TAbN1mJqweC3VQ2en1nVJ7aFoR6MdRc3AuOeL1Tmef0MKEWFsfW9YA==}
+  '@prisma/composer@0.8.0':
+    resolution: {integrity: sha512-Lfjw0+wxjxssdQoSWbLF8RP1a8tnzf/9Rbtb2f8PVg9npturQEe2WE7WwutrqYFHN4wxkiJeOqzuIgE7O2XlDg==}
     engines: {node: '>=22.18.0'}
 
   '@prisma/compute-sdk@0.39.0':
@@ -1189,18 +1189,18 @@ packages:
   '@prisma/management-api-sdk@1.62.0':
     resolution: {integrity: sha512-XJjNcsMEmvXA2vE88cBSwCQBKiWx3ArGQ00MIFePP653ZdY0Uiaodoyw++WnwewvHqOvpzgSC3XsijjRUuveHQ==}
 
-  '@prisma/orm-framework@8.0.0-rc.2':
-    resolution: {integrity: sha512-GtrL+Ouw7d4wiDEr2VHMGyIcXGBNtiIe2BvRfe6ZpCjSrU7ajDymIbkpDHIz0tVcymp+FO6H4JcBMLuFgD5nSg==}
+  '@prisma/orm-framework@8.0.0-rc.3':
+    resolution: {integrity: sha512-W0MDbaK8S7tJ7Bme/NO4H6MRdJerC+W7nC/92W/6Jb+ANBqYqISGWQxgg0oLMJAQiwsIvZIQk8PIe+/LQujAuQ==}
     peerDependencies:
       typescript: '>=5.9'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@prisma/orm-toolchain@8.0.0-rc.2':
-    resolution: {integrity: sha512-i2pJ0F34sG1pYsLFCBmHL8uHgVIjZsBMvsLKXAHHtQEEaANdsoGR1vBuf07PNk2u1B1qwWxiJepd6zxbVYxq5A==}
+  '@prisma/orm-toolchain@8.0.0-rc.3':
+    resolution: {integrity: sha512-g4S13DZ+YFOKWQvq2YNdqsD26WDeGbh/AvAoZf6xfohVbXFc+LMbCxWQxmbHqCXNuXic4wLxg3nKlE1LpXCTGA==}
     peerDependencies:
-      '@prisma/cli-engine': 0.1.1
+      '@prisma/cli-engine': 0.2.0
       typescript: '>=5.9'
       vite: ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
@@ -4009,10 +4009,10 @@ snapshots:
 
   '@oxc-project/types@0.139.0': {}
 
-  '@prisma/composer-cli@0.7.0(@prisma/cli-engine@packages+cli-engine)(@types/node@22.19.19)(magicast@0.5.3)(rollup@4.62.2)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8(@types/node@22.19.19)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(workerd@1.20260704.1)(ws@8.21.0)':
+  '@prisma/composer-cli@0.8.0(@prisma/cli-engine@packages+cli-engine)(@types/node@22.19.19)(magicast@0.5.3)(rollup@4.62.2)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8(@types/node@22.19.19)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(workerd@1.20260704.1)(ws@8.21.0)':
     dependencies:
       '@prisma/cli-engine': link:packages/cli-engine
-      '@prisma/composer': 0.7.0(@types/node@22.19.19)(magicast@0.5.3)(rollup@4.62.2)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8(@types/node@22.19.19)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(workerd@1.20260704.1)(ws@8.21.0)
+      '@prisma/composer': 0.8.0(@types/node@22.19.19)(magicast@0.5.3)(rollup@4.62.2)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8(@types/node@22.19.19)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(workerd@1.20260704.1)(ws@8.21.0)
       alchemy: 2.0.0-beta.67(@types/node@22.19.19)(effect@4.0.0-beta.103)(rollup@4.62.2)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8(@types/node@22.19.19)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(workerd@1.20260704.1)(ws@8.21.0)
       c12: 3.3.4(magicast@0.5.3)
       effect: 4.0.0-beta.103
@@ -4046,7 +4046,7 @@ snapshots:
       - workerd
       - ws
 
-  '@prisma/composer@0.7.0(@types/node@22.19.19)(magicast@0.5.3)(rollup@4.62.2)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8(@types/node@22.19.19)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(workerd@1.20260704.1)(ws@8.21.0)':
+  '@prisma/composer@0.8.0(@types/node@22.19.19)(magicast@0.5.3)(rollup@4.62.2)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8(@types/node@22.19.19)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(workerd@1.20260704.1)(ws@8.21.0)':
     dependencies:
       '@prisma/management-api-sdk': 1.62.0
       '@standard-schema/spec': 1.1.0
@@ -4146,7 +4146,7 @@ snapshots:
     dependencies:
       openapi-fetch: 0.14.0
 
-  '@prisma/orm-framework@8.0.0-rc.2(typescript@6.0.3)':
+  '@prisma/orm-framework@8.0.0-rc.3(typescript@6.0.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       arktype: 2.2.3
@@ -4155,10 +4155,10 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@prisma/orm-toolchain@8.0.0-rc.2(@prisma/cli-engine@packages+cli-engine)(magicast@0.5.3)(typanion@3.14.0)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@prisma/orm-toolchain@8.0.0-rc.3(@prisma/cli-engine@packages+cli-engine)(magicast@0.5.3)(typanion@3.14.0)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@prisma/cli-engine': link:packages/cli-engine
-      '@prisma/orm-framework': 8.0.0-rc.2(typescript@6.0.3)
+      '@prisma/orm-framework': 8.0.0-rc.3(typescript@6.0.3)
       '@vercel/detect-agent': 1.2.4
       arktype: 2.2.3
       c12: 3.3.4(magicast@0.5.3)


### PR DESCRIPTION
The release that repairs `prisma@next`. rc.4 crashes on import because it was built against engine exports the registry's `@prisma/cli-engine@0.1.1` does not contain; this release depends on `@prisma/cli-engine@0.2.0`, `@prisma/composer-cli@0.8.0` and `@prisma/orm-toolchain@8.0.0-rc.3` — both families peer the exact engine this install carries, so one engine resolves (ADR 0004).

- `node scripts/update-product-versions.mjs --channel release` + `pnpm bump-version`
- The two conformance exceptions that carried the engine transition are removed; the list is empty again.
- `PUBLISH_CHANNEL=release pnpm check:conformance`: **5 subjects checked, nothing to report.** `pnpm check:grammar` passes; 80 script tests pass.

Merging this is the publish trigger for `8.0.0-rc.5` on `next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)