### PR TITLE
chore(cli-engine): the Management API SDK becomes a peer dependency

### DIFF
--- a/.drive/projects/prisma-cli-v8/deferred.md
+++ b/.drive/projects/prisma-cli-v8/deferred.md
@@ -6,22 +6,24 @@ Nothing here is tracked outside this file.
 
 ## After the latest cutover (2026-08-25, PR #230)
 
-- **compute-sdk 0.42.0 asks for a `@prisma/management-api-sdk` this repo
-  does not install.** Its peer range is `^1.69.0`; all three manifests
-  here pin `1.55.0`, so `pnpm peers check` reports one unmet peer. Left
-  that way deliberately: the SDK version is a shared type surface, so
-  moving it in `packages/cli` and `packages/prisma` alone makes the
-  engine's `ManagementApiClient` a second, incompatible copy and every
-  command that hands the engine's client to a CLI function stops
-  typechecking. Moving all three means `packages/cli-engine` changed,
-  which needs a new engine version, which both families peer-pin
-  exactly — the three-repo release sequence. Nothing is broken in the
-  meantime: the field is declared by compute-sdk's own types and the
-  server sends it whatever the client was generated from. Two ways out,
-  operator's call: move the SDK with the next engine version train, or
-  relax compute-sdk's floor back to `^1.44.0`, which is arguably where
-  it belongs — the floor protects a build-time concern of compute-sdk's
-  own that no consumer shares.
+- **The engine 0.3.0 transition is in flight; both families still peer
+  0.2.3.** `@prisma/cli-engine` declared `@prisma/management-api-sdk` as
+  an ordinary dependency while re-exporting the SDK's client type across
+  its own public API (`ctx.api`). That is a shared type surface held as
+  a private copy: when the shell moved to a newer SDK, the engine's
+  `Client<paths>` and the shell's became unrelated types and every
+  command taking `ctx.api` into a CLI function stopped typechecking, so
+  the version could only ever move in all three manifests at once —
+  which changed the engine, which both families peer-pin exactly. 0.3.0
+  makes the SDK a peer of the engine (`^1.55.0`) with the two binaries
+  supplying the copy, so a future SDK bump touches the apps only. The
+  sequence from here, per `packages/cli/scripts/conformance.ts`: engine
+  0.3.0 publishes → `@prisma/composer-cli` and `@prisma/orm-toolchain`
+  republish peering 0.3.0 → a release PR here pins those versions and
+  deletes the two `exceptions` entries, restoring the empty list. Until
+  then conformance reports six allowed findings, including two copies of
+  the engine resolving in the sandbox install — the expected shape of a
+  transition, not a defect.
 
 - **A stale product `dev` dist-tag can block a release publish.** The
   publish run checks the dev channel before the release leg, and the

--- a/packages/cli-engine/package.json
+++ b/packages/cli-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/cli-engine",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "The execution engine of the unified Prisma CLI.",
   "type": "module",
   "exports": {
@@ -47,14 +47,17 @@
   },
   "dependencies": {
     "@clack/prompts": "1.5.0",
-    "@prisma/management-api-sdk": "1.55.0",
     "@stricli/core": "1.3.0",
     "c12": "3.3.4",
     "colorette": "^2.0.20",
     "package-manager-detector": "1.8.0",
     "string-width": "^8.2.1"
   },
