### PR TITLE
Command review for the PM pass, and a validation of the divergence records

### DIFF
--- a/.drive/projects/prisma-cli-v8/assets/briefs/api-app-to-service-rename.md
+++ b/.drive/projects/prisma-cli-v8/assets/briefs/api-app-to-service-rename.md
@@ -1,0 +1,23 @@
+# Brief: Management API — `app` → `service` endpoints (first step only)
+
+For the control-plane repo (pdp-control-plane). Outcome of the CLI command review with product (2026-08-21): the CLI calls the resource a **service**, the API still calls it an **app**. This brief covers the first step only — add the new endpoints and mark the old ones deprecated. Go no further: no removals, no response-shape changes, no SDK or CLI cutover.
+
+## Do
+
+1. **Mount every `/v1/apps…` route a second time under `/v1/services…`**, served by the same handlers. Path parameters rename with the segment (`{appId}` → `{serviceId}`); everything else — request bodies, response bodies, auth, pagination, error codes — is byte-identical between the two paths. Known routes from the CLI's usage: `GET/POST /v1/apps`, `GET /v1/apps/{appId}`, `DELETE /v1/apps/{appId}`, `GET/POST /v1/apps/{appId}/domains`, and the deployment listing/creation routes nested under an app. Cover the full set in the router, not just these.
+2. **Mark the `/v1/apps…` routes deprecated** in the OpenAPI document (`deprecated: true` on each operation, with a description pointing at the `/v1/services` twin) and emit a `Deprecation` response header on them. They keep working unchanged.
+3. **Publish the OpenAPI change** so the generated SDK types gain the new paths. Do not remove or rename any existing type, and do not rename response fields (`appEndpointDomain`, `appId` in bodies, etc.) — field renames are a later step with their own compatibility plan.
+4. Integration tests: one per new route proving the twin returns the same result as the old path for the same input, plus one proving the deprecation header is present on the old path and absent on the new.
+
+## Do not
+
+- Remove, redirect, or change behaviour of any `/v1/apps` route.
+- Rename fields inside request or response bodies.
+- Touch the CLI or the compute SDK's call sites; the CLI keeps using `/v1/apps` until a separate change moves it.
+- Rename internal types, tables, or services — this is the public path surface only.
+
+## Acceptance
+
+- Every `/v1/apps…` operation has a `/v1/services…` twin with identical semantics, covered by a test.
+- The old operations are marked deprecated in OpenAPI and answer with a `Deprecation` header.
+- The regenerated SDK types include the new paths and still include the old ones.

--- a/.drive/projects/prisma-cli-v8/assets/briefs/command-grammar-cleanup.md
+++ b/.drive/projects/prisma-cli-v8/assets/briefs/command-grammar-cleanup.md
@@ -1,0 +1,95 @@
+# Brief: command grammar cleanup (post PM review, 2026-08-21)
+
+Outcome of the command review with product (2026-08-20/21). One PR against `prisma-cli` `main`. No new commands are built; this pass removes, renames and moves existing ones. The shell owns the mount table (`packages/cli/src/cli.ts`), so most moves are mount-table edits plus the strings that name the commands (help summaries, examples, `run-command` next actions, error copy, tests).
+
+## 1. Remove the compute config and `init`
+
+`prisma.compute.ts` / `prisma.compute.json` is deprecated and unsupported. Remove every trace:
+
+- `init` is removed entirely (the command, its help, its tests, `src/commands/init/`, `src/types/init.ts`). `project link` and `project create` already cover directory linking.
+- The service commands stop reading the config: delete `loadComputeConfig` usage in `src/commands/service/target.ts`, the config-target positional (`[service]`) on every service command, `resolveComputeManagementContext`, and the `SERVICE.COMPUTE_CONFIG_INVALID` / `SERVICE.COMPUTE_CONFIG_TARGET_UNKNOWN` error codes.
+- The agent setup-status read of the config (`src/lib/agent/setup-status.ts`) goes; agent status no longer depends on a config file.
+- Delete `src/lib/app/compute-config.ts`, `build-settings.ts`, `deploy-framework.ts`, `build.ts` and whatever else only the config path reached. Drop the `@prisma/compute-sdk/config` import if nothing else needs it.
+
+## 2. Service commands take parameters only
+
+The only ambient context a platform command may use is the directory's project link (`.prisma/local.json`). Everything else comes from flags or env vars.
+
+- **Service:** `--service <name>` or `PRISMA_SERVICE_ID`. Missing → a structured error naming the flag (exit 2), in interactive terminals too. Remove the remembered selection (`readSelectedApp` / `setSelectedApp` / `rememberSelectedService`) and the interactive picker (`ctx.prompt.select` over services in `target.ts`). `service remove`'s local-state cleanup of the selection goes with it.
+- **Branch:** `--branch <name>` only. Remove the current-git-branch inference (`resolveRequestedBranch` / `readLocalGitBranch` in `target.ts`).
+- **Project:** unchanged — `--project`, env override, then the link file.
+
+`project link` keeps its interactive project picker; that command exists to establish the link.
+
+## 3. Verbs: `delete` destroys, `remove` detaches
+
+Rename these commands (paths, ids, help, examples, next actions, error copy, consent questions, tests) — no aliases:
+
+| was | is |
+| --- | --- |
+| `project remove` | `project delete` |
+| `project env remove` | `project env delete` |
+| `postgres remove` | `postgres delete` |
+| `postgres connection remove` | `postgres connection delete` |
+| `service remove` | `service delete` |
+| `service domain remove` | `service domain delete` |
+
+`git disconnect` and `auth … logout` are unchanged. `bucket delete` / `bucket key delete` already conform.
+
+## 4. Moves
+
+| was | is | notes |
+| --- | --- | --- |
+| `postgres restore` | `postgres backup restore` | restore acts on a backup |
+| `ref list` / `ref set` / `ref delete` | `migration ref list` / `set` / `delete` | the `ref` group disappears |
+| `migrate` | `db migrate` | |
+| `format` | `contract format` | |
+| `composer dev` | `dev` | root-level |
+| `composer deploy` | `deploy` | root-level |
+
+No aliases and no redirects for the old spellings (pre-rc, no compatibility debt — the same rule the deployment subgroup followed). An old spelling settles the engine's unknown-command error. For the ORM moves this reverses `prisma-next`'s own retirement of `migration ref` in favour of top-level `ref`; its shipped redirect table (which points `migration ref` → `ref`) must not be mounted as-is — drop or invert those entries.
+
+Moving `dev` / `deploy` to the root fixes Composer's known help-example defect by itself: its examples read `{bin} deploy …`, which becomes correct.
+
+## 5. Removals
+
+- `composer destroy` — dropped.
+- `composer log` — dropped (`dev` streams the same local output in the foreground).
+- The `composer` group — gone once `dev` and `deploy` are at the root; remove its group brief.
+- The `build` group (`build logs`) — the platform build runner is deprecated.
+
+## 6. Housekeeping that must land in the same PR
+
+- The grammar completeness test (`packages/cli/tests/mount-coverage.test.ts`) and any published command list / README / docs pages that enumerate commands.
+- Root help examples (`init` is currently the first example).
+- Every `run-command` next action and help example that names a moved or renamed command; grep for each old spelling across `packages/`.
+- The divergence records under `.drive/projects/prisma-cli-v8/assets/s2/` get a short entry each for the renames and moves; the command review (`assets/command-review.md`) gets regenerated.
+
+## Out of scope
+
+- New commands (`project unlink`, `service domain list`, `bucket show`, `contract validate`, `auth token *`) — deferred by product; do not build.
+- The `app` → `service` API rename — separate brief for the control-plane repo; the CLI keeps calling `/v1/apps` for now.
+- Any change to the ORM commands' behaviour; only their mount paths move.
+
+## Resulting tree (acceptance)
+
+```
+auth         login | logout | whoami | workspace list|use|logout
+project      list | show | create | link | rename | delete | transfer | env add|update|list|delete
+postgres     list | show | create | usage | delete | backup list|restore | connection list|create|rotate|delete
+bucket       list | create | delete | key list|create|delete
+branch       list
+git          connect | disconnect
+service      list | create | show | open | logs | delete
+             deployment list|show|promote|rollback|start|stop|delete
+             domain add|show|delete|retry|wait
+dev | deploy
+contract     emit | infer | format
+db           init | schema | sign | update | verify | migrate
+migration    plan | new | list | show | status | log | graph | check | ref list|set|delete
+orm          init
+lsp
+agent        install | update | status
+telemetry    status | enable | disable
+feedback
+```

--- a/.drive/projects/prisma-cli-v8/assets/command-review.md
+++ b/.drive/projects/prisma-cli-v8/assets/command-review.md
@@ -4,7 +4,7 @@ Every command the CLI mounts, for a semantic review of what each command means a
 
 The tree has five sources: the platform family (this repo), the Composer family (`@prisma/composer-cli`), the ORM family (`@prisma/orm-toolchain`), the engine's telemetry group, and a few local utilities with no owning package.
 
-**The Spec column** compares each command against the original unified-CLI grammar (the consolidate-clis command surface, Layer 4). That document calls its tree "directional, not a launch checklist", so treat mismatches as discussion points, not defects:
+**The Spec column** compares each command against the command surface in the original CLI consolidation plan. That document calls its tree "directional, not a launch checklist", so treat mismatches as discussion points, not defects:
 
 - ✅ — matches the spec's path and meaning
 - ⚠️ — in the spec, but renamed, moved, or reshaped

--- a/.drive/projects/prisma-cli-v8/assets/command-review.md
+++ b/.drive/projects/prisma-cli-v8/assets/command-review.md
@@ -1,0 +1,221 @@
+# Prisma CLI v8 — command review
+
+Every command the CLI mounts, for a semantic review of what each command means and how the tree is organized. Generated from the mounted command tree in `packages/cli/src/cli.ts` at `main` (8.0.0-rc.6, 2026-08-20). Flags and options are deliberately omitted. 90 commands in total.
+
+The tree has five sources: the platform family (this repo), the Composer family (`@prisma/composer-cli`), the ORM family (`@prisma/orm-toolchain`), the engine's telemetry group, and a few local utilities with no owning package.
+
+## Top-level commands
+
+| Command | Meaning |
+| --- | --- |
+| `init` | Write a committed compute config for this app |
+| `format` | Format your PSL contract source |
+| `lsp` | Start the Prisma Next language server |
+| `migrate` | Apply planned migrations to advance the database |
+| `feedback` | Send feedback to the Prisma CLI team |
+
+Notes for the review: `init` is the platform's compute-config wizard; the ORM's project initializer was ruled to `orm init` (operator, 2026-08-12). There is no `version` command — the engine's `--version` answers.
+
+## `auth` — Manage local authentication for the CLI
+
+| Command | Meaning |
+| --- | --- |
+| `auth login` | Log in to your Prisma platform account |
+| `auth logout` | Clear stored authentication credentials |
+| `auth whoami` | Show the authenticated user and accessible workspace |
+
+### `auth workspace` — Manage local workspace sessions
+
+| Command | Meaning |
+| --- | --- |
+| `auth workspace list` | List your workspace sessions |
+| `auth workspace use` | Make one of your workspace sessions current |
+| `auth workspace logout` | End one workspace session |
+
+## `project` — Manage and inspect your Prisma projects
+
+| Command | Meaning |
+| --- | --- |
+| `project list` | List all projects in your workspace |
+| `project show` | Show this directory's Project binding |
+| `project create` | Create a Project and link this directory |
+| `project link` | Link this directory to a Project |
+| `project rename` | Rename the resolved Project |
+| `project remove` | Remove a Project permanently after exact id confirmation |
+| `project transfer` | Transfer a Project to another workspace after exact id confirmation |
+
+### `project env` — Manage environment variables for the active project
+
+| Command | Meaning |
+| --- | --- |
+| `project env add` | Create a new environment variable |
+| `project env update` | Replace an existing environment variable's value |
+| `project env list` | List environment variable metadata for a scope (no values) |
+| `project env remove` | Remove an environment variable from a scope |
+
+## `postgres` — Manage Prisma Postgres databases for a project
+
+| Command | Meaning |
+| --- | --- |
+| `postgres list` | List Prisma Postgres databases for the resolved project |
+| `postgres show` | Show database metadata without secret values |
+| `postgres create` | Create a Prisma Postgres database and print its one-time connection URL |
+| `postgres usage` | Show usage metrics for a database |
+| `postgres restore` | Restore a database from a backup after exact id confirmation |
+| `postgres remove` | Remove a database after exact id confirmation |
+
+### `postgres backup` — Inspect platform-created database backups
+
+| Command | Meaning |
+| --- | --- |
+| `postgres backup list` | List backups for a database |
+
+### `postgres connection` — Manage one-time-view database connection strings
+
+| Command | Meaning |
+| --- | --- |
+| `postgres connection list` | List database connection metadata without secret values |
+| `postgres connection create` | Create a database connection and print its one-time connection URL |
+| `postgres connection rotate` | Rotate connection credentials and print the new one-time connection URL |
+| `postgres connection remove` | Remove a database connection after exact id confirmation |
+
+## `bucket` — Manage object-store buckets for a project
+
+| Command | Meaning |
+| --- | --- |
+| `bucket list` | List object-store buckets for the resolved project |
+| `bucket create` | Create an object-store bucket |
+| `bucket delete` | Delete a bucket and all its access keys |
+
+### `bucket key` — Manage access keys for an object-store bucket
+
+| Command | Meaning |
+| --- | --- |
+| `bucket key list` | List access keys for a bucket |
+| `bucket key create` | Create a bucket access key and print its one-time credentials |
+| `bucket key delete` | Revoke and delete a bucket access key |
+
+## `branch` — View your Platform branches
+
+| Command | Meaning |
+| --- | --- |
+| `branch list` | List Platform branches for the resolved project |
+
+## `git` — Manage Git repository connections for a project
+
+| Command | Meaning |
+| --- | --- |
+| `git connect` | Connect the resolved project to a GitHub repository |
+| `git disconnect` | Disconnect the GitHub repository from the resolved project |
+
+## `service` — Manage services and deployments for a project
+
+| Command | Meaning |
+| --- | --- |
+| `service list` | List the services in a project |
+| `service create` | Create a service in a project |
+| `service show` | Show the service and its current deployment |
+| `service open` | Open the service's live URL |
+| `service logs` | Read logs for a deployment of the service |
+| `service remove` | Remove the service from the resolved branch |
+
+### `service deployment` — Manage deployments for a service
+
+| Command | Meaning |
+| --- | --- |
+| `service deployment list` | List deployments for the service |
+| `service deployment show` | Show a deployment in detail |
+| `service deployment promote` | Promote a deployment to production by rebuilding with production env vars |
+| `service deployment rollback` | Roll back production to a previous deployment |
+| `service deployment start` | Start a stopped deployment |
+| `service deployment stop` | Stop a running deployment |
+| `service deployment delete` | Delete a deployment and the artifact it holds |
+
+### `service domain` — Manage custom domains for a service
+
+| Command | Meaning |
+| --- | --- |
+| `service domain add` | Register a custom domain on the service's production branch |
+| `service domain show` | Show custom domain status and certificate details |
+| `service domain remove` | Detach a custom domain from the service |
+| `service domain retry` | Retry custom domain DNS verification and TLS provisioning |
+| `service domain wait` | Wait until a custom domain is active or failed |
+
+## `build` — Inspect builds created by a git push or Console
+
+| Command | Meaning |
+| --- | --- |
+| `build logs` | Stream logs for a build |
+
+Platform builds are their own group; there is no local build verb.
+
+## `composer` — Run and deploy applications composed from Prisma modules
+
+| Command | Meaning |
+| --- | --- |
+| `composer dev` | Bring up the application whose root node is the entry's default export, entirely on this machine |
+| `composer deploy` | Deploy the application whose root node is the entry's default export |
+| `composer destroy` | Tear down the application whose root node is the entry's default export |
+| `composer log` | Tail the merged logs of the locally-running application whose root node is the entry's default export |
+
+## `contract` — Define and emit your application data contract
+
+| Command | Meaning |
+| --- | --- |
+| `contract emit` | Emit your contract artifacts |
+| `contract infer` | Infer a PSL contract from the live database schema |
+
+## `db` — Verify, sign and update your database against the contract
+
+| Command | Meaning |
+| --- | --- |
+| `db init` | Bootstrap a database to match the current contract and sign it |
+| `db schema` | Inspect the live database schema |
+| `db sign` | Sign the database with your contract so you can safely run queries |
+| `db update` | Update your database schema to match your contract |
+| `db verify` | Check whether the database marker and live schema match your contract |
+
+## `migration` — Plan, inspect and scaffold on-disk migrations
+
+| Command | Meaning |
+| --- | --- |
+| `migration plan` | Plan a migration from contract changes |
+| `migration new` | Scaffold a new migration for manual authoring |
+| `migration list` | List on-disk migrations per contract space |
+| `migration show` | Display migration package contents |
+| `migration status` | Show migration path and pending status |
+| `migration log` | Show executed migration history |
+| `migration graph` | Show the migration graph topology |
+| `migration check` | Verify artifact and graph integrity |
+
+Applying migrations is the top-level `migrate`.
+
+## `ref` — Manage named refs that point at contracts
+
+| Command | Meaning |
+| --- | --- |
+| `ref list` | List every named ref |
+| `ref set` | Point a ref at a contract |
+| `ref delete` | Delete a ref |
+
+## `orm` — Initialize a Prisma ORM project
+
+| Command | Meaning |
+| --- | --- |
+| `orm init` | Initialize a new Prisma Next project |
+
+## `agent` — Manage Prisma skills for AI coding agents
+
+| Command | Meaning |
+| --- | --- |
+| `agent install` | Install Prisma skills for AI coding agents |
+| `agent update` | Refresh Prisma skills for AI coding agents |
+| `agent status` | Show installed Prisma skills |
+
+## `telemetry` — Inspect and change anonymous CLI telemetry
+
+| Command | Meaning |
+| --- | --- |
+| `telemetry status` | Show whether anonymous CLI telemetry is enabled and why |
+| `telemetry enable` | Enable anonymous CLI telemetry |
+| `telemetry disable` | Disable anonymous CLI telemetry |

