### PR TITLE
feat(compute): add future-compatible keep-awake control file path

### DIFF
--- a/packages/compute/src/scale-to-zero-control.ts
+++ b/packages/compute/src/scale-to-zero-control.ts
@@ -1,15 +1,24 @@
 import fs from "node:fs";
 
-const DEFAULT_CONTROL_FILE_PATH = "/uk/libukp/scale_to_zero_disable";
+/**
+ * Possible locations of the control file.
+ *
+ * The location of these files and the protocol are an internal implementation detail
+ * subject to change. Only the high level TypeScript wrapper is a public API.
+ */
+const DEFAULT_CONTROL_FILE_PATHS: readonly string[] = [
+  "/run/prisma/compute/keep-awake",
+  "/uk/libukp/scale_to_zero_disable",
+];
 
 type ControlFileState =
-  | { kind: "uninitialized"; path: string }
-  | { kind: "unavailable"; path: string }
+  | { kind: "uninitialized"; paths: readonly string[] }
+  | { kind: "unavailable"; paths: readonly string[] }
   | { kind: "open"; fd: number; path: string };
 
 let controlFileState: ControlFileState = {
   kind: "uninitialized",
-  path: DEFAULT_CONTROL_FILE_PATH,
+  paths: DEFAULT_CONTROL_FILE_PATHS,
 };
 
 export type ScaleToZeroSignal = "acquire" | "release";
@@ -34,28 +43,40 @@ function getControlFileState(): ControlFileState {
     return controlFileState;
   }
 
-  try {
-    controlFileState = {
-      kind: "open",
-      fd: fs.openSync(controlFileState.path, fs.constants.O_WRONLY),
-      path: controlFileState.path,
-    };
-  } catch {
-    controlFileState = { kind: "unavailable", path: controlFileState.path };
+  const paths = controlFileState.paths;
+
+  for (const path of paths) {
+    try {
+      controlFileState = {
+        kind: "open",
+        fd: fs.openSync(path, fs.constants.O_WRONLY),
+        path,
+      };
+      return controlFileState;
+    } catch {
+      // Try the next candidate path.
+    }
   }
 
+  controlFileState = { kind: "unavailable", paths };
   return controlFileState;
 }
 
 export function configureScaleToZeroControlFileForTests(
-  path: string | undefined,
+  paths: string | readonly string[] | undefined,
 ): void {
   if (controlFileState.kind === "open") {
     fs.closeSync(controlFileState.fd);
   }
 
-  controlFileState = {
-    kind: "uninitialized",
-    path: path ?? DEFAULT_CONTROL_FILE_PATH,
-  };
+  let candidatePaths: readonly string[];
+  if (paths === undefined) {
+    candidatePaths = DEFAULT_CONTROL_FILE_PATHS;
+  } else if (typeof paths === "string") {
+    candidatePaths = [paths];
+  } else {
+    candidatePaths = paths;
+  }
+
+  controlFileState = { kind: "uninitialized", paths: candidatePaths };
 }

--- a/packages/compute/tests/keep-awake-guard.test.ts
+++ b/packages/compute/tests/keep-awake-guard.test.ts
@@ -116,6 +116,46 @@ describe("keep-awake guard", () => {
     await expect(promise).resolves.toBe("done");
   });
 
+  it("writes to the first candidate path when it exists", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "prisma-compute-"));
+    const preferred = path.join(dir, "keep-awake");
+    const fallback = path.join(dir, "scale_to_zero_disable");
+    await fs.writeFile(preferred, "");
+    await fs.writeFile(fallback, "");
+    configureScaleToZeroControlFileForTests([preferred, fallback]);
+
+    using guard = new KeepAwakeGuard();
+    guard.release();
+
+    expect(await readSignals(preferred)).toBe("+-");
+    expect(await readSignals(fallback)).toBe("");
+  });
+
+  it("falls back to the next candidate path when the first is missing", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "prisma-compute-"));
+    const preferred = path.join(dir, "keep-awake");
+    const fallback = path.join(dir, "scale_to_zero_disable");
+    await fs.writeFile(fallback, "");
+    configureScaleToZeroControlFileForTests([preferred, fallback]);
+
+    using guard = new KeepAwakeGuard();
+    guard.release();
+
+    expect(await readSignals(fallback)).toBe("+-");
+  });
+
+  it("is a no-op when no candidate path exists", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "prisma-compute-"));
+    configureScaleToZeroControlFileForTests([
+      path.join(dir, "keep-awake"),
+      path.join(dir, "scale_to_zero_disable"),
+    ]);
+    const promise = Promise.resolve("done");
+
+    expect(waitUntil(promise)).toBeUndefined();
+    await expect(promise).resolves.toBe("done");
+  });
+
   it("removes the abort listener after manual release", async () => {
     const { file } = await createControlFile();
     const controller = new AbortController();


### PR DESCRIPTION
## What

The keep-awake guard in `@prisma/compute` now looks for its control file at two candidate paths, in order:

1. `/run/prisma/compute/keep-awake`
2. `/uk/libukp/scale_to_zero_disable`

The first path that opens is used for all subsequent signals. If neither exists, the guard stays a no-op, as before.

## Why

The compute runtime is moving the control file to `/run/prisma/compute/keep-awake`. Supporting both paths now keeps the package forward-compatible without breaking current deployments.

## Tests

- The preferred path receives the signals when both paths exist.
- The guard falls back to the default path when the preferred path is missing.
- The guard is a no-op when no candidate path exists.

The test hook `configureScaleToZeroControlFileForTests` now accepts a single path or a list of candidate paths.