### PR TITLE
Replace deprecated tsdown noExternal with deps.alwaysBundle

### DIFF
--- a/packages/cli-engine/src/ci.ts
+++ b/packages/cli-engine/src/ci.ts
@@ -20,7 +20,7 @@ interface Vendor {
 /**
  * ci-info's provider table. Its `isCI` export is unusable — it reads
  * the real `process.env` at import; the engine reads only host-injected
- * env. The table is inlined into the build (tsdown `noExternal`): the
+ * env. The table is inlined into the build (tsdown `deps.alwaysBundle`): the
  * file is CJS-owned by ci-info, and loading it as ESM at runtime breaks
  * hosts that also require ci-info (Bun's dual registry; composer#234).
  * Pinned by tests/no-esm-json-import-in-dist.test.ts.

--- a/packages/cli-engine/tsdown.config.ts
+++ b/packages/cli-engine/tsdown.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   },
   format: ["esm"],
   // The vendor table is embedded; see src/ci.ts.
-  noExternal: ["ci-info/vendors.json"],
+  deps: { alwaysBundle: ["ci-info/vendors.json"] },
   dts: true,
   clean: true,
   fixedExtension: false,

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -15,7 +15,7 @@ export default defineConfig([
     clean: true,
     shims: true,
     fixedExtension: false,
-    noExternal: ["@repo/cli-telemetry"],
+    deps: { alwaysBundle: ["@repo/cli-telemetry"] },
     outDir: "dist",
   },
 ]);

--- a/packages/prisma/tsdown.config.ts
+++ b/packages/prisma/tsdown.config.ts
@@ -15,7 +15,7 @@ export default defineConfig([
     clean: true,
     shims: true,
     fixedExtension: false,
-    noExternal: ["@prisma/cli", "@repo/cli-telemetry"],
+    deps: { alwaysBundle: ["@prisma/cli", "@repo/cli-telemetry"] },
     outDir: "dist",
   },
   // The `prisma/config` subpath for user prisma.config.ts files.


### PR DESCRIPTION
tsdown 0.21.10 warns on every publish build that `noExternal` is deprecated. The installed version already supports the replacement, so the three configs (`prisma`, `cli`, `cli-engine`) now use `deps: { alwaysBundle: [...] }` with the same values, and the `ci.ts` comment that named the old option is updated. All three packages build cleanly with no warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)