### PR TITLE
Remove the deprecated defineConfig alias before launch

### DIFF
--- a/packages/cli-engine/src/config-loader.ts
+++ b/packages/cli-engine/src/config-loader.ts
@@ -1,7 +1,7 @@
 /**
  * The prisma.config.ts loader behind Runtime.loadConfig: resolve the
  * file (the one `--config` named, otherwise prisma.config.ts in cwd —
- * cwd only, no walking up), evaluate it, check the defineConfig version
+ * cwd only, no walking up), evaluate it, check the definePrismaConfig version
  * marker, and produce LoadedConfig.
  *
  * Which section names a CLI recognises is not this module's business:
@@ -70,10 +70,6 @@ export function definePrismaConfig<T extends Record<string, unknown>>(
 ): T & { readonly $prismaConfig: number } {
   return Object.freeze({ ...config, $prismaConfig: PRISMA_CONFIG_VERSION });
 }
-
-/** @deprecated Renamed to {@link definePrismaConfig}: every family's
- *  config helper carries a unique name, so none needs an import alias. */
-export const defineConfig = definePrismaConfig;
 
 function hasVersionMarker(value: unknown): value is Record<string, unknown> {
   return (

--- a/packages/cli-engine/src/exports/index.ts
+++ b/packages/cli-engine/src/exports/index.ts
@@ -45,7 +45,6 @@ export {
   type SpawnDeclarations,
 } from "../commands";
 export {
-  defineConfig,
   definePrismaConfig,
   loadConfig,
 } from "../config-loader";

--- a/packages/cli-engine/src/runtime.ts
+++ b/packages/cli-engine/src/runtime.ts
@@ -209,7 +209,7 @@ export interface LoadedConfig {
 }
 
 /**
- * The config contract version defineConfig writes as the structural
+ * The config contract version definePrismaConfig writes as the structural
  * `$prismaConfig` marker; the loader checks it before interpreting
  * anything.
  */

--- a/packages/cli-engine/tests/config.test.ts
+++ b/packages/cli-engine/tests/config.test.ts
@@ -13,7 +13,6 @@ import {
   createCli,
   defineCommand,
   defineCommandFamily,
-  defineConfig,
   defineConfigSection,
   definePrismaConfig,
   flag,
@@ -41,12 +40,6 @@ describe("definePrismaConfig", () => {
       toy: { greeting: "hi" },
       $prismaConfig: PRISMA_CONFIG_VERSION,
     });
-  });
-
-  test("the deprecated defineConfig alias stamps the same marker", () => {
-    expect(defineConfig({ toy: { greeting: "hi" } })).toEqual(
-      definePrismaConfig({ toy: { greeting: "hi" } }),
-    );
   });
 });
 

--- a/packages/cli-engine/tests/engine.test.ts
+++ b/packages/cli-engine/tests/engine.test.ts
@@ -29,7 +29,6 @@ describe("main export", () => {
       "credentialsRequiredError",
       "defineCommand",
       "defineCommandFamily",
-      "defineConfig",
       "defineConfigSection",
       "definePrismaConfig",
       "defineServerCommand",


### PR DESCRIPTION
The engine's deprecated `defineConfig` re-export of `definePrismaConfig` was the only `@deprecated` surface in the repository, and nothing consumes it: `prisma/config` re-exports `definePrismaConfig` by name, and the composer/ORM families' same-named helpers are their own, not imports of the engine's. Removed ahead of launch, riding the in-flight unpublished engine 0.2.3 so no additional release chain is needed. Tests and doc prose follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)