### PR TITLE
docs: surface CLI feedback command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -119,9 +119,17 @@ npx prisma-cli service version promote VERSION_ID
 
 ## Support
 
-Issues and feedback are welcome while the CLI is in public beta. Please use
-[GitHub issues](https://github.com/prisma/prisma-cli/issues) for bug reports and
-feature requests.
+Send a bug report or feature request directly from your terminal:
+
+```bash
+npx @prisma/cli@latest feedback "Describe what happened and what you expected"
+```
+
+Feedback is anonymous by default. Add `--email you@example.com` if you want a
+reply. Submissions include your message, CLI and runtime versions, OS platform,
+and architecture. Review your message for secrets before sending.
+
+For a public discussion, use [GitHub issues](https://github.com/prisma/prisma-cli/issues).
 
 Security reports should follow Prisma's
 [security policy](https://github.com/prisma/prisma-cli/blob/main/SECURITY.md)

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -116,9 +116,17 @@ npx prisma service version promote VERSION_ID
 
 ## Support
 
-Issues and feedback are welcome while the CLI is in public beta. Please use
-[GitHub issues](https://github.com/prisma/prisma-cli/issues) for bug reports and
-feature requests.
+Send a bug report or feature request directly from your terminal:
+
+```bash
+npx prisma feedback "Describe what happened and what you expected"
+```
+
+Feedback is anonymous by default. Add `--email you@example.com` if you want a
+reply. Submissions include your message, CLI and runtime versions, OS platform,
+and architecture. Review your message for secrets before sending.
+
+For a public discussion, use [GitHub issues](https://github.com/prisma/prisma-cli/issues).
 
 Security reports should follow Prisma's
 [security policy](https://github.com/prisma/prisma-cli/blob/main/SECURITY.md)


### PR DESCRIPTION
## Summary

- document the direct CLI feedback command in both published package READMEs
- explain anonymous submissions and the optional reply email
- clarify the metadata included and point public discussion to GitHub Issues

## Why

The feedback intake has received no submissions since 26 August, while the command remains present and the CLI continues to be downloaded. Both package READMEs currently route feedback to GitHub Issues and omit the command, creating a concrete discoverability gap.

## Validation

- `git diff --check`
- verified `@prisma/cli@8.0.0-rc.13 --help` still exposes `feedback <message>`

This improves discoverability; it does not prove whether any server-side POST failures also contributed.
