### PR TITLE
fix(cli): launch Windows package-manager shims through the spawn adapter

### DIFF
--- a/docs/product/output-conventions.md
+++ b/docs/product/output-conventions.md
@@ -593,6 +593,12 @@ context, status, decoration, and errors stay on stderr.
 
 ## Design Rule
 
+Delegated commands must support installed Windows `.cmd` shims as well as
+native executables and POSIX shebang scripts. The host uses cross-spawn for
+platform-specific resolution and argument escaping; callers still pass a
+command and argument array, not a shell command string. Human stdio inheritance,
+structured diagnostic forwarding, and child exit status remain unchanged.
+
 Human output and JSON output should describe the same underlying model.
 
 The CLI should never require users or agents to learn different meanings for the same command.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,6 +56,7 @@
     "@prisma/orm-toolchain": "8.0.0-rc.8",
     "@vercel/detect-agent": "^1.2.3",
     "better-result": "^2.9.2",
+    "cross-spawn": "^7.0.6",
     "dotenv": "^17.4.2",
     "execa": "^9.6.1",
     "open": "^11.0.0"
@@ -67,6 +68,7 @@
     "@repo/cli-telemetry": "workspace:8.0.0-rc.13",
     "@repo/tsconfig": "workspace:8.0.0-rc.13",
     "@types/node": "^22.19.19",
+    "@types/cross-spawn": "^6.0.6",
     "tsdown": "^0.21.10",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",