+  "peerDependencies": {
+    "@prisma/management-api-sdk": "^1.55.0"
+  },
   "devDependencies": {
+    "@prisma/management-api-sdk": "1.69.0",
     "@repo/cli-conformance": "workspace:8.0.0-rc.10",
     "@repo/tsconfig": "workspace:8.0.0-rc.10",
     "@types/node": "^22.19.19",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,10 +49,10 @@
   },
   "dependencies": {
     "@manypkg/tools": "^2.1.2",
-    "@prisma/cli-engine": "workspace:0.2.3",
+    "@prisma/cli-engine": "workspace:0.3.0",
     "@prisma/composer-cli": "0.14.0",
     "@prisma/compute-sdk": "0.42.0",
-    "@prisma/management-api-sdk": "1.55.0",
+    "@prisma/management-api-sdk": "1.69.0",
     "@prisma/orm-toolchain": "8.0.0-rc.7",
     "@vercel/detect-agent": "^1.2.3",
     "better-result": "^2.9.2",

--- a/packages/cli/scripts/conformance.ts
+++ b/packages/cli/scripts/conformance.ts
@@ -109,13 +109,30 @@ async function tarball(): Promise<readonly Finding[]> {
       shellPackage: "@prisma/cli",
       enginePackage: "@prisma/cli-engine",
       familyPackages: ["@prisma/composer-cli", "@prisma/orm-toolchain"],
-      // No exceptions. Both families declare @prisma/cli-engine as an
-      // exact peer at the version this repo ships, so one engine
-      // resolves in an install — what ADR 0004 asks for. An entry here
-      // exists only while an engine version transition is in flight
-      // (the engine must publish before a family can peer it), and the
-      // release PR that pins the families' new versions removes it.
-      exceptions: [],
+      // An engine version transition is in flight: the engine must
+      // publish 0.3.0 before either family can peer it, so both still
+      // declare 0.2.3. The release PR that pins the families' new
+      // versions removes these entries and restores the empty list.
+      exceptions: [
+        {
+          familyPackage: "@prisma/composer-cli",
+          familyPin: "0.2.3",
+          shellPin: "0.3.0",
+          reason:
+            "@prisma/cli-engine 0.3.0 moves @prisma/management-api-sdk to a peer dependency so one copy of the SDK's client type serves the engine and the shell. Breaking for the engine's consumers, so both families must republish against it.",
+          removeWhen:
+            "@prisma/composer-cli publishes a version peering @prisma/cli-engine 0.3.0 and this repo pins it.",
+        },
+        {
+          familyPackage: "@prisma/orm-toolchain",
+          familyPin: "0.2.3",
+          shellPin: "0.3.0",
+          reason:
+            "@prisma/cli-engine 0.3.0 moves @prisma/management-api-sdk to a peer dependency so one copy of the SDK's client type serves the engine and the shell. Breaking for the engine's consumers, so both families must republish against it.",
+          removeWhen:
+            "@prisma/orm-toolchain publishes a version peering @prisma/cli-engine 0.3.0 and this repo pins it.",
+        },
+      ],
       channel: CHANNEL,
       sandboxDir: join(WORK_DIR, "sandbox"),
     },

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -49,10 +49,10 @@
   },
   "dependencies": {
     "@manypkg/tools": "^2.1.2",
-    "@prisma/cli-engine": "workspace:0.2.3",
+    "@prisma/cli-engine": "workspace:0.3.0",
     "@prisma/composer-cli": "0.14.0",
     "@prisma/compute-sdk": "0.42.0",
-    "@prisma/management-api-sdk": "1.55.0",
+    "@prisma/management-api-sdk": "1.69.0",
     "@prisma/orm-toolchain": "8.0.0-rc.7",
     "@vercel/detect-agent": "^1.2.3",
     "better-result": "^2.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,17 +27,17 @@ importers:
         specifier: ^2.1.2
         version: 2.1.2
       '@prisma/cli-engine':
-        specifier: workspace:0.2.3
+        specifier: workspace:0.3.0
         version: link:../cli-engine
       '@prisma/composer-cli':
         specifier: 0.14.0
         version: 0.14.0(@prisma/cli-engine@packages+cli-engine)(@types/node@22.19.19)(@vercel/nft@1.10.2(rollup@4.62.2))(magicast@0.5.3)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1107.0))(mysql2@3.23.3(@types/node@22.19.19))(pg@8.23.0)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8(@types/node@22.19.19)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(ws@8.21.0)
       '@prisma/compute-sdk':
         specifier: 0.42.0
-        version: 0.42.0(@prisma/management-api-sdk@1.55.0)(rollup@4.62.2)
+        version: 0.42.0(@prisma/management-api-sdk@1.69.0)(rollup@4.62.2)
       '@prisma/management-api-sdk':
