### PR TITLE
Bump to version 8.0.0-rc.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-cli",
-  "version": "8.0.0-rc.7",
+  "version": "8.0.0-rc.8",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/packages/cli-conformance/package.json
+++ b/packages/cli-conformance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/cli-conformance",
   "private": true,
-  "version": "8.0.0-rc.7",
+  "version": "8.0.0-rc.8",
   "description": "Reusable conformance checks for the engine's consumers: import purity over built output, config-section validators that never throw, and verification of the tarballs a registry would receive. Depends on no package it checks.",
   "type": "module",
   "exports": {
@@ -24,7 +24,7 @@
     "test": "pnpm run typecheck && vitest run"
   },
   "devDependencies": {
-    "@repo/tsconfig": "workspace:8.0.0-rc.7",
+    "@repo/tsconfig": "workspace:8.0.0-rc.8",
     "@types/node": "^22.19.19",
     "es-module-lexer": "^2.1.0",
     "tsx": "^4.22.4",

--- a/packages/cli-engine/package.json
+++ b/packages/cli-engine/package.json
@@ -55,8 +55,8 @@
     "string-width": "^8.2.1"
   },
   "devDependencies": {
-    "@repo/cli-conformance": "workspace:8.0.0-rc.7",
-    "@repo/tsconfig": "workspace:8.0.0-rc.7",
+    "@repo/cli-conformance": "workspace:8.0.0-rc.8",
+    "@repo/tsconfig": "workspace:8.0.0-rc.8",
     "@types/node": "^22.19.19",
     "ci-info": "^4.3.1",
     "tsdown": "^0.21.10",

--- a/packages/cli-telemetry/package.json
+++ b/packages/cli-telemetry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/cli-telemetry",
   "private": true,
-  "version": "8.0.0-rc.7",
+  "version": "8.0.0-rc.8",
   "description": "CLI telemetry child sender: the detached subprocess the engine hands a composed payload to, its system probes, and the POST",
   "type": "module",
   "sideEffects": [
@@ -35,7 +35,7 @@
     "@vercel/detect-agent": "^1.2.3"
   },
   "devDependencies": {
-    "@repo/tsconfig": "workspace:8.0.0-rc.7",
+    "@repo/tsconfig": "workspace:8.0.0-rc.8",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/cli",
-  "version": "8.0.0-rc.7",
+  "version": "8.0.0-rc.8",
   "description": "Command-line interface for the Prisma Developer Platform.",
   "type": "module",
   "bin": {
@@ -62,9 +62,9 @@
   },
   "devDependencies": {
     "@prisma/composer": "0.11.0",
-    "@repo/cli-conformance": "workspace:8.0.0-rc.7",
-    "@repo/cli-telemetry": "workspace:8.0.0-rc.7",
-    "@repo/tsconfig": "workspace:8.0.0-rc.7",
+    "@repo/cli-conformance": "workspace:8.0.0-rc.8",
+    "@repo/cli-telemetry": "workspace:8.0.0-rc.8",
+    "@repo/tsconfig": "workspace:8.0.0-rc.8",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "tsx": "^4.22.4",

--- a/packages/compute/package.json
+++ b/packages/compute/package.json
@@ -42,7 +42,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@repo/tsconfig": "workspace:8.0.0-rc.7",
+    "@repo/tsconfig": "workspace:8.0.0-rc.8",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3",

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma",
-  "version": "8.0.0-rc.7",
+  "version": "8.0.0-rc.8",
   "description": "The Prisma CLI: one binary for the ORM, Composer, and the Prisma Developer Platform.",
   "type": "module",
   "bin": {
@@ -56,9 +56,9 @@
     "open": "^11.0.0"
   },
   "devDependencies": {
-    "@prisma/cli": "workspace:8.0.0-rc.7",
-    "@repo/cli-telemetry": "workspace:8.0.0-rc.7",
-    "@repo/tsconfig": "workspace:8.0.0-rc.7",
+    "@prisma/cli": "workspace:8.0.0-rc.8",
+    "@repo/cli-telemetry": "workspace:8.0.0-rc.8",
+    "@repo/tsconfig": "workspace:8.0.0-rc.8",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3"

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/tsconfig",
   "private": true,
-  "version": "8.0.0-rc.7",
+  "version": "8.0.0-rc.8",
   "description": "Base tsconfig providing package for the monorepo",
   "license": "Apache-2.0",
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,13 +61,13 @@ importers:
         specifier: 0.11.0
         version: 0.11.0(@types/node@22.19.19)(magicast@0.5.3)(rollup@4.62.2)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8(@types/node@22.19.19)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(workerd@1.20260704.1)(ws@8.21.0)
       '@repo/cli-conformance':
-        specifier: workspace:8.0.0-rc.7
+        specifier: workspace:8.0.0-rc.8
         version: link:../cli-conformance
       '@repo/cli-telemetry':
-        specifier: workspace:8.0.0-rc.7
+        specifier: workspace:8.0.0-rc.8
         version: link:../cli-telemetry
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.7
+        specifier: workspace:8.0.0-rc.8
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -88,7 +88,7 @@ importers:
   packages/cli-conformance:
     devDependencies:
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.7
+        specifier: workspace:8.0.0-rc.8
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -131,10 +131,10 @@ importers:
         version: 8.2.1
     devDependencies:
       '@repo/cli-conformance':
-        specifier: workspace:8.0.0-rc.7
+        specifier: workspace:8.0.0-rc.8
         version: link:../cli-conformance
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.7
+        specifier: workspace:8.0.0-rc.8
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -159,7 +159,7 @@ importers:
         version: 1.2.4
     devDependencies:
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.7
+        specifier: workspace:8.0.0-rc.8
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -177,7 +177,7 @@ importers:
   packages/compute:
     devDependencies:
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.7
+        specifier: workspace:8.0.0-rc.8
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -229,13 +229,13 @@ importers:
         version: 11.0.0
     devDependencies:
       '@prisma/cli':
-        specifier: workspace:8.0.0-rc.7
+        specifier: workspace:8.0.0-rc.8
         version: link:../cli
       '@repo/cli-telemetry':
-        specifier: workspace:8.0.0-rc.7
+        specifier: workspace:8.0.0-rc.8
         version: link:../cli-telemetry
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.7
+        specifier: workspace:8.0.0-rc.8
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19


### PR DESCRIPTION
The release bump for the command-grammar rework (#218): explicit id-first positional targeting, delete verbs, workflow-grouped commands, the ADR-012 service/version vocabulary, and both external families mounted as shipped against released @prisma/composer-cli@0.12.0 and @prisma/orm-toolchain@8.0.0-rc.5. Produced by scripts/bump-version.ts; the engine stays at 0.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)