### PR TITLE
Bump to version 8.0.0-rc.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-cli",
-  "version": "8.0.0-rc.12",
+  "version": "8.0.0-rc.13",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/packages/cli-conformance/package.json
+++ b/packages/cli-conformance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/cli-conformance",
   "private": true,
-  "version": "8.0.0-rc.12",
+  "version": "8.0.0-rc.13",
   "description": "Reusable conformance checks for the engine's consumers: import purity over built output, config-section validators that never throw, and verification of the tarballs a registry would receive. Depends on no package it checks.",
   "type": "module",
   "exports": {
@@ -24,7 +24,7 @@
     "test": "pnpm run typecheck && vitest run"
   },
   "devDependencies": {
-    "@repo/tsconfig": "workspace:8.0.0-rc.12",
+    "@repo/tsconfig": "workspace:8.0.0-rc.13",
     "@types/node": "^22.19.19",
     "es-module-lexer": "^2.1.0",
     "tsx": "^4.22.4",

--- a/packages/cli-engine/package.json
+++ b/packages/cli-engine/package.json
@@ -58,8 +58,8 @@
   },
   "devDependencies": {
     "@prisma/management-api-sdk": "1.69.0",
-    "@repo/cli-conformance": "workspace:8.0.0-rc.12",
-    "@repo/tsconfig": "workspace:8.0.0-rc.12",
+    "@repo/cli-conformance": "workspace:8.0.0-rc.13",
+    "@repo/tsconfig": "workspace:8.0.0-rc.13",
     "@types/node": "^22.19.19",
     "ci-info": "^4.3.1",
     "tsdown": "^0.21.10",

--- a/packages/cli-telemetry/package.json
+++ b/packages/cli-telemetry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/cli-telemetry",
   "private": true,
-  "version": "8.0.0-rc.12",
+  "version": "8.0.0-rc.13",
   "description": "CLI telemetry child sender: the detached subprocess the engine hands a composed payload to, its system probes, and the POST",
   "type": "module",
   "sideEffects": [
@@ -35,7 +35,7 @@
     "@vercel/detect-agent": "^1.2.3"
   },
   "devDependencies": {
-    "@repo/tsconfig": "workspace:8.0.0-rc.12",
+    "@repo/tsconfig": "workspace:8.0.0-rc.13",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/cli",
-  "version": "8.0.0-rc.12",
+  "version": "8.0.0-rc.13",
   "description": "Command-line interface for the Prisma Developer Platform.",
   "type": "module",
   "bin": {
@@ -63,9 +63,9 @@
   "devDependencies": {
     "@prisma/composer": "0.17.0",
     "@prisma/credentials-store": "^7.8.0",
-    "@repo/cli-conformance": "workspace:8.0.0-rc.12",
-    "@repo/cli-telemetry": "workspace:8.0.0-rc.12",
-    "@repo/tsconfig": "workspace:8.0.0-rc.12",
+    "@repo/cli-conformance": "workspace:8.0.0-rc.13",
+    "@repo/cli-telemetry": "workspace:8.0.0-rc.13",
+    "@repo/tsconfig": "workspace:8.0.0-rc.13",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "tsx": "^4.22.4",

--- a/packages/compute/package.json
+++ b/packages/compute/package.json
@@ -42,7 +42,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@repo/tsconfig": "workspace:8.0.0-rc.12",
+    "@repo/tsconfig": "workspace:8.0.0-rc.13",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3",

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma",
-  "version": "8.0.0-rc.12",
+  "version": "8.0.0-rc.13",
   "description": "The Prisma CLI: one binary for the ORM, Composer, and the Prisma Developer Platform.",
   "type": "module",
   "bin": {
@@ -61,10 +61,10 @@
     "open": "^11.0.0"
   },
   "devDependencies": {
-    "@prisma/cli": "workspace:8.0.0-rc.12",
+    "@prisma/cli": "workspace:8.0.0-rc.13",
     "@prisma/credentials-store": "^7.8.0",
-    "@repo/cli-telemetry": "workspace:8.0.0-rc.12",
-    "@repo/tsconfig": "workspace:8.0.0-rc.12",
+    "@repo/cli-telemetry": "workspace:8.0.0-rc.13",
+    "@repo/tsconfig": "workspace:8.0.0-rc.13",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/tsconfig",
   "private": true,
-  "version": "8.0.0-rc.12",
+  "version": "8.0.0-rc.13",
   "description": "Base tsconfig providing package for the monorepo",
   "license": "Apache-2.0",
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,13 +64,13 @@ importers:
         specifier: ^7.8.0
         version: 7.8.0
       '@repo/cli-conformance':
-        specifier: workspace:8.0.0-rc.12
+        specifier: workspace:8.0.0-rc.13
         version: link:../cli-conformance
       '@repo/cli-telemetry':
-        specifier: workspace:8.0.0-rc.12
+        specifier: workspace:8.0.0-rc.13
         version: link:../cli-telemetry
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.12
+        specifier: workspace:8.0.0-rc.13
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -91,7 +91,7 @@ importers:
   packages/cli-conformance:
     devDependencies:
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.12
+        specifier: workspace:8.0.0-rc.13
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -134,10 +134,10 @@ importers:
         specifier: 1.69.0
         version: 1.69.0
       '@repo/cli-conformance':
-        specifier: workspace:8.0.0-rc.12
+        specifier: workspace:8.0.0-rc.13
         version: link:../cli-conformance
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.12
+        specifier: workspace:8.0.0-rc.13
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -162,7 +162,7 @@ importers:
         version: 1.2.4
     devDependencies:
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.12
+        specifier: workspace:8.0.0-rc.13
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -180,7 +180,7 @@ importers:
   packages/compute:
     devDependencies:
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.12
+        specifier: workspace:8.0.0-rc.13
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -232,16 +232,16 @@ importers:
         version: 11.0.0
     devDependencies:
       '@prisma/cli':
-        specifier: workspace:8.0.0-rc.12
+        specifier: workspace:8.0.0-rc.13
         version: link:../cli
       '@prisma/credentials-store':
         specifier: ^7.8.0
         version: 7.8.0
       '@repo/cli-telemetry':
-        specifier: workspace:8.0.0-rc.12
+        specifier: workspace:8.0.0-rc.13
         version: link:../cli-telemetry
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.12
+        specifier: workspace:8.0.0-rc.13
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19


### PR DESCRIPTION
Bumps the unified Prisma CLI from `8.0.0-rc.12` to `8.0.0-rc.13` in lockstep.

See [`docs/oss/versioning.md`](https://github.com/prisma/prisma-cli/blob/main/docs/oss/versioning.md).

**Merging this PR ships the release.** The squashed push to `main` changes the root version, causing the `Publish to npm` workflow to publish under `latest` and create a prerelease GitHub Release with generated notes.