--- a/.drive/projects/prisma-cli-v8/assets/command-review.md
+++ b/.drive/projects/prisma-cli-v8/assets/command-review.md
@@ -4,218 +4,243 @@ Every command the CLI mounts, for a semantic review of what each command means a
 
 The tree has five sources: the platform family (this repo), the Composer family (`@prisma/composer-cli`), the ORM family (`@prisma/orm-toolchain`), the engine's telemetry group, and a few local utilities with no owning package.
 
+**The Spec column** compares each command against the original unified-CLI grammar (the consolidate-clis command surface, Layer 4). That document calls its tree "directional, not a launch checklist", so treat mismatches as discussion points, not defects:
+
+- ✅ — matches the spec's path and meaning
+- ⚠️ — in the spec, but renamed, moved, or reshaped
+- ❌ — not in the spec tree (added later, or ruled interim)
+
+A recurring ⚠️ theme: the spec's deletion verb is `delete` everywhere (it explicitly avoids `remove` as ambiguous), but the platform groups shipped `remove` where the legacy CLI used it — except `bucket delete`, which followed the spec. Worth one ruling.
+
 ## Top-level commands
 
-| Command | Meaning |
-| --- | --- |
-| `init` | Write a committed compute config for this app |
-| `format` | Format your PSL contract source |
-| `lsp` | Start the Prisma Next language server |
-| `migrate` | Apply planned migrations to advance the database |
-| `feedback` | Send feedback to the Prisma CLI team |
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `init` | Write a committed compute config for this app | ⚠️ spec's `init` is the single guided entry point; shipped as the compute-config wizard, with the ORM initializer split to `orm init` |
+| `format` | Format your PSL contract source | ⚠️ spec: `contract format` |
+| `lsp` | Start the Prisma Next language server | ❌ not in the spec tree |
+| `migrate` | Apply planned migrations to advance the database | ⚠️ spec: `db migrate` |
+| `feedback` | Send feedback to the Prisma CLI team | ✅ |
 
-Notes for the review: `init` is the platform's compute-config wizard; the ORM's project initializer was ruled to `orm init` (operator, 2026-08-12). There is no `version` command — the engine's `--version` answers.
+There is no `version` command — the engine's `--version` answers (spec listed `version` as a utility; removed by ruling 2026-08-11).
 
 ## `auth` — Manage local authentication for the CLI
 
-| Command | Meaning |
-| --- | --- |
-| `auth login` | Log in to your Prisma platform account |
-| `auth logout` | Clear stored authentication credentials |
-| `auth whoami` | Show the authenticated user and accessible workspace |
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `auth login` | Log in to your Prisma platform account | ✅ |
+| `auth logout` | Clear stored authentication credentials | ✅ |
+| `auth whoami` | Show the authenticated user and accessible workspace | ✅ |
 
 ### `auth workspace` — Manage local workspace sessions
 
-| Command | Meaning |
-| --- | --- |
-| `auth workspace list` | List your workspace sessions |
-| `auth workspace use` | Make one of your workspace sessions current |
-| `auth workspace logout` | End one workspace session |
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `auth workspace list` | List your workspace sessions | ✅ |
+| `auth workspace use` | Make one of your workspace sessions current | ✅ |
+| `auth workspace logout` | End one workspace session | ✅ |
 
 ## `project` — Manage and inspect your Prisma projects
 
-| Command | Meaning |
-| --- | --- |
-| `project list` | List all projects in your workspace |
-| `project show` | Show this directory's Project binding |
-| `project create` | Create a Project and link this directory |
-| `project link` | Link this directory to a Project |
-| `project rename` | Rename the resolved Project |
-| `project remove` | Remove a Project permanently after exact id confirmation |
-| `project transfer` | Transfer a Project to another workspace after exact id confirmation |
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `project list` | List all projects in your workspace | ✅ |
+| `project show` | Show this directory's Project binding | ✅ |
+| `project create` | Create a Project and link this directory | ✅ |
+| `project link` | Link this directory to a Project | ✅ |
+| `project rename` | Rename the resolved Project | ✅ |
+| `project remove` | Remove a Project permanently after exact id confirmation | ⚠️ spec: `project delete` |
+| `project transfer` | Transfer a Project to another workspace after exact id confirmation | ✅ |
 
 ### `project env` — Manage environment variables for the active project
 
-| Command | Meaning |
-| --- | --- |
-| `project env add` | Create a new environment variable |
-| `project env update` | Replace an existing environment variable's value |
-| `project env list` | List environment variable metadata for a scope (no values) |
-| `project env remove` | Remove an environment variable from a scope |
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `project env add` | Create a new environment variable | ✅ |
+| `project env update` | Replace an existing environment variable's value | ✅ |
+| `project env list` | List environment variable metadata for a scope (no values) | ✅ |
+| `project env remove` | Remove an environment variable from a scope | ⚠️ spec: `project env delete` |
 
 ## `postgres` — Manage Prisma Postgres databases for a project
 
-| Command | Meaning |
-| --- | --- |
-| `postgres list` | List Prisma Postgres databases for the resolved project |
-| `postgres show` | Show database metadata without secret values |
-| `postgres create` | Create a Prisma Postgres database and print its one-time connection URL |
-| `postgres usage` | Show usage metrics for a database |
-| `postgres restore` | Restore a database from a backup after exact id confirmation |
-| `postgres remove` | Remove a database after exact id confirmation |
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `postgres list` | List Prisma Postgres databases for the resolved project | ✅ |
+| `postgres show` | Show database metadata without secret values | ✅ |
+| `postgres create` | Create a Prisma Postgres database and print its one-time connection URL | ✅ |
+| `postgres usage` | Show usage metrics for a database | ✅ |
+| `postgres restore` | Restore a database from a backup after exact id confirmation | ⚠️ spec: `postgres backup restore` |
+| `postgres remove` | Remove a database after exact id confirmation | ⚠️ spec: `postgres delete` |
 
 ### `postgres backup` — Inspect platform-created database backups
 
-| Command | Meaning |
-| --- | --- |
-| `postgres backup list` | List backups for a database |
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `postgres backup list` | List backups for a database | ✅ |
 
 ### `postgres connection` — Manage one-time-view database connection strings
 
-| Command | Meaning |
-| --- | --- |
-| `postgres connection list` | List database connection metadata without secret values |
-| `postgres connection create` | Create a database connection and print its one-time connection URL |
-| `postgres connection rotate` | Rotate connection credentials and print the new one-time connection URL |
-| `postgres connection remove` | Remove a database connection after exact id confirmation |
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `postgres connection list` | List database connection metadata without secret values | ✅ |
+| `postgres connection create` | Create a database connection and print its one-time connection URL | ✅ |
+| `postgres connection rotate` | Rotate connection credentials and print the new one-time connection URL | ✅ |
+| `postgres connection remove` | Remove a database connection after exact id confirmation | ⚠️ spec: `postgres connection delete` |
 
 ## `bucket` — Manage object-store buckets for a project
 
-| Command | Meaning |
-| --- | --- |
-| `bucket list` | List object-store buckets for the resolved project |
-| `bucket create` | Create an object-store bucket |
-| `bucket delete` | Delete a bucket and all its access keys |
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `bucket list` | List object-store buckets for the resolved project | ✅ |
+| `bucket create` | Create an object-store bucket | ✅ |
+| `bucket delete` | Delete a bucket and all its access keys | ✅ |
 
 ### `bucket key` — Manage access keys for an object-store bucket
 
-| Command | Meaning |
-| --- | --- |
-| `bucket key list` | List access keys for a bucket |
-| `bucket key create` | Create a bucket access key and print its one-time credentials |
-| `bucket key delete` | Revoke and delete a bucket access key |
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `bucket key list` | List access keys for a bucket | ✅ |
+| `bucket key create` | Create a bucket access key and print its one-time credentials | ✅ |
+| `bucket key delete` | Revoke and delete a bucket access key | ✅ |
 
 ## `branch` — View your Platform branches
 
-| Command | Meaning |
-| --- | --- |
-| `branch list` | List Platform branches for the resolved project |
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `branch list` | List Platform branches for the resolved project | ✅ |
 
 ## `git` — Manage Git repository connections for a project
 
-| Command | Meaning |
-| --- | --- |
-| `git connect` | Connect the resolved project to a GitHub repository |
-| `git disconnect` | Disconnect the GitHub repository from the resolved project |
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `git connect` | Connect the resolved project to a GitHub repository | ✅ |
+| `git disconnect` | Disconnect the GitHub repository from the resolved project | ✅ |
 
 ## `service` — Manage services and deployments for a project
 
-| Command | Meaning |
-| --- | --- |
-| `service list` | List the services in a project |
-| `service create` | Create a service in a project |
-| `service show` | Show the service and its current deployment |
-| `service open` | Open the service's live URL |
-| `service logs` | Read logs for a deployment of the service |
-| `service remove` | Remove the service from the resolved branch |
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `service list` | List the services in a project | ✅ |
+| `service create` | Create a service in a project | ❌ not in the spec tree (there, a service comes into existence by deploying) |
+| `service show` | Show the service and its current deployment | ✅ |
+| `service open` | Open the service's live URL | ✅ |
+| `service logs` | Read logs for a deployment of the service | ✅ |
+| `service remove` | Remove the service from the resolved branch | ⚠️ spec: `service delete` |
 
 ### `service deployment` — Manage deployments for a service
 
-| Command | Meaning |
-| --- | --- |
-| `service deployment list` | List deployments for the service |
-| `service deployment show` | Show a deployment in detail |
-| `service deployment promote` | Promote a deployment to production by rebuilding with production env vars |
-| `service deployment rollback` | Roll back production to a previous deployment |
-| `service deployment start` | Start a stopped deployment |
-| `service deployment stop` | Stop a running deployment |
-| `service deployment delete` | Delete a deployment and the artifact it holds |
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `service deployment list` | List deployments for the service | ✅ |
+| `service deployment show` | Show a deployment in detail | ✅ |
+| `service deployment promote` | Promote a deployment to production by rebuilding with production env vars | ⚠️ spec: flat `service promote` (a Service-level traffic action) |
+| `service deployment rollback` | Roll back production to a previous deployment | ⚠️ spec: flat `service rollback` |
+| `service deployment start` | Start a stopped deployment | ❌ not in the spec tree |
+| `service deployment stop` | Stop a running deployment | ❌ not in the spec tree |
+| `service deployment delete` | Delete a deployment and the artifact it holds | ❌ not in the spec tree |
 
 ### `service domain` — Manage custom domains for a service
 
-| Command | Meaning |
-| --- | --- |
-| `service domain add` | Register a custom domain on the service's production branch |
-| `service domain show` | Show custom domain status and certificate details |
-| `service domain remove` | Detach a custom domain from the service |
-| `service domain retry` | Retry custom domain DNS verification and TLS provisioning |
-| `service domain wait` | Wait until a custom domain is active or failed |
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `service domain add` | Register a custom domain on the service's production branch | ✅ |
+| `service domain show` | Show custom domain status and certificate details | ✅ |
+| `service domain remove` | Detach a custom domain from the service | ⚠️ spec: `service domain delete` |
+| `service domain retry` | Retry custom domain DNS verification and TLS provisioning | ❌ not in the spec tree |
+| `service domain wait` | Wait until a custom domain is active or failed | ❌ not in the spec tree |
 
 ## `build` — Inspect builds created by a git push or Console
 
-| Command | Meaning |
-| --- | --- |
-| `build logs` | Stream logs for a build |
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `build logs` | Stream logs for a build | ❌ no `build` group in the spec; it covers build output via `service deployment logs` ("deployment logs also cover builds triggered by Git push") |
 
 Platform builds are their own group; there is no local build verb.
 
 ## `composer` — Run and deploy applications composed from Prisma modules
 
-| Command | Meaning |
-| --- | --- |
-| `composer dev` | Bring up the application whose root node is the entry's default export, entirely on this machine |
-| `composer deploy` | Deploy the application whose root node is the entry's default export |
-| `composer destroy` | Tear down the application whose root node is the entry's default export |
-| `composer log` | Tail the merged logs of the locally-running application whose root node is the entry's default export |
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `composer dev` | Bring up the application whose root node is the entry's default export, entirely on this machine | ❌ |
+| `composer deploy` | Deploy the application whose root node is the entry's default export | ❌ |
+| `composer destroy` | Tear down the application whose root node is the entry's default export | ❌ |
+| `composer log` | Tail the merged logs of the locally-running application whose root node is the entry's default export | ❌ |
+
+The spec bans product-named groups ("there is no `prisma composer`") and points this workload at `project dev/deploy/…`. The `composer` root is ruled interim parking (operator, 2026-08-10); the final grammar stays open as TML-3189.
 
 ## `contract` — Define and emit your application data contract
 
-| Command | Meaning |
-| --- | --- |
-| `contract emit` | Emit your contract artifacts |
-| `contract infer` | Infer a PSL contract from the live database schema |
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `contract emit` | Emit your contract artifacts | ✅ |
+| `contract infer` | Infer a PSL contract from the live database schema | ✅ |
 
 ## `db` — Verify, sign and update your database against the contract
 
-| Command | Meaning |
-| --- | --- |
-| `db init` | Bootstrap a database to match the current contract and sign it |
-| `db schema` | Inspect the live database schema |
-| `db sign` | Sign the database with your contract so you can safely run queries |
-| `db update` | Update your database schema to match your contract |
-| `db verify` | Check whether the database marker and live schema match your contract |
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `db init` | Bootstrap a database to match the current contract and sign it | ✅ |
+| `db schema` | Inspect the live database schema | ✅ |
+| `db sign` | Sign the database with your contract so you can safely run queries | ✅ |
+| `db update` | Update your database schema to match your contract | ✅ |
+| `db verify` | Check whether the database marker and live schema match your contract | ✅ |
+
+Applying migrations is the top-level `migrate` (spec: `db migrate`).
 
 ## `migration` — Plan, inspect and scaffold on-disk migrations
 
