### PR TITLE
Fix feedback submissions rejected by metadata validation

### DIFF
--- a/packages/cli/src/commands/feedback.ts
+++ b/packages/cli/src/commands/feedback.ts
@@ -250,7 +250,12 @@ export const feedbackCommand = defineCommand({
       {
         message,
         ...(email ? { email } : {}),
-        meta: { ...context },
+        meta: {
+          cliVersion: context.cliVersion,
+          nodeVersion: context.runtime.version,
+          platform: context.platform,
+          arch: context.arch,
+        },
       },
       ctx.signal,
     );

--- a/packages/cli/tests/feedback.test.ts
+++ b/packages/cli/tests/feedback.test.ts
@@ -39,8 +39,21 @@ async function startFeedbackService(options: {
       raw += chunk;
     });
     req.on("end", () => {
+      const body = JSON.parse(raw);
+      if (
+        !body.meta ||
+        Object.values(body.meta).some((value) => typeof value !== "string")
+      ) {
+        res.writeHead(400, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({
+            error: { message: "meta must be an object with string values." },
+          }),
+        );
+        return;
+      }
       requests.push({
-        body: JSON.parse(raw),
+        body,
         userAgent: req.headers["user-agent"],
       });
       res.statusCode = options.status ?? 201;
@@ -121,7 +134,7 @@ describe("prisma feedback", () => {
         cliVersion: (
           result.presented?.data as { context: { cliVersion: string } }
         ).context.cliVersion,
-        runtime: { name: "node", version: "v22.12.0" },
+        nodeVersion: "v22.12.0",
         platform: "linux",
         arch: "x64",
       },


### PR DESCRIPTION
`prisma feedback` fails against the live service with HTTP 400: `meta must be an object with string values.` The engine migration changed the wire payload from flat `nodeVersion` metadata to a nested `runtime` object.

Restore the service-compatible metadata fields (`cliVersion`, `nodeVersion`, `platform`, `arch`) while preserving the CLI result's existing context shape. The local test server now rejects non-string metadata values, and the payload assertion checks the restored contract.

Validation:

- `pnpm typecheck` and `pnpm lint` pass.
- CLI tests: 964 passed, 2 platform-specific skips.
- E2E: 6 passed, 48 credential-dependent skips.
- Built CLI successfully submitted one user-authorized, anonymous test message to the production endpoint and returned submission ID `01a08fe1-2a2d-7000-8a55-b334e2488a5e` with exit code 0.

Separate from artwork PR #253; no engine version or deployment changes.
