### PR TITLE
fix(cli): restore Deno support for packaged CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,6 @@
     "@prisma/cli-engine": "workspace:0.2.3",
     "@prisma/composer-cli": "0.14.0",
     "@prisma/compute-sdk": "0.39.0",
-    "@prisma/credentials-store": "^7.8.0",
     "@prisma/management-api-sdk": "1.55.0",
     "@prisma/orm-toolchain": "8.0.0-rc.7",
     "@vercel/detect-agent": "^1.2.3",
@@ -63,6 +62,7 @@
   },
   "devDependencies": {
     "@prisma/composer": "0.14.0",
+    "@prisma/credentials-store": "^7.8.0",
     "@repo/cli-conformance": "workspace:8.0.0-rc.10",
     "@repo/cli-telemetry": "workspace:8.0.0-rc.10",
     "@repo/tsconfig": "workspace:8.0.0-rc.10",

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -4,8 +4,9 @@ export default defineConfig([
   // The shipped CLI. Bundled (not unbundle) so the private
   // @repo/cli-telemetry workspace package lands inside this package's
   // own dist instead of being a published dependency; the sender entry
-  // ships the forkable script at dist/sender.js. Published deps
-  // (engine, @vercel/detect-agent, …) stay external.
+  // ships the forkable script at dist/sender.js. credentials-store is
+  // bundled because its xdg-app-paths dependency publishes a broken Deno
+  // conditional export. Other published deps stay external.
   {
     entry: {
       cli: "src/bin.ts",
@@ -15,7 +16,9 @@ export default defineConfig([
     clean: true,
     shims: true,
     fixedExtension: false,
-    deps: { alwaysBundle: ["@repo/cli-telemetry"] },
+    deps: {
+      alwaysBundle: ["@prisma/credentials-store", "@repo/cli-telemetry"],
+    },
     outDir: "dist",
   },
 ]);

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -52,7 +52,6 @@
     "@prisma/cli-engine": "workspace:0.2.3",
     "@prisma/composer-cli": "0.14.0",
     "@prisma/compute-sdk": "0.39.0",
-    "@prisma/credentials-store": "^7.8.0",
     "@prisma/management-api-sdk": "1.55.0",
     "@prisma/orm-toolchain": "8.0.0-rc.7",
     "@vercel/detect-agent": "^1.2.3",
@@ -63,6 +62,7 @@
   },
   "devDependencies": {
     "@prisma/cli": "workspace:8.0.0-rc.10",
+    "@prisma/credentials-store": "^7.8.0",
     "@repo/cli-telemetry": "workspace:8.0.0-rc.10",
     "@repo/tsconfig": "workspace:8.0.0-rc.10",
     "@types/node": "^22.19.19",

--- a/packages/prisma/tsdown.config.ts
+++ b/packages/prisma/tsdown.config.ts
@@ -4,8 +4,9 @@ export default defineConfig([
   // The same shell, published under the unscoped name with the `prisma`
   // bin. @prisma/cli's source is bundled in (as is the private telemetry
   // package) so this package has one implementation and no dependency on
-  // an unpublishable workspace sibling; the published runtime deps stay
-  // external and are declared here to match.
+  // an unpublishable workspace sibling. credentials-store is bundled too
+  // because its xdg-app-paths dependency publishes a broken Deno conditional
+  // export; the other published runtime deps stay external.
   {
     entry: {
       prisma: "src/bin.ts",
@@ -15,7 +16,13 @@ export default defineConfig([
     clean: true,
     shims: true,
     fixedExtension: false,
-    deps: { alwaysBundle: ["@prisma/cli", "@repo/cli-telemetry"] },
+    deps: {
+      alwaysBundle: [
+        "@prisma/cli",
+        "@prisma/credentials-store",
+        "@repo/cli-telemetry",
+      ],
+    },
     outDir: "dist",
   },
   // The `prisma/config` subpath for user prisma.config.ts files.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       '@prisma/compute-sdk':
         specifier: 0.39.0
         version: 0.39.0(@prisma/management-api-sdk@1.55.0)(rollup@4.62.2)
-      '@prisma/credentials-store':
-        specifier: ^7.8.0
-        version: 7.8.0
       '@prisma/management-api-sdk':
         specifier: 1.55.0
         version: 1.55.0
@@ -63,6 +60,9 @@ importers:
       '@prisma/composer':
         specifier: 0.14.0
         version: 0.14.0(@types/node@22.19.19)(@vercel/nft@1.10.2(rollup@4.62.2))(magicast@0.5.3)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1107.0))(mysql2@3.23.3(@types/node@22.19.19))(pg@8.23.0)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8(@types/node@22.19.19)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(ws@8.21.0)
+      '@prisma/credentials-store':
+        specifier: ^7.8.0
+        version: 7.8.0
       '@repo/cli-conformance':
         specifier: workspace:8.0.0-rc.10
         version: link:../cli-conformance
@@ -209,9 +209,6 @@ importers:
       '@prisma/compute-sdk':
         specifier: 0.39.0
         version: 0.39.0(@prisma/management-api-sdk@1.55.0)(rollup@4.62.2)
-      '@prisma/credentials-store':
-        specifier: ^7.8.0
-        version: 7.8.0
       '@prisma/management-api-sdk':
         specifier: 1.55.0
         version: 1.55.0
@@ -237,6 +234,9 @@ importers:
       '@prisma/cli':
         specifier: workspace:8.0.0-rc.10
         version: link:../cli
+      '@prisma/credentials-store':
+        specifier: ^7.8.0
+        version: 7.8.0
       '@repo/cli-telemetry':
         specifier: workspace:8.0.0-rc.10
         version: link:../cli-telemetry


### PR DESCRIPTION
## Summary

Restore Deno startup for the packaged Prisma CLI without copying or changing credential-storage behavior.

- keep `@prisma/credentials-store` as the single auth-storage implementation
- bundle it into both published CLI binaries, so Deno does not resolve its broken transitive conditional export at runtime
- move it from a published runtime dependency to a build-time dependency

## The failure

With Deno 2.9.5, the current published RC fails before parsing any command:

```console
$ deno run --minimum-dependency-age=0 -A npm:prisma@8.0.0-rc.9 --version
error: Cannot find module ".../xdg-app-paths/8.3.0/src/mod.deno.ts"
```

The same failure occurs through `npm:@prisma/cli@8.0.0-rc.9`.

The startup dependency chain is:

```text
prisma / @prisma/cli
  -> FileTokenStorage
  -> @prisma/credentials-store
  -> xdg-app-paths
```

`xdg-app-paths@8.3.0` declares a Deno conditional export at `./src/mod.deno.ts`, but that file and its imports are absent from the npm tarball. Because auth storage is statically imported, every CLI command fails, including `--version` and `orm init`.

Upgrading `@prisma/credentials-store` does not fix this: its latest release still uses `xdg-app-paths@8.3.0`.

## Why bundle the store?

The CLI should not duplicate credential persistence. `@prisma/credentials-store` remains the only implementation used by `FileTokenStorage`; this PR changes packaging only.

Both published binaries already use bundled entry points. Adding the store to `deps.alwaysBundle` makes the build resolve its Node-compatible implementation once and include it in the shipped JavaScript. The published package therefore does not ask Deno to resolve `xdg-app-paths`, while Node and Deno execute the exact same auth code.

This avoids vendoring storage logic, patching an installed package, lazy-importing auth, or adding a Deno-specific runtime branch. No auth-file schema, path, locking behavior, command, flag, or output changes.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @prisma/cli test` — 61 files, 958 passed, 1 skipped
- `pnpm --filter @repo/cli-conformance test` — 5 files, 66 passed
- `PUBLISH_CHANNEL=dev pnpm check:conformance` — 0 failing findings
- packed `prisma@8.0.0-rc.10`, installed it into a clean npm sandbox, and ran under official Deno 2.9.5:

  ```console
  prisma orm init --target postgres --authoring psl --skip-install --yes --format json
  ```

  It completed successfully and wrote the expected config, contract, database client, TypeScript config, environment example, package manifest, and Git metadata files.
