### PR TITLE
feat(cli-engine): send deploy source and client headers to the Management API

### DIFF
--- a/packages/cli-engine/package.json
+++ b/packages/cli-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/cli-engine",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "The execution engine of the unified Prisma CLI.",
   "type": "module",
   "exports": {

--- a/packages/cli-engine/src/execution/api-client.ts
+++ b/packages/cli-engine/src/execution/api-client.ts
@@ -152,7 +152,30 @@ async function constructClient(
     authBaseUrl: config.authBaseUrl,
     tokenStorage: storage,
   });
+  sdk.client.use(
+    deploySourceMiddleware(invocation.runtime.env, config.cliVersion),
+  );
   return { client: sdk.client, pinned: { active, storage } };
+}
+
+/** Analytics-only headers: the Management API records them on deploy events and behaves the same without them. */
+function deploySourceMiddleware(
+  env: Record<string, string | undefined>,
+  cliVersion: string | undefined,
+) {
+  return {
+    onRequest({ request }: { request: Request }): Request {
+      request.headers.set("x-prisma-client-name", "prisma-cli");
+      if (cliVersion !== undefined) {
+        request.headers.set("x-prisma-client-version", cliVersion);
+      }
+      request.headers.set(
+        "x-prisma-deploy-source",
+        env.GITHUB_ACTIONS === "true" ? "github-action" : "cli",
+      );
+      return request;
+    },
+  };
 }
 
 /**

--- a/packages/cli-engine/src/management-api.ts
+++ b/packages/cli-engine/src/management-api.ts
@@ -38,6 +38,8 @@ export interface ManagementApiClientConfig {
   readonly redirectUri: string;
   readonly apiBaseUrl: string;
   readonly authBaseUrl: string;
+  /** The CLI's own semver string, forwarded to the API as x-prisma-client-version. */
+  readonly cliVersion?: string;
 }
 
 /**

--- a/packages/cli-engine/tests/management-api.test.ts
+++ b/packages/cli-engine/tests/management-api.test.ts
@@ -911,3 +911,82 @@ describe("the environment credential", () => {
     expect(cli.credentialManager.state()).toEqual(before);
   });
 });
+
+describe("deploy-source analytics headers", () => {
+  interface HeaderRecord {
+    readonly clientName: string | null;
+    readonly clientVersion: string | null;
+    readonly deploySource: string | null;
+  }
+
+  function scriptFetchRecordingHeaders(): HeaderRecord[] {
+    const records: HeaderRecord[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: Request | string | URL, init?: RequestInit) => {
+        const request =
+          input instanceof Request ? input : new Request(input, init);
+        records.push({
+          clientName: request.headers.get("x-prisma-client-name"),
+          clientVersion: request.headers.get("x-prisma-client-version"),
+          deploySource: request.headers.get("x-prisma-deploy-source"),
+        });
+        return jsonResponse(200, { workspaces: [] });
+      }),
+    );
+    return records;
+  }
+
+  const configWithVersion: ManagementApiClientConfig = {
+    ...CLIENT_CONFIG,
+    cliVersion: "8.0.0-rc.13",
+  };
+
+  const session = sessionSeed("workspace-1");
+
+  test("outside GitHub Actions: source is 'cli', name and version are set", async () => {
+    const records = scriptFetchRecordingHeaders();
+    const cli = createTestCli({
+      commands: { toy: callApi },
+      sessions: [session],
+      selectedWorkspaceId: "workspace-1",
+      managementApiClientConfig: configWithVersion,
+    });
+    const { exitCode } = await cli.run(["toy"], { env: {} });
+    expect(exitCode).toBe(0);
+    expect(records).toHaveLength(1);
+    expect(records[0].clientName).toBe("prisma-cli");
+    expect(records[0].clientVersion).toBe("8.0.0-rc.13");
+    expect(records[0].deploySource).toBe("cli");
+  });
+
+  test("inside GitHub Actions: source is 'github-action'", async () => {
+    const records = scriptFetchRecordingHeaders();
+    const cli = createTestCli({
+      commands: { toy: callApi },
+      sessions: [session],
+      selectedWorkspaceId: "workspace-1",
+      managementApiClientConfig: configWithVersion,
+    });
+    const { exitCode } = await cli.run(["toy"], {
+      env: { GITHUB_ACTIONS: "true" },
+    });
+    expect(exitCode).toBe(0);
+    expect(records[0].deploySource).toBe("github-action");
+  });
+
+  test("when cliVersion is absent from config, x-prisma-client-version is not sent", async () => {
+    const records = scriptFetchRecordingHeaders();
+    const cli = createTestCli({
+      commands: { toy: callApi },
+      sessions: [session],
+      selectedWorkspaceId: "workspace-1",
+      managementApiClientConfig: CLIENT_CONFIG,
+    });
+    const { exitCode } = await cli.run(["toy"], { env: {} });
+    expect(exitCode).toBe(0);
+    expect(records[0].clientName).toBe("prisma-cli");
+    expect(records[0].clientVersion).toBeNull();
+    expect(records[0].deploySource).toBe("cli");
+  });
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@manypkg/tools": "^2.1.2",
-    "@prisma/cli-engine": "workspace:0.3.0",
+    "@prisma/cli-engine": "workspace:0.3.1",
     "@prisma/composer-cli": "0.17.0",
     "@prisma/compute-sdk": "0.42.0",
     "@prisma/management-api-sdk": "1.69.0",

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -146,6 +146,7 @@ export async function assembleRuntime(proc: HostProcess): Promise<Runtime> {
       redirectUri: DEFAULT_REDIRECT_URI,
       apiBaseUrl,
       authBaseUrl,
+      cliVersion: getCliVersion(),
     },
     spawn: makeSpawnChild(proc.stderr),
     /** The engine has already decided and composed; the bin only forks

--- a/packages/cli/tests/bin.test.ts
+++ b/packages/cli/tests/bin.test.ts
@@ -248,6 +248,7 @@ describe("assembleRuntime", () => {
       redirectUri: DEFAULT_REDIRECT_URI,
       apiBaseUrl: "https://api.example.test",
       authBaseUrl: "https://auth.prisma.io",
+      cliVersion: getCliVersion(),
     });
     expect(typeof runtime.openUrl).toBe("function");
     expect(proc.stderrText).toBe("");

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@manypkg/tools": "^2.1.2",
-    "@prisma/cli-engine": "workspace:0.3.0",
+    "@prisma/cli-engine": "workspace:0.3.1",
     "@prisma/composer-cli": "0.17.0",
     "@prisma/compute-sdk": "0.42.0",
     "@prisma/management-api-sdk": "1.69.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ importers:
         specifier: ^2.1.2
         version: 2.1.2
       '@prisma/cli-engine':
-        specifier: workspace:0.3.0
+        specifier: workspace:0.3.1
         version: link:../cli-engine
       '@prisma/composer-cli':
         specifier: 0.17.0
@@ -207,7 +207,7 @@ importers:
         specifier: ^2.1.2
         version: 2.1.2
       '@prisma/cli-engine':
-        specifier: workspace:0.3.0
+        specifier: workspace:0.3.1
         version: link:../cli-engine
       '@prisma/composer-cli':
         specifier: 0.17.0


### PR DESCRIPTION
## Problem

The Management API records Compute deploys in its analytics, but it cannot tell which tool sent a request or whether it ran in GitHub Actions. The CLI's requests carry only the runtime's default User-Agent (`node` or `Bun/x.y.z`), which any Node or Bun script also sends.

## Change

Every request from the engine's Management API client (`ctx.api`) now carries three headers:

| Header | Value |
| --- | --- |
| `x-prisma-client-name` | `prisma-cli` |
| `x-prisma-client-version` | the CLI version, from `getCliVersion()` |
| `x-prisma-deploy-source` | `github-action` when `GITHUB_ACTIONS` is `"true"`, otherwise `cli` |

- The headers are added by an openapi-fetch `onRequest` middleware on `sdk.client`, the same way the SDK adds `Authorization`.
- The version reaches the engine through a new optional `cliVersion` field on `ManagementApiClientConfig`. A host that does not set it simply omits `x-prisma-client-version`.
- `ctx.api` carries Composer's build reports during `prisma deploy` and the `prisma service` commands, so both are covered.
- `@prisma/cli-engine` is bumped from 0.3.0 to 0.3.1 with `pnpm bump-cli-engine-version patch`, because published engine versions cannot change.

The headers change analytics only. The API behaves the same with or without them, and they carry no user data: just the tool name, its version, and whether the run is in GitHub Actions.

The server side is prisma/pdp-control-plane#5284. A matching change for Composer's alchemy client covers the deployment create and start calls, which do not go through `ctx.api`.

## Verification

- `pnpm typecheck` and `pnpm lint` are clean.
- `pnpm --filter @prisma/cli-engine test`: 830 passed. New tests check the headers inside and outside GitHub Actions, and that `x-prisma-client-version` is left out when `cliVersion` is not set. They go through the real client with a stubbed `fetch`.
- `pnpm --filter @prisma/cli test`: 964 passed, 2 skipped. `bin.test.ts` now expects `cliVersion` in the assembled config.
- `pnpm --filter @prisma/compute test`: 11 passed.
- No command was added or changed, so the e2e suite is not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