-| Command | Meaning |
-| --- | --- |
-| `migration plan` | Plan a migration from contract changes |
-| `migration new` | Scaffold a new migration for manual authoring |
-| `migration list` | List on-disk migrations per contract space |
-| `migration show` | Display migration package contents |
-| `migration status` | Show migration path and pending status |
-| `migration log` | Show executed migration history |
-| `migration graph` | Show the migration graph topology |
-| `migration check` | Verify artifact and graph integrity |
-
-Applying migrations is the top-level `migrate`.
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `migration plan` | Plan a migration from contract changes | ✅ |
+| `migration new` | Scaffold a new migration for manual authoring | ✅ |
+| `migration list` | List on-disk migrations per contract space | ✅ |
+| `migration show` | Display migration package contents | ✅ |
+| `migration status` | Show migration path and pending status | ✅ |
+| `migration log` | Show executed migration history | ✅ |
+| `migration graph` | Show the migration graph topology | ✅ |
+| `migration check` | Verify artifact and graph integrity | ✅ |
 
 ## `ref` — Manage named refs that point at contracts
 
-| Command | Meaning |
-| --- | --- |
-| `ref list` | List every named ref |
-| `ref set` | Point a ref at a contract |
-| `ref delete` | Delete a ref |
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `ref list` | List every named ref | ⚠️ spec: `migration ref list` ("refs stay inside the `migration` group") |
+| `ref set` | Point a ref at a contract | ⚠️ spec: `migration ref set` |
+| `ref delete` | Delete a ref | ⚠️ spec: `migration ref delete` |
 
 ## `orm` — Initialize a Prisma ORM project
 
-| Command | Meaning |
-| --- | --- |
-| `orm init` | Initialize a new Prisma Next project |
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `orm init` | Initialize a new Prisma Next project | ❌ not in the spec tree; ruled 2026-08-12 to resolve the two families' claim on `init` |
 
 ## `agent` — Manage Prisma skills for AI coding agents
 
-| Command | Meaning |
-| --- | --- |
-| `agent install` | Install Prisma skills for AI coding agents |
-| `agent update` | Refresh Prisma skills for AI coding agents |
-| `agent status` | Show installed Prisma skills |
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `agent install` | Install Prisma skills for AI coding agents | ✅ |
+| `agent update` | Refresh Prisma skills for AI coding agents | ✅ |
+| `agent status` | Show installed Prisma skills | ✅ |
 
 ## `telemetry` — Inspect and change anonymous CLI telemetry
 
-| Command | Meaning |
-| --- | --- |
-| `telemetry status` | Show whether anonymous CLI telemetry is enabled and why |
-| `telemetry enable` | Enable anonymous CLI telemetry |
-| `telemetry disable` | Disable anonymous CLI telemetry |
+| Command | Meaning | Spec |
+| --- | --- | --- |
+| `telemetry status` | Show whether anonymous CLI telemetry is enabled and why | ✅ |
+| `telemetry enable` | Enable anonymous CLI telemetry | ✅ |
+| `telemetry disable` | Disable anonymous CLI telemetry | ✅ |
+
+## In the spec, not shipped
+
+For completeness of the comparison — the spec-tree commands with no shipped counterpart today:
+
+- **Orchestration:** `project check | dev | plan | deploy | status`, `project adopt | detach`, `project unlink`
+- **Branch lifecycle:** `branch create | show | delete` (spec deliberately deferred create/delete until workflow-created branches prove the need)
+- **Service:** `service build | run | deploy` (ruled removals — Composer supersedes them), `service deployment logs`, `service domain list`
+- **Postgres:** `postgres update`, `postgres backup create | delete` (and `restore` as a backup subcommand)
+- **Bucket:** `bucket show`
+- **Git:** `git status`
+- **Data world:** `db query | browse | seed`, `contract validate`
+- **Auth:** `auth token create | list | delete`
+- **Emulators:** `emulator start | stop | status`
+- **Utilities:** `version` (ruled removal; `--version` answers), `mcp`, `project env pull`

--- a/.drive/projects/prisma-cli-v8/assets/command-review.md
+++ b/.drive/projects/prisma-cli-v8/assets/command-review.md
@@ -12,11 +12,13 @@ The tree has five sources: the platform family (this repo), the Composer family 
 
 A recurring ⚠️ theme: the spec's deletion verb is `delete` everywhere (it explicitly avoids `remove` as ambiguous), but the platform groups shipped `remove` where the legacy CLI used it — except `bucket delete`, which followed the spec. Worth one ruling.
 
+**Pending proposal (2026-08-20): platform commands take parameters only.** `prisma.compute.ts` turned out to be deprecated, and the proposed response is to strip the platform commands' ambient resolution down to one thing: parameters (flags and env vars), plus the directory's project link, which the product team keeps. The compute-config read, the remembered service selection, the interactive service picker, and the git-branch inference would all go, and `init` — whose sole output is the deprecated file — shrinks to its link step pending a new meaning. Detailed in the divergence catalog. Affects the meaning of `init` and the resolution behaviour of every `service`, `postgres`, `bucket`, `branch`, and `git` command below, but no command paths.
+
 ## Top-level commands
 
 | Command | Meaning | Spec |
 | --- | --- | --- |
-| `init` | Write a committed compute config for this app | ⚠️ spec's `init` is the single guided entry point; shipped as the compute-config wizard, with the ORM initializer split to `orm init` |
+| `init` | Write a committed compute config for this app — **but `prisma.compute.ts` is deprecated; under the pending proposal, `init` shrinks to its project-link step pending a new meaning** | ⚠️ spec's `init` is the single guided entry point; shipped as the compute-config wizard, with the ORM initializer split to `orm init` |
 | `format` | Format your PSL contract source | ⚠️ spec: `contract format` |
 | `lsp` | Start the Prisma Next language server | ❌ not in the spec tree |
 | `migrate` | Apply planned migrations to advance the database | ⚠️ spec: `db migrate` |

--- a/.drive/projects/prisma-cli-v8/assets/divergence-catalog.md
+++ b/.drive/projects/prisma-cli-v8/assets/divergence-catalog.md
@@ -1,149 +1,168 @@
 # Prisma CLI v8 — divergence catalog
 
-Everything the v8 CLI deliberately does differently from the CLIs it replaces, in one document. Compiled from the five parity-divergence records and the engine-global baseline, corrected to what actually ships at `main` (8.0.0-rc.6, 2026-08-20) — the per-slice records predate some later changes, and this catalog reflects the shipped state.
+Everything v8 deliberately does differently from the three CLIs it replaces (`prisma-cli`, `prisma-composer`, `prisma-next`), corrected to what ships at rc.6 (2026-08-20). Compiled from the five parity-divergence records; the ratified record is from 2026-08-12. Detail lives in those records — this is the review-friendly version.
 
-Three baselines apply, because v8 absorbs three CLIs: the platform CLI (`prisma-cli`), Composer's own CLI (`prisma-composer`), and the ORM CLI (`prisma-next`). Each section says which baseline it compares against. The cumulative record was ratified by the operator on 2026-08-12; entries marked **open** still need a ruling.
+**TL;DR**
+
+- Output, exit codes, error codes, and consent are unified engine-wide; JSON is now a machine-friendly event stream and piped output is JSON automatically.
+- Renames: `database` → `postgres`, `app` → `service`, deployment verbs under `service deployment`. Removals: `app build/deploy/run` (Composer supersedes), `version`, auto-login, fixture mode, `--trace`.
+- Destructive commands now ask you to type the exact id/name; `--yes` never grants consent.
+- Nine items still need a ruling — listed at the end, the parameters-only proposal first.
 
 ## Proposed ruling (2026-08-20, for discussion): platform commands take parameters only
 
-Prompted by the discovery that `prisma.compute.ts` — the file `init` writes and the service commands read — is deprecated and no longer supported. The proposal: **platform commands operate on their parameters; the only ambient context is the directory's project link.** Concretely:
+`prisma.compute.ts` — the file `init` writes and the service commands read — is **deprecated and no longer supported**. Proposal:
 
