### PR TITLE
The skills staleness notice detects CI by ci-info's rules; engine 0.2.2

### DIFF
--- a/packages/cli-engine/package.json
+++ b/packages/cli-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/cli-engine",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "The execution engine of the unified Prisma CLI.",
   "type": "module",
   "exports": {

--- a/packages/cli-engine/src/exports/index.ts
+++ b/packages/cli-engine/src/exports/index.ts
@@ -16,6 +16,8 @@ export {
   type PositionalSpec,
   positional,
 } from "../args";
+/** ci-info's CI detection over the given env only — never process.env. */
+export { detectCI } from "../ci";
 export { type Cli, type CliRunHooks, createCli } from "../cli";
 export {
   type CommandFamily,

--- a/packages/cli-engine/tests/engine.test.ts
+++ b/packages/cli-engine/tests/engine.test.ts
@@ -34,6 +34,7 @@ describe("main export", () => {
       "definePrismaConfig",
       "defineServerCommand",
       "defineSessionCommand",
+      "detectCI",
       "emptyServiceTokenError",
       "exitWithChildStatus",
       "flag",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@manypkg/tools": "^2.1.2",
-    "@prisma/cli-engine": "workspace:0.2.1",
+    "@prisma/cli-engine": "workspace:0.2.2",
     "@prisma/composer-cli": "0.12.0",
     "@prisma/compute-sdk": "0.39.0",
     "@prisma/credentials-store": "^7.8.0",

--- a/packages/cli/scripts/conformance.ts
+++ b/packages/cli/scripts/conformance.ts
@@ -116,25 +116,25 @@ async function tarball(): Promise<readonly Finding[]> {
       // that is not on the registry, so the engine publishes first and
       // the mismatch is real until both families release against it.
       // The entries expire with the versions they name, and the PR
-      // that pins the families' 0.2.1 releases removes them; while
+      // that pins the families' 0.2.2 releases removes them; while
       // they stand, a release could ship the two-engine install they
       // describe, which is why they must not outlive the transition.
       exceptions: [
         {
           familyPackage: "@prisma/composer-cli",
           familyPin: "0.2.0",
-          shellPin: "0.2.1",
-          reason: "engine 0.2.1 must publish before composer-cli can peer it",
+          shellPin: "0.2.2",
+          reason: "engine 0.2.2 must publish before composer-cli can peer it",
           removeWhen:
-            "composer-cli releases peering 0.2.1 and the follow-up bump PR pins that release",
+            "composer-cli releases peering 0.2.2 and the follow-up bump PR pins that release",
         },
         {
           familyPackage: "@prisma/orm-toolchain",
           familyPin: "0.2.0",
-          shellPin: "0.2.1",
-          reason: "engine 0.2.1 must publish before orm-toolchain can peer it",
+          shellPin: "0.2.2",
+          reason: "engine 0.2.2 must publish before orm-toolchain can peer it",
           removeWhen:
-            "orm-toolchain releases peering 0.2.1 and the follow-up bump PR pins that release",
+            "orm-toolchain releases peering 0.2.2 and the follow-up bump PR pins that release",
         },
       ],
       channel: CHANNEL,

--- a/packages/cli/src/skills-check.ts
+++ b/packages/cli/src/skills-check.ts
@@ -8,6 +8,7 @@
  * It never changes the exit code, never writes to stdout, and is not
  * conditioned on a TTY: agents run without one and are who this is for.
  */
+import { detectCI } from "@prisma/cli-engine";
 import { readProjectSkillsConfig } from "./commands/skills/config";
 import { agentSkillDirs, DEFAULT_AGENTS } from "./lib/skills/allowlist";
 import { readSkillsCheckDisabled } from "./lib/skills/opt-out";
@@ -152,7 +153,7 @@ function isSuppressedByInvocation(runtime: SkillsCheckRuntime): boolean {
   if (env[SKILLS_CHECK_ENV_VAR] === "0") {
     return true;
   }
-  if (env.CI || env.GITHUB_ACTIONS) {
+  if (detectCI(env)) {
     return true;
   }
 

--- a/packages/cli/tests/skills-check.test.ts
+++ b/packages/cli/tests/skills-check.test.ts
@@ -240,6 +240,10 @@ describe("the skills check off switches", () => {
     ["PRISMA_SKILLS_CHECK=0", { env: { PRISMA_SKILLS_CHECK: "0" } }],
     ["CI", { env: { CI: "1" } }],
     ["GITHUB_ACTIONS", { env: { GITHUB_ACTIONS: "true" } }],
+    [
+      "TEAMCITY_VERSION (no CI variable)",
+      { env: { TEAMCITY_VERSION: "2025.1" } },
+    ],
   ])("stays silent under %s", async (_name, overrides) => {
     const proc = makeProcess({ cwd: await makeStaleProject(), ...overrides });
 

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@manypkg/tools": "^2.1.2",
-    "@prisma/cli-engine": "workspace:0.2.1",
+    "@prisma/cli-engine": "workspace:0.2.2",
     "@prisma/composer-cli": "0.12.0",
     "@prisma/compute-sdk": "0.39.0",
     "@prisma/credentials-store": "^7.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ importers:
         specifier: ^2.1.2
         version: 2.1.2
       '@prisma/cli-engine':
-        specifier: workspace:0.2.1
+        specifier: workspace:0.2.2
         version: link:../cli-engine
       '@prisma/composer-cli':
         specifier: 0.12.0
@@ -201,7 +201,7 @@ importers:
         specifier: ^2.1.2
         version: 2.1.2
       '@prisma/cli-engine':
-        specifier: workspace:0.2.1
+        specifier: workspace:0.2.2
         version: link:../cli-engine
       '@prisma/composer-cli':
         specifier: 0.12.0


### PR DESCRIPTION
## What

The per-command skills staleness notice suppressed itself only under `CI` or `GITHUB_ACTIONS`, so CI systems that set neither variable — Jenkins (`BUILD_ID`), TeamCity (`TEAMCITY_VERSION`), Azure Pipelines (`TF_BUILD`) — got the notice line in their logs.

## Changes

- The engine's `detectCI(env)` — ci-info's vendor table evaluated against a caller-supplied env, never `process.env` — is now exported from the package's public surface (it already backed `resolveIsCI`; the export-surface inventory test is updated).
- The shell's skills check replaces the two-variable check with `detectCI(runtime.env)`. The `GITHUB_ACTIONS` special case is gone (GitHub Actions sets `CI=true`, and the vendor table covers it regardless).
- The suppression test matrix keeps the `CI` case and adds `TEAMCITY_VERSION` — a vendor the old check missed.
- **Engine 0.2.2** (`pnpm bump-cli-engine-version patch`): the export surface changed, and 0.2.1 already published (immutable) from #222. The families have not released against 0.2.1 yet, so the transition exceptions from #222 move to 0.2.2 — the family releases peer 0.2.2 and skip 0.2.1 entirely.

With this, all three CI-detection surfaces (the ORM's `is-ci.ts` wrapping ci-info, the engine, and the shell's notice) derive from ci-info's data.

## Verification

Engine suite 35 files pass; CLI suite 61 files pass (including the new TEAMCITY case); `pnpm run conformance`: 0 failing, the transition mismatches suppressed by the recorded exceptions; `check-engine-version.mjs origin/main`: 0.2.2 consistent; typecheck green.

## After merge

Same train as #222, now targeting 0.2.2: main publishes `@prisma/cli-engine@0.2.2` → composer and prisma/prisma release peering 0.2.2 → a follow-up PR here pins those releases and empties the exception list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)