### PR TITLE
Close out the latest cutover in the project records

### DIFF
--- a/.drive/projects/prisma-cli-v8/assets/rollout-plan.md
+++ b/.drive/projects/prisma-cli-v8/assets/rollout-plan.md
@@ -47,6 +47,15 @@ unified CLI reaches npm, from first pre-release through owning the bare
    `prisma-composer` pointing at `prisma`, per the grammar/consolidation
    docs. (Codemods and docs-site updates are the ecosystem-cutover
    follow-on, out of this project's scope.)
+   **EXECUTED 2026-08-25** via prisma-cli #230 (`releaseDistTag`
+   widened; `prisma@8.0.0-rc.10` under `latest`) and #231 (`next`
+   mirrors `latest` by hand-move until 8.0.0 stable retires it).
+   Deprecations resolved differently than planned: `prisma-next`
+   deprecated by the operator 2026-08-24; `prisma-composer` left alone
+   (operator ruling 2026-08-25); `@prisma/cli` open in `deferred.md` —
+   it is now the actively-published scoped twin, so deprecating it may
+   no longer make sense. Step 4's `prisma7` never blocked in practice
+   (this repo already owned the bare name) and stays with the ORM team.
 
 ## Invariants
 
@@ -57,16 +66,21 @@ unified CLI reaches npm, from first pre-release through owning the bare
   (tightened per the 2026-08-12 ruling: RC-line bump PRs publish under
   `next`, so on this repo's names even a merged bump PR cannot move
   `latest` while the line is RC — only an explicit `dist-tag: latest`
-  dispatch or a stable-version bump can).
+  dispatch or a stable-version bump can). **Since the 2026-08-25
+  cutover the explicit act is behind us: every merged bump PR publishes
+  under `latest`, and merging the bump PR remains the deliberate act.**
 - Version pins across the tandem packages follow the committed-versions
   ruling (S3).
 
 ## Open items
 
 - **`prisma7` timing** — owned by the ORM team; blocks step 4 only.
+  **Overtaken 2026-08-25:** the cutover executed without it; it remains
+  v7's future publish home, nothing here waits on it.
 - **`latest`-flip criteria** (step 5) — TBD by the operator; candidate
   inputs: rc soak duration, issue rate, parity-divergence sign-off per
-  family.
+  family. **Resolved 2026-08-25 by operator ruling: the soak ended and
+  the flip executed (see step 5).**
 - **Exact `prisma-next` handoff mechanics** (step 3) — npm publisher
   config transfer + the prisma/prisma workflow change; small, ruled
   feasible since the operator owns both repos.

--- a/.drive/projects/prisma-cli-v8/deferred.md
+++ b/.drive/projects/prisma-cli-v8/deferred.md
@@ -25,6 +25,13 @@ Nothing here is tracked outside this file.
   package is now the scoped twin the workflow actively publishes, so
   deprecating it may no longer make sense. Operator decision; needs npm auth either way
   (`npm deprecate @prisma/cli@"<8.0.0" "..."`).
+  Update 2026-08-25: the cutover surfaced a live 3.x consumer —
+  pdp-control-plane's build-runner and github-webhook deploys used
+  `@prisma/cli@latest` for the old `app deploy` and broke when `latest`
+  moved to rc.10. Resolved by Kristof pinning their CLI version, not by
+  moving the tag back. No deprecation of the `<8` line while control
+  plane runs on it; the entry closes when those services migrate to
+  Composer.
 
 ## After S7's first real publish
 

--- a/.drive/projects/prisma-cli-v8/plan.md
+++ b/.drive/projects/prisma-cli-v8/plan.md
@@ -127,6 +127,8 @@ One standing caveat: every endpoint above is marked experimental and subject to 
 
 **CLOSED 2026-08-12** — shipped as prisma-cli #164 plus the Release-immutability fix #166; acceptance verified in `specs/s7-release.md`'s Close-out; leftovers in `deferred.md`. The DoD artifact exists published: the operator's first real publish put `@prisma/cli@8.0.0-rc.1` (one binary answering platform, composer and ORM) and `@prisma/cli-engine@8.0.0-rc.1` on npm under `next`, `latest` untouched — RC releases publish under `next` by ruling until the deliberate flip. The bare-`prisma` cutover waits on `prisma7`; engine-pin convergence waits on the product repos bumping to the published engine. Next by the graph: S9 after the S5 cutover and S2d land (both dispatched elsewhere).
 
+**Cutover executed 2026-08-25** (rollout-plan step 5, operator-ruled): `prisma@8.0.0-rc.10` published under `latest` — `npm install prisma` serves the unified CLI, verified by clean install (one engine in the tree, config evaluation working). The train behind it: the c12 realpath fix and detectCI export (engine 0.2.1→0.2.3, prisma-cli #222/#224/#225/#227), two family release rounds (composer 0.13.0/0.14.0, orm-toolchain rc.6/rc.7) converging both peers on engine 0.2.3, and the release PR #230 (releaseDistTag widened to `latest`; conformance exception list empty). `prisma7` never blocked in practice — this repo already owned the bare name — and remains with the ORM team as v7's new home. `next` now mirrors `latest` by hand-move (#231, policy in `docs/oss/versioning.md`); leftovers in `deferred.md` (dev-leg ordering decision, `@prisma/cli` deprecation call).
+
 ### S9 — The error-code catalogue (last)
 
 Repo: prisma-cli. The engine raises its `CLI.*` codes from sixteen-plus


### PR DESCRIPTION
The Drive closeout for the 2026-08-25 cutover: `plan.md`'s S7 entry and `assets/rollout-plan.md` still described the `latest` flip as future work. Both now record it executed — the release train behind it (engine 0.2.1→0.2.3 via #222/#224/#225/#227, two family release rounds, #230's flip, #231's next-tag policy), how each planned deprecation actually resolved (`prisma-next` deprecated 2026-08-24, `prisma-composer` left alone by ruling, `@prisma/cli` open in `deferred.md`), and that `prisma7` never blocked in practice. Records only; no behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)