### PR TITLE
chore(release): bump to 8.0.0-rc.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-cli",
-  "version": "8.0.0-rc.13",
+  "version": "8.0.0-rc.14",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/packages/cli-conformance/package.json
+++ b/packages/cli-conformance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/cli-conformance",
   "private": true,
-  "version": "8.0.0-rc.13",
+  "version": "8.0.0-rc.14",
   "description": "Reusable conformance checks for the engine's consumers: import purity over built output, config-section validators that never throw, and verification of the tarballs a registry would receive. Depends on no package it checks.",
   "type": "module",
   "exports": {
@@ -24,7 +24,7 @@
     "test": "pnpm run typecheck && vitest run"
   },
   "devDependencies": {
-    "@repo/tsconfig": "workspace:8.0.0-rc.13",
+    "@repo/tsconfig": "workspace:8.0.0-rc.14",
     "@types/node": "^22.19.19",
     "es-module-lexer": "^2.1.0",
     "tsx": "^4.22.4",

--- a/packages/cli-engine/package.json
+++ b/packages/cli-engine/package.json
@@ -58,8 +58,8 @@
   },
   "devDependencies": {
     "@prisma/management-api-sdk": "1.69.0",
-    "@repo/cli-conformance": "workspace:8.0.0-rc.13",
-    "@repo/tsconfig": "workspace:8.0.0-rc.13",
+    "@repo/cli-conformance": "workspace:8.0.0-rc.14",
+    "@repo/tsconfig": "workspace:8.0.0-rc.14",
     "@types/node": "^22.19.19",
     "ci-info": "^4.3.1",
     "tsdown": "^0.21.10",

--- a/packages/cli-telemetry/package.json
+++ b/packages/cli-telemetry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/cli-telemetry",
   "private": true,
-  "version": "8.0.0-rc.13",
+  "version": "8.0.0-rc.14",
   "description": "CLI telemetry child sender: the detached subprocess the engine hands a composed payload to, its system probes, and the POST",
   "type": "module",
   "sideEffects": [
@@ -35,7 +35,7 @@
     "@vercel/detect-agent": "^1.2.3"
   },
   "devDependencies": {
-    "@repo/tsconfig": "workspace:8.0.0-rc.13",
+    "@repo/tsconfig": "workspace:8.0.0-rc.14",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/cli",
-  "version": "8.0.0-rc.13",
+  "version": "8.0.0-rc.14",
   "description": "Command-line interface for the Prisma Developer Platform.",
   "type": "module",
   "bin": {
@@ -64,9 +64,9 @@
   "devDependencies": {
     "@prisma/composer": "0.19.0",
     "@prisma/credentials-store": "^7.8.0",
-    "@repo/cli-conformance": "workspace:8.0.0-rc.13",
-    "@repo/cli-telemetry": "workspace:8.0.0-rc.13",
-    "@repo/tsconfig": "workspace:8.0.0-rc.13",
+    "@repo/cli-conformance": "workspace:8.0.0-rc.14",
+    "@repo/cli-telemetry": "workspace:8.0.0-rc.14",
+    "@repo/tsconfig": "workspace:8.0.0-rc.14",
     "@types/node": "^22.19.19",
     "@types/cross-spawn": "^6.0.6",
     "tsdown": "^0.21.10",

--- a/packages/compute/package.json
+++ b/packages/compute/package.json
@@ -42,7 +42,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@repo/tsconfig": "workspace:8.0.0-rc.13",
+    "@repo/tsconfig": "workspace:8.0.0-rc.14",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3",

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma",
-  "version": "8.0.0-rc.13",
+  "version": "8.0.0-rc.14",
   "description": "The Prisma CLI: one binary for the ORM, Composer, and the Prisma Developer Platform.",
   "type": "module",
   "bin": {
@@ -63,10 +63,10 @@
     "open": "^11.0.0"
   },
   "devDependencies": {
-    "@prisma/cli": "workspace:8.0.0-rc.13",
+    "@prisma/cli": "workspace:8.0.0-rc.14",
     "@prisma/credentials-store": "^7.8.0",
-    "@repo/cli-telemetry": "workspace:8.0.0-rc.13",
-    "@repo/tsconfig": "workspace:8.0.0-rc.13",
+    "@repo/cli-telemetry": "workspace:8.0.0-rc.14",
+    "@repo/tsconfig": "workspace:8.0.0-rc.14",
     "@types/node": "^22.19.19",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/tsconfig",
   "private": true,
-  "version": "8.0.0-rc.13",
+  "version": "8.0.0-rc.14",
   "description": "Base tsconfig providing package for the monorepo",
   "license": "Apache-2.0",
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,13 +67,13 @@ importers:
         specifier: ^7.8.0
         version: 7.8.0
       '@repo/cli-conformance':
-        specifier: workspace:8.0.0-rc.13
+        specifier: workspace:8.0.0-rc.14
         version: link:../cli-conformance
       '@repo/cli-telemetry':
-        specifier: workspace:8.0.0-rc.13
+        specifier: workspace:8.0.0-rc.14
         version: link:../cli-telemetry
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.13
+        specifier: workspace:8.0.0-rc.14
         version: link:../tsconfig
       '@types/cross-spawn':
         specifier: ^6.0.6
@@ -97,7 +97,7 @@ importers:
   packages/cli-conformance:
     devDependencies:
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.13
+        specifier: workspace:8.0.0-rc.14
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -140,10 +140,10 @@ importers:
         specifier: 1.69.0
         version: 1.69.0
       '@repo/cli-conformance':
-        specifier: workspace:8.0.0-rc.13
+        specifier: workspace:8.0.0-rc.14
         version: link:../cli-conformance
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.13
+        specifier: workspace:8.0.0-rc.14
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -168,7 +168,7 @@ importers:
         version: 1.2.4
     devDependencies:
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.13
+        specifier: workspace:8.0.0-rc.14
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -186,7 +186,7 @@ importers:
   packages/compute:
     devDependencies:
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.13
+        specifier: workspace:8.0.0-rc.14
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19
@@ -241,16 +241,16 @@ importers:
         version: 11.0.0
     devDependencies:
       '@prisma/cli':
-        specifier: workspace:8.0.0-rc.13
+        specifier: workspace:8.0.0-rc.14
         version: link:../cli
       '@prisma/credentials-store':
         specifier: ^7.8.0
         version: 7.8.0
       '@repo/cli-telemetry':
-        specifier: workspace:8.0.0-rc.13
+        specifier: workspace:8.0.0-rc.14
         version: link:../cli-telemetry
       '@repo/tsconfig':
-        specifier: workspace:8.0.0-rc.13
+        specifier: workspace:8.0.0-rc.14
         version: link:../tsconfig
       '@types/node':
         specifier: ^22.19.19

--- a/skills/prisma-platform-core-concepts/SKILL.md
+++ b/skills/prisma-platform-core-concepts/SKILL.md
@@ -2,7 +2,7 @@
 name: prisma-platform-core-concepts
 metadata:
   library: "prisma"
-  library_version: "8.0.0-rc.13"
+  library_version: "8.0.0-rc.14"
   version: 2026.9.1
 description: >-
   Use when hosting, deploying, or operating an app on the Prisma Platform:


### PR DESCRIPTION
Release 8.0.0-rc.14. Merging publishes `prisma` and `@prisma/cli` under `latest` and creates the GitHub pre-release.

Ships `@prisma/composer-cli` 0.19.0 and `@prisma/orm-toolchain` 8.0.0-rc.10 (#261), plus everything merged since rc.13: the self-documenting help rewrite, the platform core-concepts skill, skills sync removing dropped agents, the Windows shim fix, the feedback metadata fix, and the conformance sandbox cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)