--- a/packages/cli/src/spawn.ts
+++ b/packages/cli/src/spawn.ts
@@ -1,7 +1,7 @@
-import { spawn } from "node:child_process";
 import { type Readable, Writable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import type { ChildResult, SpawnChild } from "@prisma/cli-engine";
+import spawn from "cross-spawn";
 
 interface DiagnosticStream {
   write(text: string): unknown;
@@ -25,7 +25,7 @@ export interface SpawnChildOptions {
 }
 
 /**
- * The engine's spawn seam, adapted to node:child_process. Human mode
+ * The engine's spawn seam, adapted through cross-spawn. Human mode
  * inherits stdio; structured mode pipes both child output streams to
  * diagnostics. Neither mode detaches or opens a new console, so the child
  * stays in this process's group (POSIX) or console (Windows).

--- a/packages/cli/tests/spawn-adapter.test.ts
+++ b/packages/cli/tests/spawn-adapter.test.ts
@@ -9,7 +9,7 @@
  */
 import { existsSync, mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const spawnOptionsSeen = vi.hoisted(() => [] as Array<Record<string, unknown>>);
@@ -55,6 +55,23 @@ async function waitForFile(path: string, timeoutMs = 10_000): Promise<void> {
 }
 
 describe("the shipped spawn adapter", () => {
+  test.skipIf(process.platform !== "win32")(
+    "runs the installed npm.cmd through the shipped spawn adapter",
+    async () => {
+      const command = join(dirname(process.execPath), "npm.cmd");
+      expect(existsSync(command)).toBe(true);
+      const child = spawnChild({
+        command,
+        args: ["--version"],
+        cwd: process.cwd(),
+        env: process.env,
+        output: "diagnostic",
+      });
+      await expect(child.ended).resolves.toEqual({ exitCode: 0, signal: null });
+      expect(diagnosticText.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+    },
+  );
+
   test("passes the spawn options the design rests on: inherited stdio, no detached, no new console", async () => {
     const child = spawnChild({
       command: NODE,

--- a/packages/cli/tests/spawn-adapter.test.ts
+++ b/packages/cli/tests/spawn-adapter.test.ts
@@ -14,17 +14,19 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const spawnOptionsSeen = vi.hoisted(() => [] as Array<Record<string, unknown>>);
 
-vi.mock("node:child_process", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:child_process")>();
+vi.mock("cross-spawn", async (importOriginal) => {
+  const actual = await importOriginal<{
+    default: typeof import("cross-spawn");
+  }>();
   return {
     ...actual,
-    spawn: (
+    default: (
       command: string,
       args: readonly string[],
       options: Record<string, unknown>,
     ) => {
       spawnOptionsSeen.push(options);
-      return actual.spawn(command, [...args], options as never);
+      return actual.default(command, [...args], options as never);
     },
   };
 });
@@ -32,6 +34,7 @@ vi.mock("node:child_process", async (importOriginal) => {
 import { makeSpawnChild } from "../src/spawn";
 
 const NODE = process.execPath;
+const VERSION = /^\d+\.\d+\.\d+$/;
 let diagnosticText = "";
 const spawnChild = makeSpawnChild({
   write: (text) => {
@@ -68,7 +71,7 @@ describe("the shipped spawn adapter", () => {
         output: "diagnostic",
       });
       await expect(child.ended).resolves.toEqual({ exitCode: 0, signal: null });
-      expect(diagnosticText.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+      expect(diagnosticText.trim()).toMatch(VERSION);
     },
   );
 

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -56,6 +56,7 @@
     "@prisma/orm-toolchain": "8.0.0-rc.8",
     "@vercel/detect-agent": "^1.2.3",
     "better-result": "^2.9.2",
+    "cross-spawn": "^7.0.6",
     "dotenv": "^17.4.2",
     "execa": "^9.6.1",
     "open": "^11.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       better-result:
         specifier: ^2.9.2
         version: 2.9.2
+      cross-spawn:
+        specifier: ^7.0.6
+        version: 7.0.6
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -72,6 +75,9 @@ importers:
       '@repo/tsconfig':
         specifier: workspace:8.0.0-rc.13
         version: link:../tsconfig
+      '@types/cross-spawn':
+        specifier: ^6.0.6
+        version: 6.0.6
       '@types/node':
         specifier: ^22.19.19
         version: 22.19.19
@@ -221,6 +227,9 @@ importers:
       better-result:
         specifier: ^2.9.2
         version: 2.9.2
+      cross-spawn:
+        specifier: ^7.0.6
+        version: 7.0.6
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -1842,6 +1851,9 @@ packages:
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/cross-spawn@6.0.6':
+    resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -4838,6 +4850,10 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/cross-spawn@6.0.6':
+    dependencies:
+      '@types/node': 22.19.19
 
   '@types/deep-eql@4.0.2': {}
 


### PR DESCRIPTION
## Problem
The consolidated CLI delegates Composer and other commands through its own spawn adapter. That adapter used native node:child_process.spawn, which cannot execute Windows .cmd shims directly.

## Reproduced
The first commit runs the real installed npm.cmd through the shipped adapter. Existing Windows CI failed with spawn EINVAL (-4071), while 951 other tests passed: https://github.com/prisma/prisma-cli/actions/runs/34236425789/job/102095202659.

## Fix
Use cross-spawn at the owning adapter. Preserve argv arrays, inherited human stdio, structured diagnostic forwarding/backpressure, bounded drain, exit status, and signal forwarding. No blanket shell:true and no create-prisma workaround. Declare the runtime dependency in both published package manifests. Document the execution contract.

## Verification
- Windows after fix: the same npm.cmd regression passes; all 61 CLI test files pass, 952 tests passed and 10 platform skips: https://github.com/prisma/prisma-cli/actions/runs/34237016724/job/102097241940.
- Linux CI passed: https://github.com/prisma/prisma-cli/actions/runs/34237016724/job/102097242011.
- macOS locally: all 61 CLI test files passed (960 tests, 2 platform skips).
- Repository typecheck and lint passed.
- No workflows added and no production deployment needed for the command-launch reproduction.

## Scope
Fixes Windows delegated shim launch failures, not every CLI.SPAWN_FAILED, auth error, build failure, or install failure. Composer executable discovery is separate: https://github.com/prisma/composer/pull/280.

Ready for review. All CI checks passed, including the native Windows regression.