-- **Project** resolves from `--project`, else the env override, else the local project link (`.prisma/local.json`). The link stays — the product team wants it — so `project link`, `project create`'s auto-link, and `project show`'s binding keep their meaning.
-- **Service** resolves from `--service` or `PRISMA_SERVICE_ID` only. The compute-config default, the remembered selection in local state, and the interactive picker are removed.
-- **Branch** resolves from `--branch` only. The current-git-branch inference is removed.
-- **The compute config is dead everywhere:** `init`'s write, the service commands' read, the config-target positional, the `SERVICE.COMPUTE_CONFIG_*` error codes, and the agent setup-status read. `init` shrinks to its link step (the one part of today's command that survives) plus whatever new meaning the product gives it.
+| Dimension | Resolves from | What goes |
+| --- | --- | --- |
+| Project | `--project`, env override, the local project link (**kept**, per product team) | nothing — `project link`/`show`/`create` keep their meaning |
+| Service | `--service` / `PRISMA_SERVICE_ID` only | compute-config default, remembered selection, interactive picker |
+| Branch | `--branch` only | current-git-branch inference |
+| Compute config | — | dead everywhere: `init`'s write, service reads, the config-target positional, `SERVICE.COMPUTE_CONFIG_*` codes |
 
-This is a deliberate reversal of the original spec's resolution layer (Layer 3: git mapping, prompts, auto-creating projects), not a refinement of it. Ergonomics move above the platform commands — into orchestration or a future config section — and the platform commands become plain plumbing over the API.
+`init` shrinks to its project-link step pending a new meaning. This deliberately reverses the original spec's resolution layer; ergonomics move above the platform commands, which become plain plumbing over the API.
 
-## 1. Global changes — every command, versus the legacy platform CLI
+## 1. Global changes (every command)
 
-These hold for every ported command and are the largest single source of visible difference.
-
-1. **JSON output is an event stream, not one object.** Legacy printed one pretty-printed JSON envelope. v8 prints newline-delimited frames (events plus exactly one final result frame). Inside the envelope: `command` → `commandId`, `warnings: string[]` → typed coded `diagnostics`, `nextSteps: string[]` → typed `nextActions`, and the exit code is now included. Result payloads themselves are mostly unchanged.
-2. **Output format is auto-selected.** Human output only when stdout is a terminal; piped output is JSON automatically. Legacy was human unless `--json` was passed.
-3. **Human mode writes a machine-usable payload to stdout.** Presentation (cards, tables, commentary) goes to stderr, exactly where legacy wrote it; the data rows additionally go to stdout with raw, unformatted values (no placeholders like `none`, byte counts instead of `2.0 KiB`). Legacy human mode wrote nothing to stdout. Piping a v8 command yields usable data.
-4. **Exit codes are unified.** Expected errors exit 2, a cancelled prompt exits 3, exit 1 is reserved for bugs (`CLI.INTERNAL_ERROR`), signals exit 128 + signal number (130 for Ctrl-C). Legacy exited 1 or 2 per error type.
-5. **Error codes are dotted and namespaced.** `PROJECT_NOT_FOUND` → `PROJECT.NOT_FOUND`, `DATABASE_API_ERROR` → `POSTGRES.API_ERROR`, and so on. Each code gets its own docs link.
-6. **Remediation is typed.** Legacy `fix` prose becomes one `user-choice` next action; each `nextSteps` string becomes a `run-command` action; URLs become `open-url` actions. Package-runner command strings (`npx -y @prisma/cli@latest …`) are dropped from next actions in favour of plain `prisma-cli …`.
-7. **Consent is engine-owned and stronger.** Destructive commands ask the user to type the exact id or name of the thing being destroyed (interactively) or pass `--confirm <that value>` (scripted). `--yes` never grants consent. Several commands that had only a flag, or asked nothing at all, now prompt. Cancelling a prompt exits 3 — a code these commands never produced before.
-8. **Auto-login is gone.** An unauthenticated run settles `CLI.CREDENTIALS_REQUIRED` (exit 2) instead of opening a browser sign-in mid-command.
-9. **Flags:** the shared family is `--format/--json`, `--log-level/-v/--verbose`, `-q/--quiet`, `-y/--yes`, `--confirm`, `--interactive/--no-interactive`, `--color/--no-color`, `-h/--help`. `--trace` no longer exists (log levels cover it); `--quiet` is just a log-level alias. `--verbose` is a log level, so the legacy "verbose context" blocks in results are gone.
-10. **No `version` command** (ruled removal). `prisma --version` answers, printing the version alone. The legacy command's extra facts (invocation kind, node version, platform) had no consumer worth porting.
-11. **Mock/fixture mode is gone** entirely, along with the fixture-only flags and error codes.
-12. **Rendering style.** Human output is the engine's block style. The aligned, accent-coloured key columns of the legacy cards are back byte-for-byte; still missing are the dim `│` rail framing and the `command → description` header line (deferred, per-command opt-in exists).
+| Change | What you see now |
+| --- | --- |
+| JSON is an event stream | Newline-delimited frames + one result frame. `command`→`commandId`, `warnings`→coded `diagnostics`, `nextSteps`→typed `nextActions`, exit code included |
+| Format auto-selects | Human only when stdout is a terminal; piped output is JSON |
+| stdout carries data in human mode | Presentation on stderr (as before); raw data rows on stdout, so piping works. Legacy wrote nothing to stdout |
+| Exit codes unified | 2 = expected error, 3 = cancelled prompt, 1 = bug only, 130/143 = signals |
+| Error codes dotted | `PROJECT.NOT_FOUND`, `POSTGRES.API_ERROR`, … — each gets a docs link |
+| Remediation typed | `fix` prose → `user-choice` action; `nextSteps` → `run-command` actions; URLs → `open-url` actions |
+| Consent engine-owned | Type the exact id/name, or `--confirm <value>` in scripts. `--yes` never grants consent. Cancel = exit 3 |
+| Auto-login gone | Unauthenticated runs fail with `CLI.CREDENTIALS_REQUIRED` instead of opening a browser |
+| Flags | Shared family (`--format`, `--log-level`, `--quiet`, `--yes`, `--confirm`, `--interactive`, `--color`). `--trace` gone; `--verbose` is a log level, so "verbose context" blocks are gone |
+| `version` removed | `prisma --version` answers |
+| Fixture/mock mode gone | Including its flags and error codes |
+| Rendering | Engine block style; legacy card alignment/colours restored byte-for-byte; the `│` rail framing and header line are deferred |
 
 ## 2. Renames and removals
 
-1. **`database` → `postgres`.** The whole group: paths, ids, help, error copy. No alias.
-2. **`app` → `service`.** The whole group, including `--app` → `--service`, result fields, error copy, and `PRISMA_APP_ID` → `PRISMA_SERVICE_ID`. No alias.
-3. **The deployment verbs moved under `service deployment`** (S8, no aliases): `service list-deploys` → `service deployment list`, `service show-deploy` → `service deployment show`, `service promote` → `service deployment promote`, `service rollback` → `service deployment rollback`. Command ids in JSON moved with them (`service.deployment.list` etc.). Old spellings answer `CLI.UNKNOWN_COMMAND`.
-4. **Ruled removals:** `app build`, `app deploy`, `app run` — Composer supersedes all three; deploy's build-locally-and-upload shape was judged wrong, not just redundant. Also removed: `auth logout --workspace` (use `auth workspace logout`), the `rm` alias on `project env remove`, and the mock-only login flags.
-5. **Top-level `init` is the platform's compute-config wizard; the ORM's initializer is `orm init`** (ruled 2026-08-12). A `prisma-next` user typing `prisma init` expecting a schema scaffold gets the compute wizard.
-6. **Telemetry environment variables and the preference file drop the `prisma-next` name**: `PRISMA_DISABLE_TELEMETRY`, `PRISMA_TELEMETRY_ENDPOINT`, `PRISMA_DEBUG`; preference stored under `prisma/`. No fallback to the old names or path — an existing opt-out at the old location reverts to the default. `DO_NOT_TRACK` still works.
+| Was | Is | Notes |
+| --- | --- | --- |
+| `database …` | `postgres …` | Whole group, no alias |
+| `app …` | `service …` | Whole group, incl. `--app`→`--service`, `PRISMA_APP_ID`→`PRISMA_SERVICE_ID` |
+| `service list-deploys` / `show-deploy` / `promote` / `rollback` | `service deployment list` / `show` / `promote` / `rollback` | No aliases; JSON command ids moved too |
+| `app build` / `app deploy` / `app run` | — | Ruled drops; Composer supersedes. Deploy's build-locally-and-upload shape judged wrong |
+| `version`, `auth logout --workspace`, `rm` alias, mock login flags | — | Ruled removals |
+| `prisma init` (ORM scaffold) | `orm init` | Top-level `init` is the platform wizard (ruled 2026-08-12) |
+| `PRISMA_NEXT_DISABLE_TELEMETRY` etc. | `PRISMA_DISABLE_TELEMETRY` etc. | No fallback: an old-path opt-out reverts to default. `DO_NOT_TRACK` still works |
 
-## 3. Authentication — the session model
+## 3. Authentication
 
-The auth family sits on a new credential model: a set of stored per-workspace sessions plus one selection, and — separately — the credential the current process authenticates as, which may come from `PRISMA_SERVICE_TOKEN` and is not a session.
+New model: stored per-workspace **sessions** plus one selection; `PRISMA_SERVICE_TOKEN` is a separate credential, not a session.
 
-1. **Mutations succeed while `PRISMA_SERVICE_TOKEN` is set.** `auth login`, `auth logout`, `auth workspace use`, `auth workspace logout` all operate on the stored sessions and print a one-line notice that the environment credential remains in force. Legacy refused workspace switching in that state.
-2. **`auth logout` ends every session** and reports how many, reaping orphaned entries legacy left behind.
-3. **`auth workspace use` selects only** — it never creates a session or opens a browser. A workspace you have no session for is `AUTH.NO_SESSION_FOR_WORKSPACE`; the fix is `auth login`.
-4. **`auth whoami` describes the active credential**, not an auth-state snapshot: `source` (`stored`/`environment`) and `expiresAt` are new; the identity-provider field is gone (nothing records it); a service token reports no user (its subject is a workspace, not a person); a credential naming no workspace reports `workspace: null`.
-5. **Workspace names are not refreshed on read.** Fetched once at login, best-effort; a rename in the Console shows up locally only after the next login. Legacy re-fetched on every read.
-6. **Ending a session is idempotent** — if another process already removed it, the command exits 0.
-7. **A near-expiry stored session is refreshed and persisted before delegated runs; only an unrefreshable credential is refused.** (Later change; the S3 record's "refused up front" wording predates it.)
-8. **Open — escalated engine gap:** a service token that the platform associates with a workspace, but whose own claims name none, is now refused (`SERVICE.WORKSPACE_REQUIRED`). Legacy asked the server (`/v1/me`) and carried on when the server named one. v8 commands never fetch their own identity from the network; if a server round-trip is wanted, it belongs in the credential manager. Ruling needed: complete the workspace server-side, or require every issued token to carry the claim.
+| Change | What you see now |
+| --- | --- |
+| Mutations work under `PRISMA_SERVICE_TOKEN` | login/logout/workspace commands operate on stored sessions, with a notice that the env credential stays in force. Legacy refused switching |
+| `auth logout` ends every session | Reports the count; reaps orphaned entries |
+| `auth workspace use` selects only | Never creates a session or opens a browser |
+| `auth whoami` describes the credential | `source` and `expiresAt` new; provider field gone; a service token reports no user; no-workspace credential reports `workspace: null` |
+| Names not refreshed on read | A Console rename shows locally only after the next login |
+| Session logout is idempotent | Already-removed session → exit 0 |
+| Near-expiry sessions refresh | Refreshed and persisted before delegated runs; only unrefreshable credentials are refused |
 
-## 4. Resource groups — project, postgres, bucket, branch, git
+**Open:** a service token whose workspace only the server knows is now refused (legacy asked `/v1/me`). Ruling: complete it server-side in the credential manager, or require the claim on every token.
 
-On top of the global changes:
+## 4. Resource groups (project, postgres, bucket, branch, git)
 
-1. **New consent prompts.** `postgres restore/remove`, `postgres connection rotate/remove`, `bucket delete`, `project remove`, `project transfer` previously had only a `--confirm` flag (or nothing interactive); they now type-to-confirm the exact id. `bucket key delete` still asks nothing — the legacy inconsistency ports unchanged, recorded for review.
-2. **A rejected project listing now fails instead of looking empty.** Legacy swallowed API errors and printed "No projects found." with exit 0; every command resolving a project by name inherited the confusion. Fixed in both shells (ruled: this defect was not behaviour anyone chose).
-3. **Plan-limit errors** lose the legacy full-page custom rendering; summary, why and upgrade guidance survive as a normal error with one action.
-4. **Pre-result progress lines** (`Creating database...`) are gone on the synchronous commands.
-5. **`git connect` works non-interactively again** where possible; the wait for the GitHub App installation is the engine's browser-wait (one endpoint event carrying the install URL, engine-owned polling). Install URLs are `open-url` actions instead of fake commands. Cancelling the wait exits 3 while sleeping between polls, 130 if a poll request was in flight — the split is accepted, not smoothed over.
-6. **`bucket key create`** shows its four credential values as masked field rows in the human card (legacy named no values); the stdout `S3_*=` lines and the JSON secrets are unchanged.
-7. Known small quirks recorded, not fixed: `project rename`'s validation copy still says "Project create requires a name"; `branch list` keeps its resolution quirk (no `--project` flag); `git connect`/`git disconnect` keep their raw JSON result shape.
+| Change | What you see now |
+| --- | --- |
+| New consent prompts | `postgres restore/remove`, `connection rotate/remove`, `bucket delete`, `project remove/transfer` now type-to-confirm. `bucket key delete` still asks nothing (ported inconsistency, for review) |
+| Rejected listings fail | Legacy printed "No projects found." with exit 0 on API errors; fixed in both shells |
+| Plan-limit errors | Lose the custom full-page rendering; keep summary, why, upgrade action |
+| Progress lines gone | `Creating database...` etc. — sync commands emit no events |
+| `git connect` | Works non-interactively where possible; install wait is engine-owned; install URLs are `open-url` actions. Cancel during the wait: exit 3 between polls, 130 mid-request |
+| `bucket key create` | Human card shows the four credentials as masked rows; stdout `S3_*=` lines and JSON secrets unchanged |
+| Recorded quirks | `project rename` copy bug kept; `branch list` resolution quirk kept; `git` JSON result shape kept raw |
 
 ## 5. Services and deployments
 
-Versus the legacy `app` family, beyond the renames in section 2:
-
-1. **Which deployment is live comes from the platform record alone.** The local cache of "live deployment" is retired in both directions — a stale cache can no longer make a deployment look live, and `service deployment list` rows report `null` (unknown) where a cache entry used to claim `true`/`false`.
-2. **`service deployment rollback` asks for consent** (new — legacy asked nothing before changing what production serves). The token is the target deployment's id, so the user must look at which deployment is about to go live.
-3. **Rollback refuses to guess.** With no `--to` and no identifiable live deployment, legacy promoted the newest deployment — most likely the one already live — and reported success. v8 refuses (`SERVICE.LIVE_DEPLOYMENT_UNKNOWN`) and tells the user to name a target or list deployments.
-4. **Five commands are new:** `service list`, `service create`, `service deployment start/stop/delete`. `service create` changes what is possible — before it, a service only came into existence as a side effect of deploying.
-5. **`service create` is idempotent-ish:** a name already taken on the branch returns the existing service with `existing: true` instead of failing (mirrors `service domain add`). **Open — operator ruling pending** on whether it should hard-fail instead. Also: `--branch` resolves *or creates* the named branch, so a typo silently creates a branch (shared-helper behaviour, recorded).
-6. **`stop` asks no consent; `delete` demands the deployment id typed back.** Deliberate: the line is reversibility — a stopped deployment can start again, a deleted one cannot.
-7. **A deployment's url follows liveness.** `service deployment show` reports the promoted address only for the live deployment and the preview address otherwise; presenters show `not deployed` rather than a dead address for never-promoted services.
-8. **`service open`** now also opens the browser under `--json` in an interactive terminal, reports `opened: false` instead of erroring on a failed open, and prints the URL to stdout.
-9. **Success lines are past tense.** A command that changed something ends on "Removed hello-world…" instead of opening with "Removing…".
-10. **Follow-up suggestions pointing at `service deploy` are removed** (the command no longer exists); an empty `nextActions` list is now a normal outcome. Guidance can return pointing at Composer.
+| Change | What you see now |
+| --- | --- |
+| Live = platform record only | Local live-deployment cache retired both ways; stale cache can't fake a live deployment; unknown renders as `null`, not `false` |
+| Rollback asks consent | New — token is the **target deployment id**, so you look at what's about to go live |
+| Rollback refuses to guess | No `--to` + no known live deployment → `SERVICE.LIVE_DEPLOYMENT_UNKNOWN`. Legacy promoted the newest (often the already-live one) and claimed success |
+| Five new commands | `service list`, `service create`, `deployment start/stop/delete`. `create` means a service no longer exists only as a deploy side effect |
+| `create` is idempotent-ish | Name taken → returns the existing service with `existing: true`. **Open:** should it hard-fail? Also: `--branch` creates a missing branch (shared-helper behaviour) |
+| `stop` free, `delete` guarded | Stop is reversible → no consent; delete requires the id typed back |
+| URLs follow liveness | Promoted address only for the live deployment; `not deployed` instead of dead addresses |
+| `service open` | Also opens the browser under `--json` in a terminal; failed open reports `opened: false`; URL printed to stdout |
+| No more "deploy the service" hints | The command they pointed at is gone; empty `nextActions` is now normal |
 
 ## 6. `service logs`
 
-Shipped later than the rest of the family (the S2c port was shelved waiting on socket transport; what shipped is a different shape). Versus the old `app logs`:
-
-1. **A page read replaces a held socket.** Default: the last 100 lines, then exit 0 — the `kubectl logs` shape. `--follow` restores the streaming behaviour via polling (2-second interval); latency is bounded by the poll, not the server's write. The WebSocket upgrade exists on the platform and the CLI does not use it; live streaming remains future work.
-2. **New flags:** `--tail <n>` and `--from-start`; passing both is refused (`SERVICE.LOGS_RANGE_CONFLICT`).
-3. **Refusals instead of silent nonsense:** a page with no resume cursor stops a follow (`SERVICE.LOGS_NO_CURSOR`); a page that ends without its terminal record settles `SERVICE.LOGS_INCOMPLETE` after printing what arrived — a truncated log is never presented as complete.
-4. **A platform-reported log-read failure now fails the command** (`SERVICE.LOGS_FAILED`, exit 2) where the old command printed the message and exited 0. In `--follow`, a retryable failure is retried once, with the budget reset on success.
-5. **Interrupting `--follow` exits 130** — a wrapper treating non-zero as failure sees one when a developer stops following.
+| Change | What you see now |
+| --- | --- |
+| Page read, not a socket | Default: last 100 lines, exit 0 (the `kubectl logs` shape). `--follow` polls every 2 s. Live WebSocket streaming remains future work |
+| New flags | `--tail <n>`, `--from-start`; both together refused |
+| Refusals over silent nonsense | No resume cursor → stop the follow; truncated page → `SERVICE.LOGS_INCOMPLETE` after printing what arrived |
+| Platform log failure fails the run | Exit 2 (legacy printed and exited 0); in follow, one retry per failure, budget resets on success |
+| Ctrl-C on follow | Exit 130 |
 
 ## 7. `build logs`
 
-1. Records become engine events; JSON framing is uniform (the legacy opt-out of the success wrapper does not port), and the header line is now framed in JSON output.
-2. **Open — escalated engine gap: a failed build cannot exit 1.** Legacy streamed the logs and set exit 1 on a build failure. The engine constrains documented exit codes, so v8 settles `BUILD.FAILED` at exit 2. Still non-zero, still carries the resume cursor; the code changes 1 → 2. Ruling needed on giving streams a termination status or a documented code.
-3. A run whose build produced no log records reports no cursor anywhere in JSON (nothing to resume from).
+| Change | What you see now |
+| --- | --- |
+| Uniform JSON framing | The legacy no-wrapper opt-out doesn't port; the header is framed in JSON |
+| **Open:** failed build exits 2, not 1 | Engine constrains exit codes; still non-zero, still carries the resume cursor |
+| No-record run | Reports no cursor in JSON (nothing to resume from) |
 
-## 8. Composer — versus `prisma-composer`
+## 8. Composer (vs `prisma-composer`)
 
-The four commands (`dev`, `deploy`, `destroy`, `log`) mount under `prisma composer …`. The standalone `prisma-composer` bin survives with unprefixed spellings — and now runs the same engine and handlers, so the differences below apply to both invocations.
+The four commands mount as `prisma composer …`; the standalone bin survives and now runs the same engine, so these apply to both.
 
-1. **All engine-global behaviour is new to composer users:** shared flags, JSON framing, format auto-selection, help layout.
-2. **Parse failures say what was wrong** instead of reprinting the whole usage wall. A bare `prisma composer` exits 0 (was 2).
-3. **`deploy --production` is gone from help and parsing** — legacy advertised it and always rejected it at runtime. `destroy` keeps it, where it is valid.
-4. **The reproduce hint on a failed converge is a typed next action**, the redundant failure envelope is gone (the child already owned the terminal), and the hint is dropped when the user themselves killed the child with Ctrl-C.
-5. **JSON mode works for spawning commands:** the child's output routes to diagnostics, stdout stays framed, and a failed child keeps its verbatim exit code with `CLI.CHILD_PROCESS_FAILED` carrying the status.
-6. **`dev` (and `log`) exit 130 on Ctrl-C where legacy exited 0.** The most likely divergence to be noticed: supervisors treating non-zero as failure see one on every manual stop. Engine-wide rule — a signal-ended run is an abort whatever the handler concluded.
-7. **`--tail` is a typed number flag:** `--tail 5abc` is now an error instead of silently 5; the trade is that fractional and negative values are now accepted and passed through (recorded, not narrowed).
-8. **Failures move earlier:** unauthenticated `deploy`/`destroy` are refused before the config is read (legacy failed deep inside the child after doing platform work), and the effect-resolution preflight no longer takes out unrelated commands or `--help`.
-9. **`destroy` still asks nothing** before tearing down — the guard remains the required explicit target. If it deserves a confirmation, that is a Composer product decision, raised upstream.
-10. **Known defect, deferred:** help examples name the wrong invocation under the prisma bin (`prisma deploy …` instead of `prisma composer deploy …`) — the engine's placeholder substitutes the binary name only, and it needs a mount-aware placeholder plus composer rewriting eight strings. Unreachable from the standalone bin.
+| Change | What you see now |
+| --- | --- |
+| Engine behaviour is all new here | Shared flags, JSON framing, auto-format, help layout |
+| Parse errors are specific | No more full usage wall; bare `prisma composer` exits 0 (was 2) |
+| `deploy --production` gone | Legacy advertised it and always rejected it. `destroy` keeps it |
+| Failed converge | Reproduce hint is a typed action; redundant envelope gone; hint dropped on Ctrl-C |
+| JSON works for spawning commands | Child output → diagnostics; failed child keeps its exit code with `CLI.CHILD_PROCESS_FAILED` |
+| **`dev`/`log` exit 130 on Ctrl-C** (was 0) | Most likely to be noticed: supervisors treating non-zero as failure see one on every manual stop |
+| `--tail` typed | `5abc` now errors; trade: fractional/negative now accepted and passed through |
+| Failures move earlier | Unauthenticated deploy/destroy refused before config read; effect preflight no longer breaks unrelated commands or `--help` |
+| `destroy` still asks nothing | Guard is the explicit target; a confirmation would be a Composer product decision |
+| **Open:** help examples wrong under the prisma bin | `prisma deploy …` instead of `prisma composer deploy …`; needs a mount-aware placeholder, cross-repo |
 
-## 9. ORM family — versus `prisma-next`
+## 9. ORM family (vs `prisma-next`)
 
-Mounting the family introduced **no user-visible divergence**: the commands answer for the first time under this binary. The differences between the ORM commands under this shell and under `prisma-next` belong to the port record kept in prisma/prisma. Two notes:
-
-1. The family ships its redirect table for spellings `prisma-next` had already retired (`migration apply`, `migration ref`, four `migration status` flags).
-2. Operational cost, not a divergence: the ORM family's entry statically imports esbuild, arktype and a dozen framework subpaths, so every invocation of the bin pays that startup cost — including `prisma --version`. Fixing it is a prisma/prisma change; tracked as deferred.
+No user-visible divergence — the commands answer for the first time under this binary; the port record lives in prisma/prisma. Two notes: the redirect table covers spellings `prisma-next` already retired, and the family's static imports (esbuild, arktype) slow every invocation including `--version` — deferred, prisma/prisma's fix.
 
 ## 10. `init`
 
-1. **The three optional steps (install types, link, agent skills) default to no.** Ratified with a stated cost: interactive users press `y` where they pressed Enter; unattended runs keep exactly today's behaviour. One line per prompt to flip.
-2. **`--format` is renamed `--config-format`** (the engine reserves `--format` for output format). The value must be exactly `ts` or `json` — `typescript`, mixed case and whitespace are no longer accepted.
-3. **Cancelling a question aborts the run at exit 3** (legacy recorded a decline and exited 0); an already-written config stays on disk. Unattended runs report `declined` where legacy said `skipped` (JSON-only difference).
-4. **The link step no longer auto-logs-in**; signed out, it reports `link.status: "unauthenticated"` with a sign-in action.
-5. One legacy catch-all usage error split into nine distinct `INIT.*` codes (machine-facing contract change; every sentence preserved).
+(See the proposal up top — under it, most of this command goes.)
+
+| Change | What you see now |
+| --- | --- |
+| Optional steps default to no | Interactive users press `y` where they pressed Enter; unattended runs unchanged. Ratified; one line per prompt to flip |
+| `--format` → `--config-format` | Value must be exactly `ts` or `json` |
+| Cancel aborts | Exit 3 (legacy recorded a decline, exit 0); written config stays |
+| Link step never auto-logs-in | Signed out → `link.status: "unauthenticated"` + sign-in action |
+| Nine `INIT.*` codes | One legacy catch-all usage error split up (machine-facing change; prose preserved) |
 
 ## 11. Agent skills, feedback, telemetry
 
-1. **`agent install/update/status`** keep their spellings and behaviour; warnings and next steps become typed. **Open — escalated engine gap:** help examples lose the package-runner form (`pnpm dlx @prisma/cli@latest agent install` → bare `agent install`) while run-time next actions keep it, so the command spells itself two ways. Worth one group-wide ruling.
-2. **The crash-recovery feedback action does not port — open, escalated engine gap.** Legacy pre-filled `prisma-cli feedback "<command> crashed: …"` on every unexpected error. The engine settles crashes itself with no contribution point for the shell, so a v8 crash offers no recovery action. The `feedback` command itself works; only the automatic pre-fill is gone. A small engine hook would restore it.
-3. **`feedback`'s payload** reports the runtime truthfully (`runtime: {name, version}` instead of `nodeVersion`), so a bun or deno build identifies itself.
-4. **Telemetry:** config-file enrichment dropped (the config it read does not exist in this product); events fire at command start (same point as the reference); first-run disclosure says "Prisma" not "Prisma Next" and no longer suggests hand-editing the machine-owned preference file; negated flags are counted under one name (`--color`, not `--color` and `--no-color`).
+| Change | What you see now |
+| --- | --- |
+| **Open:** agent help spells itself two ways | Help examples are bare (`agent install`), runtime actions keep the runner form (`npx -y @prisma/cli@latest …`). One group-wide ruling wanted |
+| **Open:** crash-recovery pre-fill gone | Legacy pre-filled `feedback "<command> crashed: …"` on crashes; the engine offers no hook. `feedback` itself works |
+| `feedback` payload | `runtime: {name, version}` instead of `nodeVersion` — bun/deno report truthfully |
+| Telemetry | Config-file enrichment dropped; events at command start; disclosure says "Prisma"; negated flags counted under one name |
 
-## 12. Open items in one place
+## 12. Open items for the discussion
 
-For the discussion — everything above that still needs a decision:
-
-1. Service token whose workspace only the server knows: refuse (current) or complete server-side in the credential manager (§3.8).
-2. `build logs` exit code on a failed build: 2 today, legacy 1 (§7.2).
-3. Agent-group help examples versus package-runner next actions: pick one spelling policy group-wide (§11.1).
-4. Crash-recovery feedback pre-fill: needs a small engine hook (§11.2).
-5. `service create` idempotency: return-existing (current) or hard-fail (§5.5).
-6. Composer help examples under the prisma bin: needs a mount-aware placeholder, coordinated across repos (§8.10).
-7. `bucket key delete` asks no consent while `bucket delete` does — ported inconsistency, review whether to keep (§4.1).
-8. One unswept `--trace` mention survives in service-reachable legacy error prose; every other group rewrites it. Small fix.
-9. The parameters-only proposal at the top of this document: ratify the rule, decide `init`'s new meaning, and schedule the removal of the deprecated `prisma.compute.*` machinery.
+| # | Item | Where |
+| --- | --- | --- |
+| 1 | **Parameters-only proposal**: ratify, give `init` a new meaning, schedule the compute-config removal | top of this doc |
+| 2 | Service token whose workspace only the server knows: refuse vs resolve in the credential manager | §3 |
+| 3 | `build logs` exit code on a failed build: 2 today, legacy 1 | §7 |
+| 4 | Agent help examples vs package-runner actions: one spelling policy | §11 |
+| 5 | Crash-recovery feedback pre-fill: needs a small engine hook | §11 |
+| 6 | `service create`: return-existing vs hard-fail | §5 |
+| 7 | Composer help examples under the prisma bin: mount-aware placeholder, cross-repo | §8 |
+| 8 | `bucket key delete` asks no consent while `bucket delete` does | §4 |
+| 9 | One unswept `--trace` mention in service-reachable error prose | small fix |

--- a/.drive/projects/prisma-cli-v8/assets/divergence-catalog.md
+++ b/.drive/projects/prisma-cli-v8/assets/divergence-catalog.md
@@ -4,6 +4,17 @@ Everything the v8 CLI deliberately does differently from the CLIs it replaces, i
 
 Three baselines apply, because v8 absorbs three CLIs: the platform CLI (`prisma-cli`), Composer's own CLI (`prisma-composer`), and the ORM CLI (`prisma-next`). Each section says which baseline it compares against. The cumulative record was ratified by the operator on 2026-08-12; entries marked **open** still need a ruling.
 
+## Proposed ruling (2026-08-20, for discussion): platform commands take parameters only
+
+Prompted by the discovery that `prisma.compute.ts` — the file `init` writes and the service commands read — is deprecated and no longer supported. The proposal: **platform commands operate on their parameters; the only ambient context is the directory's project link.** Concretely:
+
+- **Project** resolves from `--project`, else the env override, else the local project link (`.prisma/local.json`). The link stays — the product team wants it — so `project link`, `project create`'s auto-link, and `project show`'s binding keep their meaning.
+- **Service** resolves from `--service` or `PRISMA_SERVICE_ID` only. The compute-config default, the remembered selection in local state, and the interactive picker are removed.
+- **Branch** resolves from `--branch` only. The current-git-branch inference is removed.
+- **The compute config is dead everywhere:** `init`'s write, the service commands' read, the config-target positional, the `SERVICE.COMPUTE_CONFIG_*` error codes, and the agent setup-status read. `init` shrinks to its link step (the one part of today's command that survives) plus whatever new meaning the product gives it.
+
+This is a deliberate reversal of the original spec's resolution layer (Layer 3: git mapping, prompts, auto-creating projects), not a refinement of it. Ergonomics move above the platform commands — into orchestration or a future config section — and the platform commands become plain plumbing over the API.
+
 ## 1. Global changes — every command, versus the legacy platform CLI
 
 These hold for every ported command and are the largest single source of visible difference.
@@ -135,3 +146,4 @@ For the discussion — everything above that still needs a decision:
 6. Composer help examples under the prisma bin: needs a mount-aware placeholder, coordinated across repos (§8.10).
 7. `bucket key delete` asks no consent while `bucket delete` does — ported inconsistency, review whether to keep (§4.1).
 8. One unswept `--trace` mention survives in service-reachable legacy error prose; every other group rewrites it. Small fix.
+9. The parameters-only proposal at the top of this document: ratify the rule, decide `init`'s new meaning, and schedule the removal of the deprecated `prisma.compute.*` machinery.

--- a/.drive/projects/prisma-cli-v8/assets/divergence-catalog.md
+++ b/.drive/projects/prisma-cli-v8/assets/divergence-catalog.md
@@ -1,168 +1,77 @@
-# Prisma CLI v8 — divergence catalog
+# Prisma CLI v8 — divergences from the spec
 
-Everything v8 deliberately does differently from the three CLIs it replaces (`prisma-cli`, `prisma-composer`, `prisma-next`), corrected to what ships at rc.6 (2026-08-20). Compiled from the five parity-divergence records; the ratified record is from 2026-08-12. Detail lives in those records — this is the review-friendly version.
+Where the shipped CLI (8.0.0-rc.6, 2026-08-20) departs from the unified-CLI spec (the consolidate-clis grammar, Layers 1–5), for discussion. Changes the spec *asked for* are not discussion material and are summarized at the end. Sources: the five parity-divergence records, the operator rulings, and the spec itself; the per-slice records hold the fine detail.
 
-**TL;DR**
+## The headline: the proposal on the table
 
-- Output, exit codes, error codes, and consent are unified engine-wide; JSON is now a machine-friendly event stream and piped output is JSON automatically.
-- Renames: `database` → `postgres`, `app` → `service`, deployment verbs under `service deployment`. Removals: `app build/deploy/run` (Composer supersedes), `version`, auto-login, fixture mode, `--trace`.
-- Destructive commands now ask you to type the exact id/name; `--yes` never grants consent.
-- Nine items still need a ruling — listed at the end, the parameters-only proposal first.
-
-## Proposed ruling (2026-08-20, for discussion): platform commands take parameters only
-
-`prisma.compute.ts` — the file `init` writes and the service commands read — is **deprecated and no longer supported**. Proposal:
+**`prisma.compute.ts` is deprecated and unsupported — and it is what `init` writes and what the service commands read.** Proposed response (2026-08-20): platform commands take parameters only.
 
 | Dimension | Resolves from | What goes |
 | --- | --- | --- |
-| Project | `--project`, env override, the local project link (**kept**, per product team) | nothing — `project link`/`show`/`create` keep their meaning |
+| Project | `--project`, env override, the local project link (**kept**, per product team) | nothing |
 | Service | `--service` / `PRISMA_SERVICE_ID` only | compute-config default, remembered selection, interactive picker |
 | Branch | `--branch` only | current-git-branch inference |
-| Compute config | — | dead everywhere: `init`'s write, service reads, the config-target positional, `SERVICE.COMPUTE_CONFIG_*` codes |
+| Compute config | — | dead everywhere; `init` shrinks to its link step pending a new meaning |
 
-`init` shrinks to its project-link step pending a new meaning. This deliberately reverses the original spec's resolution layer; ergonomics move above the platform commands, which become plain plumbing over the API.
+This deliberately reverses the spec's Layer 3 (resolution: git mapping, prompts, auto-creating projects). Ergonomics move above the platform commands — into orchestration or config — and the platform commands become plain plumbing over the API.
 
-## 1. Global changes (every command)
+## Departures from the spec, by decision status
 
-| Change | What you see now |
+### A. Ruled during the build — standing decisions to revisit or reaffirm
+
+| Area | Spec says | Shipped | Ruling |
+| --- | --- | --- | --- |
+| `service build` / `run` / `deploy` | flat service verbs exist | dropped, no successor — Composer supersedes; deploy's build-locally-and-upload shape judged wrong | 2026-08-10 |
+| `composer` root | no product names in the tree ("there is no `prisma composer`") | `composer dev/deploy/destroy/log` mounted | interim parking 2026-08-10; final grammar open as TML-3189 |
+| `init` | the single guided entry point into everything | the platform compute-config wizard; ORM scaffold moved to `orm init` (not in spec) | 2026-08-12 |
+| `version` | listed as a utility command | removed; `--version` answers | 2026-08-11 |
+| `service promote` / `rollback` | flat — Service-level traffic actions | moved under `service deployment` | S8, R-S8-1 |
+| `service logs` | live streaming (deployment logs) | a page read; `--follow` polls every 2 s; WebSocket transport not built | 2026-08-10 shelve, later shipped in page shape |
+
+### B. Never ruled — drifted from the spec without a decision
+
+| Area | Spec says | Shipped | Note |
+| --- | --- | --- | --- |
+| Deletion verb | `delete` everywhere; `remove` explicitly avoided as ambiguous | `remove` on 6 commands (`project`, `project env`, `postgres`, `postgres connection`, `service`, `service domain`) — but `bucket delete` | ports inherited legacy verbs; the spec's verb table was never applied as a rename ruling. Six cheap renames if ruled |
+| `migrate` | `db migrate` | top-level `migrate` | port kept `prisma-next`'s spelling |
+| `format` | `contract format` | top-level `format` | same |
+| `ref` group | `migration ref …` ("refs stay inside the migration group") | top-level `ref set/list/delete` | same |
+| `postgres restore` | `postgres backup restore` | flat `postgres restore` | legacy shape kept |
+| `build` group | no such group; `service deployment logs` covers builds from git push | `build logs` | legacy shape kept |
+| `lsp` | not in the tree | top-level `lsp` | arrived with the ORM family |
+
+### C. New surface the spec never described
+
+| Command | Why it exists |
 | --- | --- |
-| JSON is an event stream | Newline-delimited frames + one result frame. `command`→`commandId`, `warnings`→coded `diagnostics`, `nextSteps`→typed `nextActions`, exit code included |
-| Format auto-selects | Human only when stdout is a terminal; piped output is JSON |
-| stdout carries data in human mode | Presentation on stderr (as before); raw data rows on stdout, so piping works. Legacy wrote nothing to stdout |
-| Exit codes unified | 2 = expected error, 3 = cancelled prompt, 1 = bug only, 130/143 = signals |
-| Error codes dotted | `PROJECT.NOT_FOUND`, `POSTGRES.API_ERROR`, … — each gets a docs link |
-| Remediation typed | `fix` prose → `user-choice` action; `nextSteps` → `run-command` actions; URLs → `open-url` actions |
-| Consent engine-owned | Type the exact id/name, or `--confirm <value>` in scripts. `--yes` never grants consent. Cancel = exit 3 |
-| Auto-login gone | Unauthenticated runs fail with `CLI.CREDENTIALS_REQUIRED` instead of opening a browser |
-| Flags | Shared family (`--format`, `--log-level`, `--quiet`, `--yes`, `--confirm`, `--interactive`, `--color`). `--trace` gone; `--verbose` is a log level, so "verbose context" blocks are gone |
-| `version` removed | `prisma --version` answers |
-| Fixture/mock mode gone | Including its flags and error codes |
-| Rendering | Engine block style; legacy card alignment/colours restored byte-for-byte; the `│` rail framing and header line are deferred |
+| `service create` | a service no longer exists only as a deploy side effect. **Open:** name-taken returns the existing service (`existing: true`) — hard-fail instead? |
+| `service deployment start` / `stop` / `delete` | direct lifecycle over the API (S8). Stop unguarded (reversible), delete requires the id typed back |
+| `service domain retry` / `wait` | operational conveniences from the legacy CLI |
 
-## 2. Renames and removals
+### D. In the spec, not shipped
 
-| Was | Is | Notes |
-| --- | --- | --- |
-| `database …` | `postgres …` | Whole group, no alias |
-| `app …` | `service …` | Whole group, incl. `--app`→`--service`, `PRISMA_APP_ID`→`PRISMA_SERVICE_ID` |
-| `service list-deploys` / `show-deploy` / `promote` / `rollback` | `service deployment list` / `show` / `promote` / `rollback` | No aliases; JSON command ids moved too |
-| `app build` / `app deploy` / `app run` | — | Ruled drops; Composer supersedes. Deploy's build-locally-and-upload shape judged wrong |
-| `version`, `auth logout --workspace`, `rm` alias, mock login flags | — | Ruled removals |
-| `prisma init` (ORM scaffold) | `orm init` | Top-level `init` is the platform wizard (ruled 2026-08-12) |
-| `PRISMA_NEXT_DISABLE_TELEMETRY` etc. | `PRISMA_DISABLE_TELEMETRY` etc. | No fallback: an old-path opt-out reverts to default. `DO_NOT_TRACK` still works |
+Orchestration (`project check/dev/plan/deploy/status`, `adopt/detach`, `unlink`), `branch create/show/delete`, `service deployment logs`, `service domain list`, `postgres update`, `postgres backup create/delete`, `bucket show`, `git status`, `db query/browse/seed`, `contract validate`, `auth token *`, `emulator *`, `project env pull`, `mcp`. None removed by ruling — simply not yet built. Worth agreeing which are on the roadmap and which quietly died.
 
-## 3. Authentication
+## Engineering gaps still open (engine limitations, not spec questions)
 
-New model: stored per-workspace **sessions** plus one selection; `PRISMA_SERVICE_TOKEN` is a separate credential, not a session.
-
-| Change | What you see now |
+| # | Item |
 | --- | --- |
-| Mutations work under `PRISMA_SERVICE_TOKEN` | login/logout/workspace commands operate on stored sessions, with a notice that the env credential stays in force. Legacy refused switching |
-| `auth logout` ends every session | Reports the count; reaps orphaned entries |
-| `auth workspace use` selects only | Never creates a session or opens a browser |
-| `auth whoami` describes the credential | `source` and `expiresAt` new; provider field gone; a service token reports no user; no-workspace credential reports `workspace: null` |
-| Names not refreshed on read | A Console rename shows locally only after the next login |
-| Session logout is idempotent | Already-removed session → exit 0 |
-| Near-expiry sessions refresh | Refreshed and persisted before delegated runs; only unrefreshable credentials are refused |
+| 1 | A service token whose workspace only the server knows is refused; legacy resolved it via `/v1/me`. Complete it in the credential manager, or require the claim on every token |
+| 2 | `build logs` cannot exit 1 on a failed build (exits 2; engine constrains codes) |
+| 3 | Agent help spells itself two ways: bare examples vs package-runner next actions |
+| 4 | Crash-recovery feedback pre-fill gone; needs a small engine hook |
+| 5 | Composer help examples name the wrong invocation under the prisma bin; needs a mount-aware placeholder, cross-repo |
+| 6 | `bucket key delete` asks no consent while `bucket delete` does (ported inconsistency) |
+| 7 | One unswept `--trace` mention in service-reachable error prose |
 
-**Open:** a service token whose workspace only the server knows is now refused (legacy asked `/v1/me`). Ruling: complete it server-side in the credential manager, or require the claim on every token.
+## Reference: planned changes, executed
 
-## 4. Resource groups (project, postgres, bucket, branch, git)
+Spec- or design-mandated changes users of the old CLIs will feel. Not discussion material; kept for completeness.
 
-| Change | What you see now |
-| --- | --- |
-| New consent prompts | `postgres restore/remove`, `connection rotate/remove`, `bucket delete`, `project remove/transfer` now type-to-confirm. `bucket key delete` still asks nothing (ported inconsistency, for review) |
-| Rejected listings fail | Legacy printed "No projects found." with exit 0 on API errors; fixed in both shells |
-| Plan-limit errors | Lose the custom full-page rendering; keep summary, why, upgrade action |
-| Progress lines gone | `Creating database...` etc. — sync commands emit no events |
-| `git connect` | Works non-interactively where possible; install wait is engine-owned; install URLs are `open-url` actions. Cancel during the wait: exit 3 between polls, 130 mid-request |
-| `bucket key create` | Human card shows the four credentials as masked rows; stdout `S3_*=` lines and JSON secrets unchanged |
-| Recorded quirks | `project rename` copy bug kept; `branch list` resolution quirk kept; `git` JSON result shape kept raw |
-
-## 5. Services and deployments
-
-| Change | What you see now |
-| --- | --- |
-| Live = platform record only | Local live-deployment cache retired both ways; stale cache can't fake a live deployment; unknown renders as `null`, not `false` |
-| Rollback asks consent | New — token is the **target deployment id**, so you look at what's about to go live |
-| Rollback refuses to guess | No `--to` + no known live deployment → `SERVICE.LIVE_DEPLOYMENT_UNKNOWN`. Legacy promoted the newest (often the already-live one) and claimed success |
-| Five new commands | `service list`, `service create`, `deployment start/stop/delete`. `create` means a service no longer exists only as a deploy side effect |
-| `create` is idempotent-ish | Name taken → returns the existing service with `existing: true`. **Open:** should it hard-fail? Also: `--branch` creates a missing branch (shared-helper behaviour) |
-| `stop` free, `delete` guarded | Stop is reversible → no consent; delete requires the id typed back |
-| URLs follow liveness | Promoted address only for the live deployment; `not deployed` instead of dead addresses |
-| `service open` | Also opens the browser under `--json` in a terminal; failed open reports `opened: false`; URL printed to stdout |
-| No more "deploy the service" hints | The command they pointed at is gone; empty `nextActions` is now normal |
-
-## 6. `service logs`
-
-| Change | What you see now |
-| --- | --- |
-| Page read, not a socket | Default: last 100 lines, exit 0 (the `kubectl logs` shape). `--follow` polls every 2 s. Live WebSocket streaming remains future work |
-| New flags | `--tail <n>`, `--from-start`; both together refused |
-| Refusals over silent nonsense | No resume cursor → stop the follow; truncated page → `SERVICE.LOGS_INCOMPLETE` after printing what arrived |
-| Platform log failure fails the run | Exit 2 (legacy printed and exited 0); in follow, one retry per failure, budget resets on success |
-| Ctrl-C on follow | Exit 130 |
-
-## 7. `build logs`
-
-| Change | What you see now |
-| --- | --- |
-| Uniform JSON framing | The legacy no-wrapper opt-out doesn't port; the header is framed in JSON |
-| **Open:** failed build exits 2, not 1 | Engine constrains exit codes; still non-zero, still carries the resume cursor |
-| No-record run | Reports no cursor in JSON (nothing to resume from) |
-
-## 8. Composer (vs `prisma-composer`)
-
-The four commands mount as `prisma composer …`; the standalone bin survives and now runs the same engine, so these apply to both.
-
-| Change | What you see now |
-| --- | --- |
-| Engine behaviour is all new here | Shared flags, JSON framing, auto-format, help layout |
-| Parse errors are specific | No more full usage wall; bare `prisma composer` exits 0 (was 2) |
-| `deploy --production` gone | Legacy advertised it and always rejected it. `destroy` keeps it |
-| Failed converge | Reproduce hint is a typed action; redundant envelope gone; hint dropped on Ctrl-C |
-| JSON works for spawning commands | Child output → diagnostics; failed child keeps its exit code with `CLI.CHILD_PROCESS_FAILED` |
-| **`dev`/`log` exit 130 on Ctrl-C** (was 0) | Most likely to be noticed: supervisors treating non-zero as failure see one on every manual stop |
-| `--tail` typed | `5abc` now errors; trade: fractional/negative now accepted and passed through |
-| Failures move earlier | Unauthenticated deploy/destroy refused before config read; effect preflight no longer breaks unrelated commands or `--help` |
-| `destroy` still asks nothing | Guard is the explicit target; a confirmation would be a Composer product decision |
-| **Open:** help examples wrong under the prisma bin | `prisma deploy …` instead of `prisma composer deploy …`; needs a mount-aware placeholder, cross-repo |
-
-## 9. ORM family (vs `prisma-next`)
-
-No user-visible divergence — the commands answer for the first time under this binary; the port record lives in prisma/prisma. Two notes: the redirect table covers spellings `prisma-next` already retired, and the family's static imports (esbuild, arktype) slow every invocation including `--version` — deferred, prisma/prisma's fix.
-
-## 10. `init`
-
-(See the proposal up top — under it, most of this command goes.)
-
-| Change | What you see now |
-| --- | --- |
-| Optional steps default to no | Interactive users press `y` where they pressed Enter; unattended runs unchanged. Ratified; one line per prompt to flip |
-| `--format` → `--config-format` | Value must be exactly `ts` or `json` |
-| Cancel aborts | Exit 3 (legacy recorded a decline, exit 0); written config stays |
-| Link step never auto-logs-in | Signed out → `link.status: "unauthenticated"` + sign-in action |
-| Nine `INIT.*` codes | One legacy catch-all usage error split up (machine-facing change; prose preserved) |
-
-## 11. Agent skills, feedback, telemetry
-
-| Change | What you see now |
-| --- | --- |
-| **Open:** agent help spells itself two ways | Help examples are bare (`agent install`), runtime actions keep the runner form (`npx -y @prisma/cli@latest …`). One group-wide ruling wanted |
-| **Open:** crash-recovery pre-fill gone | Legacy pre-filled `feedback "<command> crashed: …"` on crashes; the engine offers no hook. `feedback` itself works |
-| `feedback` payload | `runtime: {name, version}` instead of `nodeVersion` — bun/deno report truthfully |
-| Telemetry | Config-file enrichment dropped; events at command start; disclosure says "Prisma"; negated flags counted under one name |
-
-## 12. Open items for the discussion
-
-| # | Item | Where |
-| --- | --- | --- |
-| 1 | **Parameters-only proposal**: ratify, give `init` a new meaning, schedule the compute-config removal | top of this doc |
-| 2 | Service token whose workspace only the server knows: refuse vs resolve in the credential manager | §3 |
-| 3 | `build logs` exit code on a failed build: 2 today, legacy 1 | §7 |
-| 4 | Agent help examples vs package-runner actions: one spelling policy | §11 |
-| 5 | Crash-recovery feedback pre-fill: needs a small engine hook | §11 |
-| 6 | `service create`: return-existing vs hard-fail | §5 |
-| 7 | Composer help examples under the prisma bin: mount-aware placeholder, cross-repo | §8 |
-| 8 | `bucket key delete` asks no consent while `bucket delete` does | §4 |
-| 9 | One unswept `--trace` mention in service-reachable error prose | small fix |
+- **Renames:** `database` → `postgres`, `app` → `service` (including flags, env vars, error copy; no aliases). Nested nouns per the spec: `service deployment list` replaces `list-deploys` etc., ids moved with paths.
+- **One output model (engine design R1–R14):** JSON is an event stream with typed diagnostics and next actions; format auto-selects (piped = JSON); human mode writes presentation to stderr and raw data rows to stdout; exit codes unified (2 expected error, 3 cancelled prompt, 1 bugs only, 130/143 signals); dotted error codes with per-code docs links.
+- **Consent per the spec's guarded-deletion invariant:** destructive commands require the exact id/name typed back or `--confirm <value>`; `--yes` never grants consent.
+- **Auth on the session model:** per-workspace sessions plus one selection; `PRISMA_SERVICE_TOKEN` is a credential, not a session; mutations work while it is set; `whoami` describes the credential; no auto-login anywhere.
+- **Retired:** fixture/mock mode, `--trace`, verbose-context blocks, per-error exit codes, the local live-deployment cache (live derives from the platform record alone; rollback refuses to guess and asks consent on the target deployment id).
+- **Telemetry:** `PRISMA_NEXT_*` variables and the shared preference file renamed to `PRISMA_*` / `prisma/`, no fallback; `DO_NOT_TRACK` unchanged.
+- **ORM family:** mounted unchanged; no user-visible divergence from `prisma-next` introduced by the mount.

--- a/.drive/projects/prisma-cli-v8/assets/divergence-catalog.md
+++ b/.drive/projects/prisma-cli-v8/assets/divergence-catalog.md
@@ -1,6 +1,6 @@
 # Prisma CLI v8 — divergences from the spec
 
-Where the shipped CLI (8.0.0-rc.6, 2026-08-20) departs from the unified-CLI spec (the consolidate-clis grammar, Layers 1–5), for discussion. Changes the spec *asked for* are not discussion material and are summarized at the end. Sources: the five parity-divergence records, the operator rulings, and the spec itself; the per-slice records hold the fine detail.
+Where the shipped CLI (8.0.0-rc.6, 2026-08-20) departs from the unified-CLI spec (the CLI consolidation plan's command surface), for discussion. Changes the spec *asked for* are not discussion material and are summarized at the end. Compiled from the project's divergence records, which hold the fine detail.
 
 ## The headline: the proposal on the table
 
@@ -22,11 +22,11 @@ This deliberately reverses the spec's Layer 3 (resolution: git mapping, prompts,
 | Area | Spec says | Shipped | Ruling |
 | --- | --- | --- | --- |
 | `service build` / `run` / `deploy` | flat service verbs exist | dropped, no successor — Composer supersedes; deploy's build-locally-and-upload shape judged wrong | 2026-08-10 |
-| `composer` root | no product names in the tree ("there is no `prisma composer`") | `composer dev/deploy/destroy/log` mounted | interim parking 2026-08-10; final grammar open as TML-3189 |
+| `composer` root | no product names in the tree ("there is no `prisma composer`") | `composer dev/deploy/destroy/log` mounted | 2026-08-10, as interim parking; the final grammar is still an open ticket (Linear TML-3189) |
 | `init` | the single guided entry point into everything | the platform compute-config wizard; ORM scaffold moved to `orm init` (not in spec) | 2026-08-12 |
 | `version` | listed as a utility command | removed; `--version` answers | 2026-08-11 |
-| `service promote` / `rollback` | flat — Service-level traffic actions | moved under `service deployment` | S8, R-S8-1 |
-| `service logs` | live streaming (deployment logs) | a page read; `--follow` polls every 2 s; WebSocket transport not built | 2026-08-10 shelve, later shipped in page shape |
+| `service promote` / `rollback` | flat — Service-level traffic actions | moved under `service deployment` | mid-2026-08, when the deployment subgroup was built; old spellings deleted with no aliases (pre-rc, no compatibility debt) |
+| `service logs` | live streaming (deployment logs) | a page read; `--follow` polls every 2 s; WebSocket transport not built | 2026-08-10: postponed until the engine can carry a socket; later shipped as a page read instead |
 
 ### B. Never ruled — drifted from the spec without a decision
 
@@ -45,7 +45,7 @@ This deliberately reverses the spec's Layer 3 (resolution: git mapping, prompts,
 | Command | Why it exists |
 | --- | --- |
 | `service create` | a service no longer exists only as a deploy side effect. **Open:** name-taken returns the existing service (`existing: true`) — hard-fail instead? |
-| `service deployment start` / `stop` / `delete` | direct lifecycle over the API (S8). Stop unguarded (reversible), delete requires the id typed back |
+| `service deployment start` / `stop` / `delete` | direct lifecycle over the API. Stop unguarded (reversible), delete requires the id typed back |
 | `service domain retry` / `wait` | operational conveniences from the legacy CLI |
 
 ### D. In the spec, not shipped
@@ -69,7 +69,7 @@ Orchestration (`project check/dev/plan/deploy/status`, `adopt/detach`, `unlink`)
 Spec- or design-mandated changes users of the old CLIs will feel. Not discussion material; kept for completeness.
 
 - **Renames:** `database` → `postgres`, `app` → `service` (including flags, env vars, error copy; no aliases). Nested nouns per the spec: `service deployment list` replaces `list-deploys` etc., ids moved with paths.
-- **One output model (engine design R1–R14):** JSON is an event stream with typed diagnostics and next actions; format auto-selects (piped = JSON); human mode writes presentation to stderr and raw data rows to stdout; exit codes unified (2 expected error, 3 cancelled prompt, 1 bugs only, 130/143 signals); dotted error codes with per-code docs links.
+- **One output model (from the settled engine design):** JSON is an event stream with typed diagnostics and next actions; format auto-selects (piped = JSON); human mode writes presentation to stderr and raw data rows to stdout; exit codes unified (2 expected error, 3 cancelled prompt, 1 bugs only, 130/143 signals); dotted error codes with per-code docs links.
 - **Consent per the spec's guarded-deletion invariant:** destructive commands require the exact id/name typed back or `--confirm <value>`; `--yes` never grants consent.
 - **Auth on the session model:** per-workspace sessions plus one selection; `PRISMA_SERVICE_TOKEN` is a credential, not a session; mutations work while it is set; `whoami` describes the credential; no auto-login anywhere.
 - **Retired:** fixture/mock mode, `--trace`, verbose-context blocks, per-error exit codes, the local live-deployment cache (live derives from the platform record alone; rollback refuses to guess and asks consent on the target deployment id).

--- a/.drive/projects/prisma-cli-v8/assets/divergence-catalog.md
+++ b/.drive/projects/prisma-cli-v8/assets/divergence-catalog.md
@@ -1,0 +1,137 @@
+# Prisma CLI v8 — divergence catalog
+
+Everything the v8 CLI deliberately does differently from the CLIs it replaces, in one document. Compiled from the five parity-divergence records and the engine-global baseline, corrected to what actually ships at `main` (8.0.0-rc.6, 2026-08-20) — the per-slice records predate some later changes, and this catalog reflects the shipped state.
+
+Three baselines apply, because v8 absorbs three CLIs: the platform CLI (`prisma-cli`), Composer's own CLI (`prisma-composer`), and the ORM CLI (`prisma-next`). Each section says which baseline it compares against. The cumulative record was ratified by the operator on 2026-08-12; entries marked **open** still need a ruling.
+
+## 1. Global changes — every command, versus the legacy platform CLI
+
+These hold for every ported command and are the largest single source of visible difference.
+
+1. **JSON output is an event stream, not one object.** Legacy printed one pretty-printed JSON envelope. v8 prints newline-delimited frames (events plus exactly one final result frame). Inside the envelope: `command` → `commandId`, `warnings: string[]` → typed coded `diagnostics`, `nextSteps: string[]` → typed `nextActions`, and the exit code is now included. Result payloads themselves are mostly unchanged.
+2. **Output format is auto-selected.** Human output only when stdout is a terminal; piped output is JSON automatically. Legacy was human unless `--json` was passed.
+3. **Human mode writes a machine-usable payload to stdout.** Presentation (cards, tables, commentary) goes to stderr, exactly where legacy wrote it; the data rows additionally go to stdout with raw, unformatted values (no placeholders like `none`, byte counts instead of `2.0 KiB`). Legacy human mode wrote nothing to stdout. Piping a v8 command yields usable data.
+4. **Exit codes are unified.** Expected errors exit 2, a cancelled prompt exits 3, exit 1 is reserved for bugs (`CLI.INTERNAL_ERROR`), signals exit 128 + signal number (130 for Ctrl-C). Legacy exited 1 or 2 per error type.
+5. **Error codes are dotted and namespaced.** `PROJECT_NOT_FOUND` → `PROJECT.NOT_FOUND`, `DATABASE_API_ERROR` → `POSTGRES.API_ERROR`, and so on. Each code gets its own docs link.
+6. **Remediation is typed.** Legacy `fix` prose becomes one `user-choice` next action; each `nextSteps` string becomes a `run-command` action; URLs become `open-url` actions. Package-runner command strings (`npx -y @prisma/cli@latest …`) are dropped from next actions in favour of plain `prisma-cli …`.
+7. **Consent is engine-owned and stronger.** Destructive commands ask the user to type the exact id or name of the thing being destroyed (interactively) or pass `--confirm <that value>` (scripted). `--yes` never grants consent. Several commands that had only a flag, or asked nothing at all, now prompt. Cancelling a prompt exits 3 — a code these commands never produced before.
+8. **Auto-login is gone.** An unauthenticated run settles `CLI.CREDENTIALS_REQUIRED` (exit 2) instead of opening a browser sign-in mid-command.
+9. **Flags:** the shared family is `--format/--json`, `--log-level/-v/--verbose`, `-q/--quiet`, `-y/--yes`, `--confirm`, `--interactive/--no-interactive`, `--color/--no-color`, `-h/--help`. `--trace` no longer exists (log levels cover it); `--quiet` is just a log-level alias. `--verbose` is a log level, so the legacy "verbose context" blocks in results are gone.
+10. **No `version` command** (ruled removal). `prisma --version` answers, printing the version alone. The legacy command's extra facts (invocation kind, node version, platform) had no consumer worth porting.
+11. **Mock/fixture mode is gone** entirely, along with the fixture-only flags and error codes.
+12. **Rendering style.** Human output is the engine's block style. The aligned, accent-coloured key columns of the legacy cards are back byte-for-byte; still missing are the dim `│` rail framing and the `command → description` header line (deferred, per-command opt-in exists).
+
+## 2. Renames and removals
+
+1. **`database` → `postgres`.** The whole group: paths, ids, help, error copy. No alias.
+2. **`app` → `service`.** The whole group, including `--app` → `--service`, result fields, error copy, and `PRISMA_APP_ID` → `PRISMA_SERVICE_ID`. No alias.
+3. **The deployment verbs moved under `service deployment`** (S8, no aliases): `service list-deploys` → `service deployment list`, `service show-deploy` → `service deployment show`, `service promote` → `service deployment promote`, `service rollback` → `service deployment rollback`. Command ids in JSON moved with them (`service.deployment.list` etc.). Old spellings answer `CLI.UNKNOWN_COMMAND`.
+4. **Ruled removals:** `app build`, `app deploy`, `app run` — Composer supersedes all three; deploy's build-locally-and-upload shape was judged wrong, not just redundant. Also removed: `auth logout --workspace` (use `auth workspace logout`), the `rm` alias on `project env remove`, and the mock-only login flags.
+5. **Top-level `init` is the platform's compute-config wizard; the ORM's initializer is `orm init`** (ruled 2026-08-12). A `prisma-next` user typing `prisma init` expecting a schema scaffold gets the compute wizard.
+6. **Telemetry environment variables and the preference file drop the `prisma-next` name**: `PRISMA_DISABLE_TELEMETRY`, `PRISMA_TELEMETRY_ENDPOINT`, `PRISMA_DEBUG`; preference stored under `prisma/`. No fallback to the old names or path — an existing opt-out at the old location reverts to the default. `DO_NOT_TRACK` still works.
+
+## 3. Authentication — the session model
+
+The auth family sits on a new credential model: a set of stored per-workspace sessions plus one selection, and — separately — the credential the current process authenticates as, which may come from `PRISMA_SERVICE_TOKEN` and is not a session.
+
+1. **Mutations succeed while `PRISMA_SERVICE_TOKEN` is set.** `auth login`, `auth logout`, `auth workspace use`, `auth workspace logout` all operate on the stored sessions and print a one-line notice that the environment credential remains in force. Legacy refused workspace switching in that state.
+2. **`auth logout` ends every session** and reports how many, reaping orphaned entries legacy left behind.
+3. **`auth workspace use` selects only** — it never creates a session or opens a browser. A workspace you have no session for is `AUTH.NO_SESSION_FOR_WORKSPACE`; the fix is `auth login`.
+4. **`auth whoami` describes the active credential**, not an auth-state snapshot: `source` (`stored`/`environment`) and `expiresAt` are new; the identity-provider field is gone (nothing records it); a service token reports no user (its subject is a workspace, not a person); a credential naming no workspace reports `workspace: null`.
+5. **Workspace names are not refreshed on read.** Fetched once at login, best-effort; a rename in the Console shows up locally only after the next login. Legacy re-fetched on every read.
+6. **Ending a session is idempotent** — if another process already removed it, the command exits 0.
+7. **A near-expiry stored session is refreshed and persisted before delegated runs; only an unrefreshable credential is refused.** (Later change; the S3 record's "refused up front" wording predates it.)
+8. **Open — escalated engine gap:** a service token that the platform associates with a workspace, but whose own claims name none, is now refused (`SERVICE.WORKSPACE_REQUIRED`). Legacy asked the server (`/v1/me`) and carried on when the server named one. v8 commands never fetch their own identity from the network; if a server round-trip is wanted, it belongs in the credential manager. Ruling needed: complete the workspace server-side, or require every issued token to carry the claim.
+
+## 4. Resource groups — project, postgres, bucket, branch, git
+
+On top of the global changes:
+
+1. **New consent prompts.** `postgres restore/remove`, `postgres connection rotate/remove`, `bucket delete`, `project remove`, `project transfer` previously had only a `--confirm` flag (or nothing interactive); they now type-to-confirm the exact id. `bucket key delete` still asks nothing — the legacy inconsistency ports unchanged, recorded for review.
+2. **A rejected project listing now fails instead of looking empty.** Legacy swallowed API errors and printed "No projects found." with exit 0; every command resolving a project by name inherited the confusion. Fixed in both shells (ruled: this defect was not behaviour anyone chose).
+3. **Plan-limit errors** lose the legacy full-page custom rendering; summary, why and upgrade guidance survive as a normal error with one action.
+4. **Pre-result progress lines** (`Creating database...`) are gone on the synchronous commands.
+5. **`git connect` works non-interactively again** where possible; the wait for the GitHub App installation is the engine's browser-wait (one endpoint event carrying the install URL, engine-owned polling). Install URLs are `open-url` actions instead of fake commands. Cancelling the wait exits 3 while sleeping between polls, 130 if a poll request was in flight — the split is accepted, not smoothed over.
+6. **`bucket key create`** shows its four credential values as masked field rows in the human card (legacy named no values); the stdout `S3_*=` lines and the JSON secrets are unchanged.
+7. Known small quirks recorded, not fixed: `project rename`'s validation copy still says "Project create requires a name"; `branch list` keeps its resolution quirk (no `--project` flag); `git connect`/`git disconnect` keep their raw JSON result shape.
+
+## 5. Services and deployments
+
+Versus the legacy `app` family, beyond the renames in section 2:
+
+1. **Which deployment is live comes from the platform record alone.** The local cache of "live deployment" is retired in both directions — a stale cache can no longer make a deployment look live, and `service deployment list` rows report `null` (unknown) where a cache entry used to claim `true`/`false`.
+2. **`service deployment rollback` asks for consent** (new — legacy asked nothing before changing what production serves). The token is the target deployment's id, so the user must look at which deployment is about to go live.
+3. **Rollback refuses to guess.** With no `--to` and no identifiable live deployment, legacy promoted the newest deployment — most likely the one already live — and reported success. v8 refuses (`SERVICE.LIVE_DEPLOYMENT_UNKNOWN`) and tells the user to name a target or list deployments.
+4. **Five commands are new:** `service list`, `service create`, `service deployment start/stop/delete`. `service create` changes what is possible — before it, a service only came into existence as a side effect of deploying.
+5. **`service create` is idempotent-ish:** a name already taken on the branch returns the existing service with `existing: true` instead of failing (mirrors `service domain add`). **Open — operator ruling pending** on whether it should hard-fail instead. Also: `--branch` resolves *or creates* the named branch, so a typo silently creates a branch (shared-helper behaviour, recorded).
+6. **`stop` asks no consent; `delete` demands the deployment id typed back.** Deliberate: the line is reversibility — a stopped deployment can start again, a deleted one cannot.
+7. **A deployment's url follows liveness.** `service deployment show` reports the promoted address only for the live deployment and the preview address otherwise; presenters show `not deployed` rather than a dead address for never-promoted services.
+8. **`service open`** now also opens the browser under `--json` in an interactive terminal, reports `opened: false` instead of erroring on a failed open, and prints the URL to stdout.
+9. **Success lines are past tense.** A command that changed something ends on "Removed hello-world…" instead of opening with "Removing…".
+10. **Follow-up suggestions pointing at `service deploy` are removed** (the command no longer exists); an empty `nextActions` list is now a normal outcome. Guidance can return pointing at Composer.
+
+## 6. `service logs`
+
+Shipped later than the rest of the family (the S2c port was shelved waiting on socket transport; what shipped is a different shape). Versus the old `app logs`:
+
+1. **A page read replaces a held socket.** Default: the last 100 lines, then exit 0 — the `kubectl logs` shape. `--follow` restores the streaming behaviour via polling (2-second interval); latency is bounded by the poll, not the server's write. The WebSocket upgrade exists on the platform and the CLI does not use it; live streaming remains future work.
+2. **New flags:** `--tail <n>` and `--from-start`; passing both is refused (`SERVICE.LOGS_RANGE_CONFLICT`).
+3. **Refusals instead of silent nonsense:** a page with no resume cursor stops a follow (`SERVICE.LOGS_NO_CURSOR`); a page that ends without its terminal record settles `SERVICE.LOGS_INCOMPLETE` after printing what arrived — a truncated log is never presented as complete.
+4. **A platform-reported log-read failure now fails the command** (`SERVICE.LOGS_FAILED`, exit 2) where the old command printed the message and exited 0. In `--follow`, a retryable failure is retried once, with the budget reset on success.
+5. **Interrupting `--follow` exits 130** — a wrapper treating non-zero as failure sees one when a developer stops following.
+
+## 7. `build logs`
+
+1. Records become engine events; JSON framing is uniform (the legacy opt-out of the success wrapper does not port), and the header line is now framed in JSON output.
+2. **Open — escalated engine gap: a failed build cannot exit 1.** Legacy streamed the logs and set exit 1 on a build failure. The engine constrains documented exit codes, so v8 settles `BUILD.FAILED` at exit 2. Still non-zero, still carries the resume cursor; the code changes 1 → 2. Ruling needed on giving streams a termination status or a documented code.
+3. A run whose build produced no log records reports no cursor anywhere in JSON (nothing to resume from).
+
+## 8. Composer — versus `prisma-composer`
+
+The four commands (`dev`, `deploy`, `destroy`, `log`) mount under `prisma composer …`. The standalone `prisma-composer` bin survives with unprefixed spellings — and now runs the same engine and handlers, so the differences below apply to both invocations.
+
+1. **All engine-global behaviour is new to composer users:** shared flags, JSON framing, format auto-selection, help layout.
+2. **Parse failures say what was wrong** instead of reprinting the whole usage wall. A bare `prisma composer` exits 0 (was 2).
+3. **`deploy --production` is gone from help and parsing** — legacy advertised it and always rejected it at runtime. `destroy` keeps it, where it is valid.
+4. **The reproduce hint on a failed converge is a typed next action**, the redundant failure envelope is gone (the child already owned the terminal), and the hint is dropped when the user themselves killed the child with Ctrl-C.
+5. **JSON mode works for spawning commands:** the child's output routes to diagnostics, stdout stays framed, and a failed child keeps its verbatim exit code with `CLI.CHILD_PROCESS_FAILED` carrying the status.
+6. **`dev` (and `log`) exit 130 on Ctrl-C where legacy exited 0.** The most likely divergence to be noticed: supervisors treating non-zero as failure see one on every manual stop. Engine-wide rule — a signal-ended run is an abort whatever the handler concluded.
+7. **`--tail` is a typed number flag:** `--tail 5abc` is now an error instead of silently 5; the trade is that fractional and negative values are now accepted and passed through (recorded, not narrowed).
+8. **Failures move earlier:** unauthenticated `deploy`/`destroy` are refused before the config is read (legacy failed deep inside the child after doing platform work), and the effect-resolution preflight no longer takes out unrelated commands or `--help`.
+9. **`destroy` still asks nothing** before tearing down — the guard remains the required explicit target. If it deserves a confirmation, that is a Composer product decision, raised upstream.
+10. **Known defect, deferred:** help examples name the wrong invocation under the prisma bin (`prisma deploy …` instead of `prisma composer deploy …`) — the engine's placeholder substitutes the binary name only, and it needs a mount-aware placeholder plus composer rewriting eight strings. Unreachable from the standalone bin.
+
+## 9. ORM family — versus `prisma-next`
+
+Mounting the family introduced **no user-visible divergence**: the commands answer for the first time under this binary. The differences between the ORM commands under this shell and under `prisma-next` belong to the port record kept in prisma/prisma. Two notes:
+
+1. The family ships its redirect table for spellings `prisma-next` had already retired (`migration apply`, `migration ref`, four `migration status` flags).
+2. Operational cost, not a divergence: the ORM family's entry statically imports esbuild, arktype and a dozen framework subpaths, so every invocation of the bin pays that startup cost — including `prisma --version`. Fixing it is a prisma/prisma change; tracked as deferred.
+
+## 10. `init`
+
+1. **The three optional steps (install types, link, agent skills) default to no.** Ratified with a stated cost: interactive users press `y` where they pressed Enter; unattended runs keep exactly today's behaviour. One line per prompt to flip.
+2. **`--format` is renamed `--config-format`** (the engine reserves `--format` for output format). The value must be exactly `ts` or `json` — `typescript`, mixed case and whitespace are no longer accepted.
+3. **Cancelling a question aborts the run at exit 3** (legacy recorded a decline and exited 0); an already-written config stays on disk. Unattended runs report `declined` where legacy said `skipped` (JSON-only difference).
+4. **The link step no longer auto-logs-in**; signed out, it reports `link.status: "unauthenticated"` with a sign-in action.
+5. One legacy catch-all usage error split into nine distinct `INIT.*` codes (machine-facing contract change; every sentence preserved).
+
+## 11. Agent skills, feedback, telemetry
+
+1. **`agent install/update/status`** keep their spellings and behaviour; warnings and next steps become typed. **Open — escalated engine gap:** help examples lose the package-runner form (`pnpm dlx @prisma/cli@latest agent install` → bare `agent install`) while run-time next actions keep it, so the command spells itself two ways. Worth one group-wide ruling.
+2. **The crash-recovery feedback action does not port — open, escalated engine gap.** Legacy pre-filled `prisma-cli feedback "<command> crashed: …"` on every unexpected error. The engine settles crashes itself with no contribution point for the shell, so a v8 crash offers no recovery action. The `feedback` command itself works; only the automatic pre-fill is gone. A small engine hook would restore it.
+3. **`feedback`'s payload** reports the runtime truthfully (`runtime: {name, version}` instead of `nodeVersion`), so a bun or deno build identifies itself.
+4. **Telemetry:** config-file enrichment dropped (the config it read does not exist in this product); events fire at command start (same point as the reference); first-run disclosure says "Prisma" not "Prisma Next" and no longer suggests hand-editing the machine-owned preference file; negated flags are counted under one name (`--color`, not `--color` and `--no-color`).
+
+## 12. Open items in one place
+
+For the discussion — everything above that still needs a decision:
+
+1. Service token whose workspace only the server knows: refuse (current) or complete server-side in the credential manager (§3.8).
+2. `build logs` exit code on a failed build: 2 today, legacy 1 (§7.2).
+3. Agent-group help examples versus package-runner next actions: pick one spelling policy group-wide (§11.1).
+4. Crash-recovery feedback pre-fill: needs a small engine hook (§11.2).
+5. `service create` idempotency: return-existing (current) or hard-fail (§5.5).
+6. Composer help examples under the prisma bin: needs a mount-aware placeholder, coordinated across repos (§8.10).
+7. `bucket key delete` asks no consent while `bucket delete` does — ported inconsistency, review whether to keep (§4.1).
+8. One unswept `--trace` mention survives in service-reachable legacy error prose; every other group rewrites it. Small fix.

--- a/.drive/projects/prisma-cli-v8/assets/divergence-validation-2026-08-20.md
+++ b/.drive/projects/prisma-cli-v8/assets/divergence-validation-2026-08-20.md
@@ -1,0 +1,40 @@
+# Parity-divergence records — validation against rc.6 (2026-08-20)
+
+The project keeps five parity-divergence records, each listing where the v8 CLI knowingly differs from the legacy CLI. This report checks their concrete claims against the code at `main` (8.0.0-rc.6). Verdict per record below; the records themselves are left untouched because the cumulative one is operator-ratified.
+
+**Bottom line: every ratified decision still holds.** All six signed-off items and the class-level rules (dotted error codes, exit 2/3, `--trace` removal, the renames and removals, no `version` command) are accurate in today's code. What has gone stale is description, not decisions: later slices renamed the `service` grammar, shipped the shelved `service logs`, flattened the `src/v8/` tree, and bumped pinned versions, and the records were not updated to match.
+
+## [`s2/parity-divergences.md`](s2/parity-divergences.md) — cumulative S2 record, ratified 2026-08-12
+
+Signed-off items 1–6 all verified as still true, including the three escalated engine gaps (`build logs` cannot exit 1; a service token whose workspace only the server knows is refused; the crash-recovery feedback action is absent). Stale content:
+
+1. **The S2c `service` rename tables are outdated.** S8 restructured the group: `service list-deploys`, `service show-deploy`, `service promote`, `service rollback` are gone, replaced by the `service deployment` subgroup. `service list` and `service create` are new commands with no divergence entry. The consent-point count ("two, later three") is now four (`service remove`, `service domain remove`, `service deployment rollback`, `service deployment delete`).
+2. **`service logs` is recorded as shelved but ships.** It mounts at `service logs` and polls the Management API (no WebSocket). Everything the record says "went with the command" is back: its test file, `SERVICE.DEPLOYMENT_DETACHED`, `SERVICE.DEPLOYMENT_OUTSIDE_PROJECT`. The "one real capability loss of the pass" claim in the shell-deletion section no longer holds. The current contract is `specs/service-logs.md` + `s2/parity-divergences-service-logs.md`.
+3. **D3 entry 41 is no longer true**: the `PROJECT_AMBIGUOUS` next step no longer says `app deploy` verbatim; it now offers `project list` / `project link <id>` ([resolution.ts:271](../../../../packages/cli/src/lib/project/resolution.ts)).
+4. **File citations are dangling**: every `src/v8/…` path (tree flattened at shell deletion), every `src/shell/…` path (deleted), the `v8-` test-file prefixes, and the bin path `dist/v8/cli.js` (now `dist/cli.js`).
+5. **One unswept `--trace` path**: five groups rewrite `--trace` out of legacy error prose, but `commands/service/errors.ts` does not, and legacy prose reachable through it still mentions `--trace` ([provider.ts:181](../../../../packages/cli/src/lib/project/provider.ts)). Worth a small fix or a divergence entry.
+
+## [`s2/parity-divergences-s3.md`](s2/parity-divergences-s3.md) — composer
+
+All behavioural entries verified in the shipping `@prisma/composer-cli` 0.10.0: mounting, the help-examples defect (still unfixed, deferral correct), `deploy --production` dropped while `destroy` keeps it, structured child output, exit-code semantics, config-path handling, the effect-resolution preflight. Stale:
+
+1. **Version pins**: the record cites `@prisma/composer@0.6.0-dev.16`; the CLI now pins `composer-cli`/`composer` 0.10.0 (dev pins removed by #192). The examples also live in `@prisma/composer-cli`'s `dist/family.mjs`, not `@prisma/composer`'s.
+2. **Near-expiry sessions are refreshed, not refused.** #183 changed `credentials: "child"` to rotate and persist a refreshable session inside the near-expiry window; only unrefreshable credentials are refused. The record still says close-to-expiry is "refused up front".
+3. **The "legacy" baseline no longer runs anywhere.** The published `prisma-composer` bin is now the same engine and family mounted at top level; the clipanion shell the record's legacy column describes is gone. The comparisons stay valid as history, but cannot be reproduced against today's `prisma-composer`.
+
+## [`s2/parity-divergences-s7.md`](s2/parity-divergences-s7.md) — release
+
+Mostly holds (no shipped command moved; the ORM redirect table ships). Stale:
+
+1. It lists `prisma init` as an ORM-family mount. The ORM initializer was ruled to `orm init` (operator, 2026-08-12); top-level `init` is the platform's compute-config wizard.
+2. "Eight `@prisma/orm-framework` subpaths" is now twelve in the pinned `orm-toolchain` 8.0.0-rc.4. The `arktype`/`esbuild` static-import complaint still stands.
+
+## [`s2/parity-divergences-s8.md`](s2/parity-divergences-s8.md) — services
+
+Verified almost entirely accurate: the `service deployment` grammar with no aliases, command ids, consent rules (`deployment delete` requires the id as confirmation token and `--yes` cannot grant it), live-URL derivation, the retired local live-deployment cache, `service create`'s branch resolution and 409 handling. One mis-scoping:
+
+1. The "narrower than the contract" caveat (live deployment must appear in the listing page) is attributed to `service show`, but lives in the shared `resolveCurrentLiveDeploymentId` ([target.ts:430](../../../../packages/cli/src/commands/service/target.ts)), so it equally applies to `service deployment list`, `service logs`, `service open`, and `service deployment promote`.
+
+## [`s2/parity-divergences-service-logs.md`](s2/parity-divergences-service-logs.md) — service logs
+
+Fully accurate. Mount point, transport (NDJSON pages, 2 s `--follow` poll), flags and their conflict error, cursor/incomplete/failed error codes, single retry with budget reset, interrupt exit 130 — all verified. Two footnotes: the test-only `PRISMA_CLI_SERVICE_LOGS_POLL_MS` override is undocumented, and the unused WebSocket path (`streamDeploymentLogs`) still exists in the provider with no caller.

--- a/.drive/projects/prisma-cli-v8/assets/divergence-validation-2026-08-20.md
+++ b/.drive/projects/prisma-cli-v8/assets/divergence-validation-2026-08-20.md
@@ -4,17 +4,17 @@ The project keeps five parity-divergence records, each listing where the v8 CLI 
 
 **Bottom line: every ratified decision still holds.** All six signed-off items and the class-level rules (dotted error codes, exit 2/3, `--trace` removal, the renames and removals, no `version` command) are accurate in today's code. What has gone stale is description, not decisions: later slices renamed the `service` grammar, shipped the shelved `service logs`, flattened the `src/v8/` tree, and bumped pinned versions, and the records were not updated to match.
 
-## [`s2/parity-divergences.md`](s2/parity-divergences.md) — cumulative S2 record, ratified 2026-08-12
+## `s2/parity-divergences.md` — cumulative S2 record, ratified 2026-08-12
 
 Signed-off items 1–6 all verified as still true, including the three escalated engine gaps (`build logs` cannot exit 1; a service token whose workspace only the server knows is refused; the crash-recovery feedback action is absent). Stale content:
 
 1. **The S2c `service` rename tables are outdated.** S8 restructured the group: `service list-deploys`, `service show-deploy`, `service promote`, `service rollback` are gone, replaced by the `service deployment` subgroup. `service list` and `service create` are new commands with no divergence entry. The consent-point count ("two, later three") is now four (`service remove`, `service domain remove`, `service deployment rollback`, `service deployment delete`).
 2. **`service logs` is recorded as shelved but ships.** It mounts at `service logs` and polls the Management API (no WebSocket). Everything the record says "went with the command" is back: its test file, `SERVICE.DEPLOYMENT_DETACHED`, `SERVICE.DEPLOYMENT_OUTSIDE_PROJECT`. The "one real capability loss of the pass" claim in the shell-deletion section no longer holds. The current contract is `specs/service-logs.md` + `s2/parity-divergences-service-logs.md`.
-3. **D3 entry 41 is no longer true**: the `PROJECT_AMBIGUOUS` next step no longer says `app deploy` verbatim; it now offers `project list` / `project link <id>` ([resolution.ts:271](../../../../packages/cli/src/lib/project/resolution.ts)).
+3. **D3 entry 41 is no longer true**: the `PROJECT_AMBIGUOUS` next step no longer says `app deploy` verbatim; it now offers `project list` / `project link <id>` (`resolution.ts:271`).
 4. **File citations are dangling**: every `src/v8/…` path (tree flattened at shell deletion), every `src/shell/…` path (deleted), the `v8-` test-file prefixes, and the bin path `dist/v8/cli.js` (now `dist/cli.js`).
-5. **One unswept `--trace` path**: five groups rewrite `--trace` out of legacy error prose, but `commands/service/errors.ts` does not, and legacy prose reachable through it still mentions `--trace` ([provider.ts:181](../../../../packages/cli/src/lib/project/provider.ts)). Worth a small fix or a divergence entry.
+5. **One unswept `--trace` path**: five groups rewrite `--trace` out of legacy error prose, but `commands/service/errors.ts` does not, and legacy prose reachable through it still mentions `--trace` (`provider.ts:181`). Worth a small fix or a divergence entry.
 
-## [`s2/parity-divergences-s3.md`](s2/parity-divergences-s3.md) — composer
+## `s2/parity-divergences-s3.md` — composer
 
 All behavioural entries verified in the shipping `@prisma/composer-cli` 0.10.0: mounting, the help-examples defect (still unfixed, deferral correct), `deploy --production` dropped while `destroy` keeps it, structured child output, exit-code semantics, config-path handling, the effect-resolution preflight. Stale:
 
@@ -22,19 +22,19 @@ All behavioural entries verified in the shipping `@prisma/composer-cli` 0.10.0: 
 2. **Near-expiry sessions are refreshed, not refused.** #183 changed `credentials: "child"` to rotate and persist a refreshable session inside the near-expiry window; only unrefreshable credentials are refused. The record still says close-to-expiry is "refused up front".
 3. **The "legacy" baseline no longer runs anywhere.** The published `prisma-composer` bin is now the same engine and family mounted at top level; the clipanion shell the record's legacy column describes is gone. The comparisons stay valid as history, but cannot be reproduced against today's `prisma-composer`.
 
-## [`s2/parity-divergences-s7.md`](s2/parity-divergences-s7.md) — release
+## `s2/parity-divergences-s7.md` — release
 
 Mostly holds (no shipped command moved; the ORM redirect table ships). Stale:
 
 1. It lists `prisma init` as an ORM-family mount. The ORM initializer was ruled to `orm init` (operator, 2026-08-12); top-level `init` is the platform's compute-config wizard.
 2. "Eight `@prisma/orm-framework` subpaths" is now twelve in the pinned `orm-toolchain` 8.0.0-rc.4. The `arktype`/`esbuild` static-import complaint still stands.
 
-## [`s2/parity-divergences-s8.md`](s2/parity-divergences-s8.md) — services
+## `s2/parity-divergences-s8.md` — services
 
 Verified almost entirely accurate: the `service deployment` grammar with no aliases, command ids, consent rules (`deployment delete` requires the id as confirmation token and `--yes` cannot grant it), live-URL derivation, the retired local live-deployment cache, `service create`'s branch resolution and 409 handling. One mis-scoping:
 
-1. The "narrower than the contract" caveat (live deployment must appear in the listing page) is attributed to `service show`, but lives in the shared `resolveCurrentLiveDeploymentId` ([target.ts:430](../../../../packages/cli/src/commands/service/target.ts)), so it equally applies to `service deployment list`, `service logs`, `service open`, and `service deployment promote`.
+1. The "narrower than the contract" caveat (live deployment must appear in the listing page) is attributed to `service show`, but lives in the shared `resolveCurrentLiveDeploymentId` (`target.ts:430`), so it equally applies to `service deployment list`, `service logs`, `service open`, and `service deployment promote`.
 
-## [`s2/parity-divergences-service-logs.md`](s2/parity-divergences-service-logs.md) — service logs
+## `s2/parity-divergences-service-logs.md` — service logs
 
 Fully accurate. Mount point, transport (NDJSON pages, 2 s `--follow` poll), flags and their conflict error, cursor/incomplete/failed error codes, single retry with budget reset, interrupt exit 130 — all verified. Two footnotes: the test-only `PRISMA_CLI_SERVICE_LOGS_POLL_MS` override is undocumented, and the unused WebSocket path (`streamDeploymentLogs`) still exists in the provider with no caller.


### PR DESCRIPTION
Two documents for the command review with Luan:

- `.drive/projects/prisma-cli-v8/assets/command-review.md` — all 90 mounted commands with their one-line meanings, organized by group, generated from `packages/cli/src/cli.ts` at rc.6. Flags and options deliberately omitted; the review is about semantic content and organization.
- `.drive/projects/prisma-cli-v8/assets/divergence-validation-2026-08-20.md` — the five parity-divergence records checked against the code at rc.6. Every ratified decision still holds, including all six signed-off items and the three escalated engine gaps. The stale parts are descriptions, not decisions: the S8 service-grammar rename invalidated the S2c rename and consent tables, `service logs` shipped despite the cumulative record saying it is shelved, every `src/v8/` and `src/shell/` citation dangles, and the composer record's version pins and near-expiry-refusal claim are outdated. One unswept `--trace` mention survives in service error prose and may deserve a small fix.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)