-        specifier: 1.55.0
-        version: 1.55.0
+        specifier: 1.69.0
+        version: 1.69.0
       '@prisma/orm-toolchain':
         specifier: 8.0.0-rc.7
         version: 8.0.0-rc.7(@prisma/cli-engine@packages+cli-engine)(magicast@0.5.3)(typanion@3.14.0)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -114,9 +114,6 @@ importers:
       '@clack/prompts':
         specifier: 1.5.0
         version: 1.5.0
-      '@prisma/management-api-sdk':
-        specifier: 1.55.0
-        version: 1.55.0
       '@stricli/core':
         specifier: 1.3.0
         version: 1.3.0
@@ -133,6 +130,9 @@ importers:
         specifier: ^8.2.1
         version: 8.2.1
     devDependencies:
+      '@prisma/management-api-sdk':
+        specifier: 1.69.0
+        version: 1.69.0
       '@repo/cli-conformance':
         specifier: workspace:8.0.0-rc.10
         version: link:../cli-conformance
@@ -201,17 +201,17 @@ importers:
         specifier: ^2.1.2
         version: 2.1.2
       '@prisma/cli-engine':
-        specifier: workspace:0.2.3
+        specifier: workspace:0.3.0
         version: link:../cli-engine
       '@prisma/composer-cli':
         specifier: 0.14.0
         version: 0.14.0(@prisma/cli-engine@packages+cli-engine)(@types/node@22.19.19)(@vercel/nft@1.10.2(rollup@4.62.2))(magicast@0.5.3)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1107.0))(mysql2@3.23.3(@types/node@22.19.19))(pg@8.23.0)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8(@types/node@22.19.19)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(ws@8.21.0)
       '@prisma/compute-sdk':
         specifier: 0.42.0
-        version: 0.42.0(@prisma/management-api-sdk@1.55.0)(rollup@4.62.2)
+        version: 0.42.0(@prisma/management-api-sdk@1.69.0)(rollup@4.62.2)
       '@prisma/management-api-sdk':
-        specifier: 1.55.0
-        version: 1.55.0
+        specifier: 1.69.0
+        version: 1.69.0
       '@prisma/orm-toolchain':
         specifier: 8.0.0-rc.7
         version: 8.0.0-rc.7(@prisma/cli-engine@packages+cli-engine)(magicast@0.5.3)(typanion@3.14.0)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -1357,9 +1357,6 @@ packages:
 
   '@prisma/get-platform@7.2.0':
     resolution: {integrity: sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA==}
-
-  '@prisma/management-api-sdk@1.55.0':
-    resolution: {integrity: sha512-WuDDOhxOHfROGY7QAU6wtlbWR0diNwfsQw1epQkhalvgOUe/JzIjxqpBpQzMA54zFVlMmcnT6OEiQfwCIKiRjA==}
 
   '@prisma/management-api-sdk@1.69.0':
     resolution: {integrity: sha512-z3zBWvOjFSWqUwkJcsdkBZzkUaUMEEcKy4QiMfo7n1GqNQvRYkzxzaNRTqmxTjw3thOjmdq+UegIqOU57i7jiA==}
@@ -4445,9 +4442,9 @@ snapshots:
       - vitest
       - ws
 
-  '@prisma/compute-sdk@0.42.0(@prisma/management-api-sdk@1.55.0)(rollup@4.62.2)':
+  '@prisma/compute-sdk@0.42.0(@prisma/management-api-sdk@1.69.0)(rollup@4.62.2)':
     dependencies:
-      '@prisma/management-api-sdk': 1.55.0
+      '@prisma/management-api-sdk': 1.69.0
       '@vercel/nft': 1.10.2(rollup@4.62.2)
       better-result: 2.9.2
       jiti: 2.7.0
@@ -4498,10 +4495,6 @@ snapshots:
   '@prisma/get-platform@7.2.0':
     dependencies:
       '@prisma/debug': 7.2.0
-
-  '@prisma/management-api-sdk@1.55.0':
-    dependencies:
-      openapi-fetch: 0.14.0
 
   '@prisma/management-api-sdk@1.69.0':
     dependencies:


### PR DESCRIPTION
## Purpose of change

`@prisma/cli-engine` hands the shell a Management API client through `ctx.api`, and re-exports the SDK's type for it:

```ts
// packages/cli-engine/src/management-api.ts
/** The SDK's typed client, re-exported so consumers never import
 *  @prisma/management-api-sdk directly. */
export type ManagementApiClient = SdkClient;
```

That type belongs to `@prisma/management-api-sdk`, and until now the engine held that package as an ordinary dependency at an exact version — as did `packages/cli` and `packages/prisma`, each independently:

```
cli-engine  dependencies: @prisma/management-api-sdk = 1.55.0
cli         dependencies: @prisma/management-api-sdk = 1.55.0
prisma      dependencies: @prisma/management-api-sdk = 1.55.0
```

A package whose public API carries another package's types has a shared type surface. Held as three private copies, the three pins can disagree — and when they disagree, the types stop being the same type. Moving only the shell to a newer SDK produces this, roughly fifteen times over:

```
src/commands/branch/list.ts(80,9): error TS2345:
  Argument of type 'Client<paths@1.55.0>' is not assignable to
  parameter of type 'Client<paths@1.69.0>'
```

So the SDK version could only ever move in all three manifests at once. One of the three is the engine, and a changed engine needs a new engine version, and both `@prisma/composer-cli` and `@prisma/orm-toolchain` peer-pin the engine **exactly** — so an SDK bump, a routine act, cost a three-repo release sequence every time. That is what blocked #235 from taking `@prisma/management-api-sdk@1.69.0`, the version `@prisma/compute-sdk@0.42.0` asks for.

## What's changed

The engine now declares the SDK the way a shared type surface should be declared:

- **`cli-engine`**: `@prisma/management-api-sdk` moves from `dependencies` to `peerDependencies` at `^1.55.0` — a range, not a pin, because the consumer chooses. It stays in `devDependencies` at the version the workspace supplies so the package still builds and tests standalone.
- **`cli` and `prisma`** keep it as a real dependency and move to `1.69.0`. They are the binaries; they install the one copy everyone binds to. All three packages now resolve `@prisma+management-api-sdk@1.69.0`, and `pnpm peers check` no longer reports compute-sdk's unmet peer.
- **Engine `0.2.3` → `0.3.0`**, the pre-1.0 breaking slot: consumers of the published engine must now supply the SDK themselves.

After this, moving the SDK touches the two app manifests and nothing else — no engine version, no family republish.

## The transition this starts

The engine must publish before a family can peer it, so both families still declare `0.2.3` and conformance reports six pin mismatches. `packages/cli/scripts/conformance.ts` has a place for exactly this, and its comment prescribes the sequence; both entries are filled in with a `removeWhen`:

```
0 failing, 6 allowed, 5 subject(s) checked
```

Every one prints in full with its reason, including the two copies of the engine that resolve in the sandbox install — the expected shape of a transition rather than a defect. The remaining steps, recorded in the deferred ledger: engine 0.3.0 publishes → both families republish peering 0.3.0 → a release PR here pins them and deletes the two exceptions, restoring the empty list.

Verified: `pnpm typecheck`, `pnpm --filter @prisma/cli test` (958 passed), `pnpm check:conformance` (0 failing), `node scripts/check-engine-version.mjs`.

## Alternatives considered

- **Relax `@prisma/compute-sdk`'s peer floor back to `^1.44.0`.** This was my first proposal and it was wrong. That floor is the one peer dependency in the picture that already works: it correctly reported that this repo was pinned behind. Widening it would have silenced an accurate warning and left the actual cause — three private copies of a shared type — in place.
- **Bump all three manifests to 1.69.0 and take the release chain.** Fixes today's mismatch and leaves the next one to cost exactly the same. The same engine bump buys the structural fix instead.
- **A `pnpm` override forcing one SDK version.** Makes the workspace green while the published engine still declares a version it does not get, so anyone installing `@prisma/cli-engine` alongside `@prisma/compute-sdk` reproduces the two-copy break. It hides the problem precisely where it would be felt.
- **An exact peer (`1.69.0`) rather than a range.** Recreates the lockstep-bump problem one layer up: every SDK release would force an engine release again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
